### PR TITLE
NTP-412: Rename database connection strings

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-COMPOSE_PROJECT_NAME=national-tutoring
+COMPOSE_PROJECT_NAME=find-a-tuition-partner

--- a/Infrastructure.Tests/Extensions/GetNtpConnectionStringTests.cs
+++ b/Infrastructure.Tests/Extensions/GetNtpConnectionStringTests.cs
@@ -34,7 +34,7 @@ public class GetNtpConnectionStringTests
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string>
             {
-                {$"ConnectionStrings:{EnvironmentVariables.NtpDatabaseConnectionString}", expected},
+                {$"ConnectionStrings:{EnvironmentVariables.FatpDatabaseConnectionString}", expected},
                 {EnvironmentVariables.VcapServices, ScenarioConstants.VcapServicesInvalidJson}
             })
             .Build();
@@ -52,7 +52,7 @@ public class GetNtpConnectionStringTests
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string>
             {
-                {$"ConnectionStrings:{EnvironmentVariables.NtpDatabaseConnectionString}", expected}
+                {$"ConnectionStrings:{EnvironmentVariables.FatpDatabaseConnectionString}", expected}
             })
             .Build();
 

--- a/Infrastructure/Constants/EnvironmentVariables.cs
+++ b/Infrastructure/Constants/EnvironmentVariables.cs
@@ -2,7 +2,7 @@
 
 public class EnvironmentVariables
 {
-    public const string NtpDatabaseConnectionString = "NtpDatabase";
+    public const string FatpDatabaseConnectionString = "FatpDatabase";
     public const string VcapServices = "VCAP_SERVICES";
     public const string VcapApplication = "VCAP_APPLICATION";
 }

--- a/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Application.Extraction;
 using Application.Factories;
 using Application.Repositories;
 using Infrastructure.Configuration.GPaaS;
+using Infrastructure.Constants;
 using Infrastructure.Extraction;
 using Infrastructure.Factories;
 using Infrastructure.Repositories;
@@ -55,7 +56,7 @@ public static class ServiceCollectionExtensions
             }
         }
 
-        return configuration.GetConnectionString("NtpDatabase");
+        return configuration.GetConnectionString(EnvironmentVariables.FatpDatabaseConnectionString);
     }
 
     public static IServiceCollection AddLocationFilterService(this IServiceCollection services)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dotnet tool update -g dotnet-ef
 The service uses Postgres 13 for the database backing service. It is recommended that you use a pre built docker image for local development. Run the following command to start the container.
 
 ```
-docker run --name ntp -e POSTGRES_PASSWORD=<LOCAL_DEV_PASSWORD> -p 5432:5432 -d postgres:13
+docker run --name find-a-tuition-partner-postgres-db -e POSTGRES_PASSWORD=<LOCAL_DEV_PASSWORD> -p 5432:5432 -d postgres:13
 ```
 
 Please note that you will need to start the container from the Docker Desktop container tab every time you restart your machine.
@@ -41,7 +41,7 @@ Please note that you will need to start the container from the Docker Desktop co
 You will need to register the database connection string for local development as a .NET user secret with the following command.
 
 ```
-dotnet user-secrets set "ConnectionStrings:NtpDatabase" "Host=localhost;Username=postgres;Password=<LOCAL_DEV_PASSWORD>;Database=ntp" -p UI
+dotnet user-secrets set "ConnectionStrings:FatpDatabase" "Host=localhost;Username=postgres;Password=<LOCAL_DEV_PASSWORD>;Database=fatp" -p UI
 ```
 
 You will also need to set the current data encryption key used to encrypt the data files in order to import them locally. Ask the other developers for the latest encryption key and add it as a .NET user secret with the following command.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     depends_on:
       - db
     environment:
-      - ConnectionStrings:NtpDatabase=Host=db;Username=postgres;Password=password
+      - ConnectionStrings:FatpDatabase=Host=db;Username=postgres;Password=password
       - AppLogging:DefaultLogEventLevel=Information
       - AppLogging:OverrideLogEventLevel=Warning
 


### PR DESCRIPTION
## Context

GDS has requested that service be focused on the "Find a tuition partner" option rather than the wider "Compare national tutoring options" context. The informational pages related to the Academic Mentor and School Led options will now be hosted on GOV.UK rather than this service.

## Changes proposed in this pull request

Rename the database connection strings and related docker commands from ntp -> fatp

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

[NTP-412](https://dfedigital.atlassian.net/browse/NTP-412)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] Test coverage of new code is at least 80% - N/A
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/) - N/A
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off - N/A
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code