### PR TITLE
NTP-349/411: Performance testing using the GIAS dataset

### DIFF
--- a/DataImporter/Program.cs
+++ b/DataImporter/Program.cs
@@ -42,6 +42,7 @@ if (args.Any(x => x == "import"))
             services.AddDataImporter();
             services.AddHostedService<DataImporterService>();
         })
+        .AddLogging()
         .Build();
 
     await host.RunAsync();

--- a/FindATuitionPartner.sln
+++ b/FindATuitionPartner.sln
@@ -21,6 +21,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataImporter", "DataImporte
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Domain.Tests", "Domain.Tests\Domain.Tests.csproj", "{E9F72A1A-677A-49B6-BB8F-0C36FA7D460A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GiasPostcodeSearch", "GiasPostcodeSearch\GiasPostcodeSearch.csproj", "{1268FE9B-1B7C-4360-824E-460B9FB884E6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,6 +65,10 @@ Global
 		{E9F72A1A-677A-49B6-BB8F-0C36FA7D460A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9F72A1A-677A-49B6-BB8F-0C36FA7D460A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9F72A1A-677A-49B6-BB8F-0C36FA7D460A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1268FE9B-1B7C-4360-824E-460B9FB884E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1268FE9B-1B7C-4360-824E-460B9FB884E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1268FE9B-1B7C-4360-824E-460B9FB884E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1268FE9B-1B7C-4360-824E-460B9FB884E6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GiasPostcodeSearch/GiasPostcodeSearch.csproj
+++ b/GiasPostcodeSearch/GiasPostcodeSearch.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/GiasPostcodeSearch/GiasPostcodeSearch.csproj
+++ b/GiasPostcodeSearch/GiasPostcodeSearch.csproj
@@ -8,16 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="appsettings.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.2.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />

--- a/GiasPostcodeSearch/GiasPostcodeSearch.csproj
+++ b/GiasPostcodeSearch/GiasPostcodeSearch.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/GiasPostcodeSearch/GiasPostcodeSearch.csproj
+++ b/GiasPostcodeSearch/GiasPostcodeSearch.csproj
@@ -8,6 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.2.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />

--- a/GiasPostcodeSearch/GiasPostcodeSearch.csproj
+++ b/GiasPostcodeSearch/GiasPostcodeSearch.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="27.2.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>

--- a/GiasPostcodeSearch/GiasPostcodeSearchService.cs
+++ b/GiasPostcodeSearch/GiasPostcodeSearchService.cs
@@ -30,7 +30,7 @@ public class GiasPostcodeSearchService : IHostedService
 
         foreach (var schoolDatum in schoolData)
         {
-            _logger.LogDebug($"Searching for Tuition Partners covering {schoolDatum.Name}'s postcode {schoolDatum.Postcode}");
+            _logger.LogDebug($"Searching for Tuition Partners covering School {schoolDatum}");
 
             var requestUri = $"search-results?Postcode={schoolDatum.Postcode}";
             

--- a/GiasPostcodeSearch/GiasPostcodeSearchService.cs
+++ b/GiasPostcodeSearch/GiasPostcodeSearchService.cs
@@ -1,0 +1,67 @@
+﻿using System.Diagnostics;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace GiasPostcodeSearch;
+
+public class GiasPostcodeSearchService : IHostedService
+{
+    private readonly IHostApplicationLifetime _host;
+    private readonly ILogger<GiasPostcodeSearchService> _logger;
+    private readonly HttpClient _httpClient;
+    private readonly ISchoolDataProvider _schoolDataProvider;
+
+    public GiasPostcodeSearchService(IHostApplicationLifetime host, ILogger<GiasPostcodeSearchService> logger, HttpClient httpClient, ISchoolDataProvider schoolDataProvider)
+    {
+        _host = host;
+        _logger = logger;
+        _httpClient = httpClient;
+        _schoolDataProvider = schoolDataProvider;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var schoolData = await _schoolDataProvider.GetSchoolDataAsync();
+
+        var count = 0;
+        var totalElapsedMilliseconds = 0L;
+        var minElapsedMilliseconds = long.MaxValue;
+        var maxElapsedMilliseconds = 0L;
+
+        foreach (var schoolDatum in schoolData)
+        {
+            _logger.LogDebug($"Searching for Tuition Partners covering {schoolDatum.Name}'s postcode {schoolDatum.Postcode}");
+
+            var requestUri = $"search-results?Postcode={schoolDatum.Postcode}";
+            
+            var stopWatch = new Stopwatch();
+            stopWatch.Stop();
+            var response = await _httpClient.GetAsync(requestUri, cancellationToken);
+            stopWatch.Start();
+            totalElapsedMilliseconds += stopWatch.ElapsedMilliseconds;
+            minElapsedMilliseconds = Math.Min(minElapsedMilliseconds, stopWatch.ElapsedMilliseconds);
+            maxElapsedMilliseconds = Math.Max(minElapsedMilliseconds, stopWatch.ElapsedMilliseconds);
+
+            if (response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug($"Response status code {response.StatusCode} returned after {stopWatch.ElapsedMilliseconds}ms");
+            }
+            else
+            {
+                _logger.LogError($"Search request {requestUri} resulted in non success status code {response.StatusCode}");
+            }
+
+            count++;
+        }
+
+        var averageElapsedMilliseconds = (int)(totalElapsedMilliseconds / (double)count);
+        _logger.LogInformation($"{count} searches run. Average response time {averageElapsedMilliseconds} min {minElapsedMilliseconds} max {maxElapsedMilliseconds}");
+
+        _host.StopApplication();
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/GiasPostcodeSearch/GiasPostcodeSearchService.cs
+++ b/GiasPostcodeSearch/GiasPostcodeSearchService.cs
@@ -21,7 +21,7 @@ public class GiasPostcodeSearchService : IHostedService
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        var schoolData = await _schoolDataProvider.GetSchoolDataAsync();
+        var schoolData = await _schoolDataProvider.GetSchoolDataAsync(cancellationToken);
 
         var count = 0;
         var totalElapsedMilliseconds = 0L;
@@ -35,9 +35,9 @@ public class GiasPostcodeSearchService : IHostedService
             var requestUri = $"search-results?Postcode={schoolDatum.Postcode}";
             
             var stopWatch = new Stopwatch();
-            stopWatch.Stop();
-            var response = await _httpClient.GetAsync(requestUri, cancellationToken);
             stopWatch.Start();
+            var response = await _httpClient.GetAsync(requestUri, cancellationToken);
+            stopWatch.Stop();
             totalElapsedMilliseconds += stopWatch.ElapsedMilliseconds;
             minElapsedMilliseconds = Math.Min(minElapsedMilliseconds, stopWatch.ElapsedMilliseconds);
             maxElapsedMilliseconds = Math.Max(minElapsedMilliseconds, stopWatch.ElapsedMilliseconds);
@@ -52,10 +52,12 @@ public class GiasPostcodeSearchService : IHostedService
             }
 
             count++;
+
+            if (count == 10) break;
         }
 
         var averageElapsedMilliseconds = (int)(totalElapsedMilliseconds / (double)count);
-        _logger.LogInformation($"{count} searches run. Average response time {averageElapsedMilliseconds} min {minElapsedMilliseconds} max {maxElapsedMilliseconds}");
+        _logger.LogInformation($"{count} searches run. Average response time {averageElapsedMilliseconds}ms min {minElapsedMilliseconds}ms max {maxElapsedMilliseconds}ms");
 
         _host.StopApplication();
     }

--- a/GiasPostcodeSearch/GiasPostcodeSearchService.cs
+++ b/GiasPostcodeSearch/GiasPostcodeSearchService.cs
@@ -31,6 +31,7 @@ public class GiasPostcodeSearchService : IHostedService
         _logger.LogInformation($"GIAS dataset loaded. {schoolData.Length} eligible schools");
 
         var count = 0;
+        var errorCount = 0;
         var totalCount = schoolData.Length;
         var elapsedMilliseconds = 0L;
         var minElapsedMilliseconds = long.MaxValue;
@@ -89,6 +90,7 @@ public class GiasPostcodeSearchService : IHostedService
                 else
                 {
                     _logger.LogError($"Search request {requestUri} resulted in non success status code {response.StatusCode}");
+                    errorCount++;
                 }
 
                 count++;
@@ -97,7 +99,7 @@ public class GiasPostcodeSearchService : IHostedService
                 {
                     averageElapsedMilliseconds = (int)(elapsedMilliseconds / (double)count);
                     searchesPerSecond = (int)((double)count / (runStopWatch.ElapsedMilliseconds / 1000));
-                    _logger.LogInformation($"{count} searches of {totalCount} run in {runStopWatch.ElapsedMilliseconds / 1000}s. {searchesPerSecond} searches per second. Average response time {averageElapsedMilliseconds}ms min {minElapsedMilliseconds}ms ({fastestRequestUri}) max {maxElapsedMilliseconds}ms ({slowestRequestUri})");
+                    _logger.LogInformation($"{count} searches of {totalCount} run in {runStopWatch.ElapsedMilliseconds / 1000}s. Error count {errorCount}. {searchesPerSecond} searches per second. Average response time {averageElapsedMilliseconds}ms min {minElapsedMilliseconds}ms ({fastestRequestUri}) max {maxElapsedMilliseconds}ms ({slowestRequestUri})");
                     
                     // Reset metrics for next run
                     minElapsedMilliseconds = long.MaxValue;
@@ -111,7 +113,7 @@ public class GiasPostcodeSearchService : IHostedService
         runStopWatch.Stop();
         averageElapsedMilliseconds = (int)(elapsedMilliseconds / (double)count);
         searchesPerSecond = (int)((double)count / runStopWatch.ElapsedMilliseconds);
-        _logger.LogInformation($"Run complete. {count} searches run in {runStopWatch.ElapsedMilliseconds/1000}s. {searchesPerSecond} searches per second. Average response time {averageElapsedMilliseconds}ms min {minElapsedMilliseconds}ms ({fastestRequestUri}) max {maxElapsedMilliseconds}ms ({slowestRequestUri})");
+        _logger.LogInformation($"Run complete. {count} searches run in {runStopWatch.ElapsedMilliseconds/1000}s. Error count {errorCount}. {searchesPerSecond} searches per second. Average response time {averageElapsedMilliseconds}ms min {minElapsedMilliseconds}ms ({fastestRequestUri}) max {maxElapsedMilliseconds}ms ({slowestRequestUri})");
 
         _host.StopApplication();
     }

--- a/GiasPostcodeSearch/GiasPostcodeSearchService.cs
+++ b/GiasPostcodeSearch/GiasPostcodeSearchService.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -27,6 +27,8 @@ public class GiasPostcodeSearchService : IHostedService
                 PhaseOfEducation.Primary, PhaseOfEducation.MiddleDeemedPrimary, PhaseOfEducation.Secondary,
                 PhaseOfEducation.MiddleDeemedSecondary, PhaseOfEducation.AllThrough
             }.Contains(x.PhaseOfEducation)).ToArray();
+
+        _logger.LogInformation($"GIAS dataset loaded. {schoolData.Length} eligible schools");
 
         var count = 0;
         var totalCount = schoolData.Length;

--- a/GiasPostcodeSearch/GiasPostcodeSearchService.cs
+++ b/GiasPostcodeSearch/GiasPostcodeSearchService.cs
@@ -27,20 +27,39 @@ public class GiasPostcodeSearchService : IHostedService
         var totalElapsedMilliseconds = 0L;
         var minElapsedMilliseconds = long.MaxValue;
         var maxElapsedMilliseconds = 0L;
+        string fastestRequestUri = "";
+        string slowestRequestUri = "";
+
+        var runStopWatch = new Stopwatch();
+        runStopWatch.Start();
 
         foreach (var schoolDatum in schoolData)
         {
             _logger.LogDebug($"Searching for Tuition Partners covering School {schoolDatum}");
 
-            var requestUri = $"search-results?Postcode={schoolDatum.Postcode}";
+            var subjectsQueryString = GetSubjectsQueryString(schoolDatum);
+            if (subjectsQueryString == null)
+            {
+                _logger.LogInformation($"School {schoolDatum} is not valid for this service");
+            }
+
+            var requestUri = $"search-results?Postcode={schoolDatum.Postcode}&{subjectsQueryString}";
             
             var stopWatch = new Stopwatch();
             stopWatch.Start();
             var response = await _httpClient.GetAsync(requestUri, cancellationToken);
             stopWatch.Stop();
             totalElapsedMilliseconds += stopWatch.ElapsedMilliseconds;
-            minElapsedMilliseconds = Math.Min(minElapsedMilliseconds, stopWatch.ElapsedMilliseconds);
-            maxElapsedMilliseconds = Math.Max(minElapsedMilliseconds, stopWatch.ElapsedMilliseconds);
+            if (stopWatch.ElapsedMilliseconds < minElapsedMilliseconds)
+            {
+                minElapsedMilliseconds = stopWatch.ElapsedMilliseconds;
+                fastestRequestUri = requestUri;
+            }
+            if (stopWatch.ElapsedMilliseconds > maxElapsedMilliseconds)
+            {
+                maxElapsedMilliseconds = stopWatch.ElapsedMilliseconds;
+                slowestRequestUri = requestUri;
+            }
 
             if (response.IsSuccessStatusCode)
             {
@@ -56,8 +75,9 @@ public class GiasPostcodeSearchService : IHostedService
             if (count == 10) break;
         }
 
-        var averageElapsedMilliseconds = (int)(totalElapsedMilliseconds / (double)count);
-        _logger.LogInformation($"{count} searches run. Average response time {averageElapsedMilliseconds}ms min {minElapsedMilliseconds}ms max {maxElapsedMilliseconds}ms");
+        runStopWatch.Stop();
+        var averageElapsedMilliseconds = (int)(runStopWatch.ElapsedMilliseconds / (double)count);
+        _logger.LogInformation($"{count} searches run in {runStopWatch.ElapsedMilliseconds/1000}s. Average response time {averageElapsedMilliseconds}ms min {minElapsedMilliseconds}ms ({fastestRequestUri}) max {maxElapsedMilliseconds}ms ({slowestRequestUri})");
 
         _host.StopApplication();
     }
@@ -65,5 +85,21 @@ public class GiasPostcodeSearchService : IHostedService
     public Task StopAsync(CancellationToken cancellationToken)
     {
         return Task.CompletedTask;
+    }
+
+    private string? GetSubjectsQueryString(SchoolDatum schoolDatum)
+    {
+        switch (schoolDatum.PhaseOfEducation)
+        {
+            case PhaseOfEducation.Primary:
+            case PhaseOfEducation.MiddleDeemedPrimary:
+                return "Data.Subjects=KeyStage1-English&Data.Subjects=KeyStage2-Maths&Data.Subjects=KeyStage2-Science";
+            case PhaseOfEducation.Secondary:
+            case PhaseOfEducation.MiddleDeemedSecondary:
+                return "Data.Subjects=KeyStage3-English&Data.Subjects=KeyStage3-Maths&Data.Subjects=KeyStage4-Science";
+            case PhaseOfEducation.AllThrough:
+                return "Data.Subjects=KeyStage1-English&Data.Subjects=KeyStage1-Maths&Data.Subjects=KeyStage1-Science&Data.Subjects=KeyStage2-English&Data.Subjects=KeyStage2-Maths&Data.Subjects=KeyStage2-Science&Data.Subjects=KeyStage3-English&Data.Subjects=KeyStage3-Maths&Data.Subjects=KeyStage3-Science&Data.Subjects=KeyStage4-English&Data.Subjects=KeyStage4-Maths&Data.Subjects=KeyStage4-Science";
+            default: return null;
+        }
     }
 }

