### PR TITLE
NTP-255: Add Google Analytics integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ If you need to test logit.io integration from your development environment, use 
 dotnet user-secrets set "AppLogging:TcpSinkUri" "<TLS_URL>" -p UI
 ```
 
+### Google Analytics (GA4)
+
+Google Analytics is used to track service traffic and usage. There is a separate property per environment with an associated data stream and therefore measurement id.
+
+If you need to test Google Analytics integration from your development environment, use the following command to add the neccessary user secret:
+
+```
+dotnet user-secrets set "GoogleAnalytics:MeasurementId" "<MEASUREMENT_ID>" -p UI
+```
+
 ## Testing
 
 ### End To End Testing

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,11 @@
-﻿<!DOCTYPE html>
+﻿@inject IConfiguration Configuration
+
+@{
+	var measurementId = Configuration["GoogleAnalytics:MeasurementId"];
+	var enableGoogleAnalytics = !string.IsNullOrWhiteSpace(measurementId);
+}
+
+<!DOCTYPE html>
 <html lang="en" class="govuk-template ">
 
 <head>
@@ -19,6 +26,19 @@
     <link rel="stylesheet" href="~/dist/main.css" asp-append-version="true" />
 
     <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
+    
+    @if (enableGoogleAnalytics)
+    {
+	    <!-- Global site tag (gtag.js) - Google Analytics -->
+	    <script async src="https://www.googletagmanager.com/gtag/js?id=@measurementId"></script>
+	    <script>
+	        window.dataLayer = window.dataLayer || [];
+	        function gtag(){dataLayer.push(arguments);}
+	        gtag('js', new Date());
+
+	        gtag('config', '@measurementId');
+        </script>
+    }
 </head>
 
 <body class="govuk-template__body ">

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,3 +12,4 @@ applications:
     AppLogging:DefaultLogEventLevel: ((default-log-event-level))
     AppLogging:OverrideLogEventLevel: ((override-log-event-level))
     AppLogging:TcpSinkUri: ((tcp-sink-uri))
+    GoogleAnalytics:MeasurementId: ((google-analytics-measurement-id))

--- a/vars-production.yml
+++ b/vars-production.yml
@@ -4,3 +4,4 @@ memory: 1G
 dotnet-environment: Production
 default-log-event-level: Information
 override-log-event-level: Warning
+google-analytics-measurement-id: G-SDYZ8PH0R0

--- a/vars-qa.yml
+++ b/vars-qa.yml
@@ -4,3 +4,4 @@ memory: 256M
 dotnet-environment: QA
 default-log-event-level: Debug
 override-log-event-level: Information
+google-analytics-measurement-id: G-R32QZSL32G

--- a/vars-research.yml
+++ b/vars-research.yml
@@ -4,3 +4,4 @@ memory: 256M
 dotnet-environment: Research
 default-log-event-level: Information
 override-log-event-level: Warning
+google-analytics-measurement-id: G-VFDS3WSTQM

--- a/vars-staging.yml
+++ b/vars-staging.yml
@@ -4,3 +4,4 @@ memory: 1G
 dotnet-environment: Staging
 default-log-event-level: Information
 override-log-event-level: Warning
+google-analytics-measurement-id: G-CTS2R4EDLX


### PR DESCRIPTION
## Context

We now have access to Google Analytics and have set up a property per environment with an associated data stream. We need to prove we can send metrics to GA.

## Changes proposed in this pull request

Add Google Analytics global site tag that is enabled when the related environment variable is set.

## Guidance to review

GA measurement ids are not considered secrets as they are viewable in HTML source.

## Link to Jira ticket

[NTP-255](https://dfedigital.atlassian.net/browse/NTP-255)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md) - N/A
- [ ] Test coverage of new code is at least 80% - N/A
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/) - N/A
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off - N/A
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code - N/A