--- a/GiasPostcodeSearch/GiasSchoolDataProvider.cs
+++ b/GiasPostcodeSearch/GiasSchoolDataProvider.cs
@@ -1,6 +1,8 @@
 ﻿using System.Globalization;
+using Application.Extensions;
 using CsvHelper;
 using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
 using Microsoft.Extensions.Logging;
 
 namespace GiasPostcodeSearch;
@@ -35,9 +37,27 @@ public class GiasSchoolDataProvider : ISchoolDataProvider
         {
             Map(m => m.Urn).Name("URN");
             Map(m => m.Name).Name("EstablishmentName");
+            Map(m => m.PhaseOfEducation).Name("PhaseOfEducation (name)").TypeConverter<PhaseOfEducationConverter>();
             Map(m => m.Postcode).Name("Postcode");
             Map(m => m.LocalAuthorityCode).Name("LA (code)");
             //Map(m => m.LocalAuthorityDistrictCode).Name("EstablishmentName");
+        }
+    }
+
+    private class PhaseOfEducationConverter : EnumConverter
+    {
+        private readonly IDictionary<string, PhaseOfEducation> _map;
+
+        public PhaseOfEducationConverter() : base(typeof(PhaseOfEducation))
+        {
+            _map = Enum.GetValues(typeof(PhaseOfEducation)).Cast<PhaseOfEducation>().ToDictionary(x => x.DisplayName(), x => x);
+        }
+
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+        {
+            if (_map.TryGetValue(text, out var phaseOfEducation)) return phaseOfEducation;
+
+            throw new ArgumentException($"{text} is not a valid Phase of Education", nameof(text));
         }
     }
 }

--- a/GiasPostcodeSearch/GiasSchoolDataProvider.cs
+++ b/GiasPostcodeSearch/GiasSchoolDataProvider.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace GiasPostcodeSearch;
+
+public class GiasSchoolDataProvider : ISchoolDataProvider
+{
+    private const string GiasUrl = "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public";
+
+    private readonly ILogger<GiasSchoolDataProvider> _logger;
+    private readonly HttpClient _httpClient;
+
+    public GiasSchoolDataProvider(ILogger<GiasSchoolDataProvider> logger, HttpClient httpClient)
+    {
+        _logger = logger;
+        _httpClient = httpClient;
+    }
+
+    public async Task<IEnumerable<SchoolDatum>> GetSchoolDataAsync()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/GiasPostcodeSearch/GiasSchoolDataProvider.cs
+++ b/GiasPostcodeSearch/GiasSchoolDataProvider.cs
@@ -18,7 +18,7 @@ public class GiasSchoolDataProvider : ISchoolDataProvider
         _httpClient = httpClient;
     }
 
-    public async Task<IEnumerable<SchoolDatum>> GetSchoolDataAsync(CancellationToken cancellationToken)
+    public async Task<IReadOnlyCollection<SchoolDatum>> GetSchoolDataAsync(CancellationToken cancellationToken)
     {
         var dateFilename = DateTime.Today.ToString("yyyyMMdd");
 

--- a/GiasPostcodeSearch/ISchoolDataProvider.cs
+++ b/GiasPostcodeSearch/ISchoolDataProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace GiasPostcodeSearch;
+
+public interface ISchoolDataProvider
+{
+    Task<IEnumerable<SchoolDatum>> GetSchoolDataAsync();
+}

--- a/GiasPostcodeSearch/ISchoolDataProvider.cs
+++ b/GiasPostcodeSearch/ISchoolDataProvider.cs
@@ -2,5 +2,5 @@
 
 public interface ISchoolDataProvider
 {
-    Task<IEnumerable<SchoolDatum>> GetSchoolDataAsync();
+    Task<IEnumerable<SchoolDatum>> GetSchoolDataAsync(CancellationToken cancellationToken);
 }

--- a/GiasPostcodeSearch/ISchoolDataProvider.cs
+++ b/GiasPostcodeSearch/ISchoolDataProvider.cs
@@ -2,5 +2,5 @@
 
 public interface ISchoolDataProvider
 {
-    Task<IEnumerable<SchoolDatum>> GetSchoolDataAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<SchoolDatum>> GetSchoolDataAsync(CancellationToken cancellationToken);
 }

--- a/GiasPostcodeSearch/Program.cs
+++ b/GiasPostcodeSearch/Program.cs
@@ -1,14 +1,10 @@
-﻿using System.Net;
-using System.Net.Http.Headers;
+﻿using System.Net.Http.Headers;
 using System.Text;
 using GiasPostcodeSearch;
-using Infrastructure.Configuration;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using Serilog.Events;
-using Serilog.Sinks.Network;
 
 var argsValid = true;
 

--- a/GiasPostcodeSearch/Program.cs
+++ b/GiasPostcodeSearch/Program.cs
@@ -21,11 +21,14 @@ if (!argsValid) return;
 var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((hostContext, services) =>
     {
+        services.AddHttpClient<ISchoolDataProvider, GiasSchoolDataProvider>(client =>
+        {
+            client.BaseAddress = new Uri("https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/");
+        });
         services.AddHttpClient<IHostedService, GiasPostcodeSearchService>(client =>
         {
             client.BaseAddress = new Uri(url);
         });
-        services.AddHostedService<GiasPostcodeSearchService>();
     })
     .Build();
 

--- a/GiasPostcodeSearch/Program.cs
+++ b/GiasPostcodeSearch/Program.cs
@@ -1,0 +1,32 @@
+﻿using GiasPostcodeSearch;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+var argsValid = true;
+
+var url = "";
+var urlParam = args.FirstOrDefault(a => a.Contains("url"));
+if (string.IsNullOrWhiteSpace(urlParam) || !urlParam.Contains("="))
+{
+    Console.WriteLine("--url=<FIND_A_TUITION_PARTNER_URL> parameter is required");
+    argsValid = false;
+}
+else
+{
+    url = urlParam.Split("=")[1];
+}
+
+if (!argsValid) return;
+
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((hostContext, services) =>
+    {
+        services.AddHttpClient<IHostedService, GiasPostcodeSearchService>(client =>
+        {
+            client.BaseAddress = new Uri(url);
+        });
+        services.AddHostedService<GiasPostcodeSearchService>();
+    })
+    .Build();
+
+await host.RunAsync();

--- a/GiasPostcodeSearch/Program.cs
+++ b/GiasPostcodeSearch/Program.cs
@@ -2,8 +2,13 @@
 using System.Net.Http.Headers;
 using System.Text;
 using GiasPostcodeSearch;
+using Infrastructure.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.Network;
 
 var argsValid = true;
 
@@ -35,8 +40,6 @@ if (passwordParam != null && passwordParam.Contains("="))
     password = passwordParam.Split("=")[1];
 }
 
-ServicePointManager.DefaultConnectionLimit = 32;
-
 var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((hostContext, services) =>
     {
@@ -55,6 +58,14 @@ var host = Host.CreateDefaultBuilder(args)
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64EncodedAuthenticationString);
             }
         });
+    })
+    .UseSerilog((context, config) =>
+    {
+        config
+            .MinimumLevel.Is(LogEventLevel.Information)
+            .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+            .MinimumLevel.Override("System", LogEventLevel.Warning)
+            .WriteTo.Console();
     })
     .Build();
 

--- a/GiasPostcodeSearch/Properties/launchSettings.json
+++ b/GiasPostcodeSearch/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "GiasPostcodeSearch": {
+      "commandName": "Project",
+      "commandLineArgs": "--url=\"https://localhost:7036/\""
+    }
+  }
+}

--- a/GiasPostcodeSearch/SchoolDatum.cs
+++ b/GiasPostcodeSearch/SchoolDatum.cs
@@ -1,3 +1,10 @@
 ﻿namespace GiasPostcodeSearch;
 
-public record SchoolDatum(string Name, string Postcode, string LocalAuthorityCode, string LocalAuthorityDistrictCode);
+public class SchoolDatum
+{
+    public string Urn { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Postcode { get; init; } = string.Empty;
+    public string LocalAuthorityCode { get; init; } = string.Empty;
+    public string LocalAuthorityDistrictCode { get; init; } = string.Empty;
+}

--- a/GiasPostcodeSearch/SchoolDatum.cs
+++ b/GiasPostcodeSearch/SchoolDatum.cs
@@ -1,10 +1,38 @@
-﻿namespace GiasPostcodeSearch;
+﻿using System.ComponentModel;
+
+namespace GiasPostcodeSearch;
 
 public class SchoolDatum
 {
     public string Urn { get; init; } = string.Empty;
     public string Name { get; init; } = string.Empty;
+    public PhaseOfEducation PhaseOfEducation { get; set; }
     public string Postcode { get; init; } = string.Empty;
     public string LocalAuthorityCode { get; init; } = string.Empty;
     public string LocalAuthorityDistrictCode { get; init; } = string.Empty;
+
+    public override string ToString()
+    {
+        return $"URN: {Urn}, Name: {Name}, Phase of Education: {PhaseOfEducation}, Postcode: {Postcode}, Local Authority code: {LocalAuthorityCode}, Local Authority District code: {LocalAuthorityDistrictCode}";
+    }
+}
+
+public enum PhaseOfEducation
+{
+    [Description("Not applicable")]
+    NotApplicable = 0,
+    [Description("Nursery")]
+    Nursery,
+    [Description("Primary")]
+    Primary,
+    [Description("Secondary")]
+    Secondary,
+    [Description("16 plus")]
+    SixteenPlus,
+    [Description("All-through")]
+    AllThrough,
+    [Description("Middle deemed primary")]
+    MiddleDeemedPrimary,
+    [Description("Middle deemed secondary")]
+    MiddleDeemedSecondary
 }

--- a/GiasPostcodeSearch/SchoolDatum.cs
+++ b/GiasPostcodeSearch/SchoolDatum.cs
@@ -1,0 +1,3 @@
+﻿namespace GiasPostcodeSearch;
+
+public record SchoolDatum(string Name, string Postcode, string LocalAuthorityCode, string LocalAuthorityDistrictCode);

--- a/GiasPostcodeSearch/appsettings.json
+++ b/GiasPostcodeSearch/appsettings.json
@@ -1,0 +1,9 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "System": "Warning"
+        }
+    }
+}

--- a/GiasPostcodeSearch/appsettings.json
+++ b/GiasPostcodeSearch/appsettings.json
@@ -1,9 +1,0 @@
-{
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft": "Warning",
-            "System": "Warning"
-        }
-    }
-}

--- a/Infrastructure/DataEncryptionService.cs
+++ b/Infrastructure/DataEncryptionService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Security.Cryptography;
-using System.Text;
 using Application.Extensions;
 using Infrastructure.Configuration;
 using Microsoft.Extensions.Hosting;

--- a/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="27.2.1" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.17.1" />
     <PackageReference Include="Mapster" Version="7.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="6.0.6" />

--- a/docs/runbooks/performance-testing.md
+++ b/docs/runbooks/performance-testing.md
@@ -1,0 +1,53 @@
+---
+Last verfied: 2022-07-18
+---
+
+# Performance Testing
+
+## Description
+
+Performance testing for the service has been conducted using a custom .NET console app. We chose to use a custom app because the expected dataset of search parameters is known. It is the list of state funded schools in England which is publicly available from the [Get information about Schools](https://get-information-schools.service.gov.uk/) site.
+
+This means it is possible to download the latest dataset, extract the required school data and run a search for each school. This can be done in parallel for basic performance testing and has the added benefit of testing all possible postcodes to confirm searches using them run without error.
+
+## Results
+
+Date       | Searches | Run Time | Searches Per Second | Average Response Time
+---------- | -------- |----------|---------------------|----------------------
+18-07-2022 | 20188    | 5m 26s   | 61                  | 258ms                
+
+## Runbook
+
+### Scaling
+
+All environments use three nodes for resiliance and to confirm that there are no bugs related to an accidental reliance on state in a single node. It is however preferable to run performance testing against a single node to understand what load can be sustained per node.
+
+Change the number of nodes used to one on the target environment by issuing the following cf command
+
+```
+cf scale national-tutoring-<ENVIRONMENT> -i 1
+```
+
+### Performance Testing
+
+The `GiasPostcodeSearch` console application is the performance testing application. It loads the full GIAS dataset of elligable schools into memory then uses `Parallel.ForEachAsync` and `HttpClient` to request the search results page using each school's postcode and a subject list relevant to their phase of education.
+
+The application will accept three arguments
+
+* `--url=<FIND_A_TUITION_PARTNER_URL>` (required) - the service url to test against
+* `--username=<BASIC_HTTP_AUTH_USERNAME>` (optional) - the basic HTTP authorization username configured for the service url argument
+* `--password=<BASIC_HTTP_AUTH_PASSWORD>` (optional) - the basic HTTP authorization password configured for the service url argument
+
+Use the following command to run the application against the chosen environment
+
+```
+dotnet run --project GiasPostcodeSearch --url="<FIND_A_TUITION_PARTNER_URL>" --username="<BASIC_HTTP_AUTH_USERNAME>" --password="<BASIC_HTTP_AUTH_PASSWORD>"
+```
+
+The console app will print out performance stats for every 500 results similar to the following
+
+```
+17500 searches of 20188 run in 284s. 61 searches per second. Average response time 258ms min 128ms (search-results?Data.Postcode=HU9 4JL&Data.Subjects=KeyStage1-English&Data.Subjects=KeyStage2-Maths&Data.Subjects=KeyStage2-Science) max 779ms (search-results?Data.Postcode=WF7 5JB&Data.Subjects=KeyStage1-English&Data.Subjects=KeyStage2-Maths&Data.Subjects=KeyStage2-Science)
+```
+
+It will also log an error for any failed searches. The urls logged can be used to rerun the searches used for further debugging and optimization work.


### PR DESCRIPTION
## Context

Prior to going live, the team needs reassurance that the service will cope under reasonable launch day load. This load has been estimated as roughly the following:

Total eligible schools x five searches per school over an eight hour period:

(20188 x 5) / 8 / 60 = 210 searches per minute or around 3.5 per second

Realistically it is highly unlikely that all the schools will use the service on launch day however there is likely to be media interest in the service which could increase stats. A high end estimate of 10 searches per second will be used as a baseline.

## Changes proposed in this pull request

The new `GiasPostcodeSearch` console app has been added to perform load testing. A custom app has been used because the eligible dataset is known and available from the GIAS service.

## Guidance to review

This is a utility console app which is why it is not covered by unit tests.

## Link to Jira ticket

* [NTP-349](https://dfedigital.atlassian.net/browse/NTP-349)
* [NTP-411](https://dfedigital.atlassian.net/browse/NTP-411)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] Test coverage of new code is at least 80% - N/A
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/) - N/A
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off - N/A
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code