### PR TITLE
NTP-376: Make TP details page location aware

### DIFF
--- a/Tests/TempData.cs
+++ b/Tests/TempData.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using UI.Extensions;
 
 namespace Tests;
@@ -10,7 +11,7 @@ public class TempData
     {
         var data = new TestableTempDataDictionary();
         data.Set("Bananas", "this is a string");
-        data.Get<string>("Bananas").Should().Be("this is a string");
+        data.Peek<string>("Bananas").Should().Be("this is a string");
     }
 
     [Fact]
@@ -22,7 +23,7 @@ public class TempData
     [Fact]
     public void No_exception_when_getting_null_temp_data()
     {
-        ((ITempDataDictionary?)null).Get<string>("Bananas").Should().BeNull();
+        ((ITempDataDictionary?)null).Peek<string>("Bananas").Should().BeNull();
     }
 
     [Fact]
@@ -30,18 +31,27 @@ public class TempData
     {
         var data = new TestableTempDataDictionary();
         data.Set("Bananas", "this is a string");
-        data.Get<SomeClass>("Bananas").Should().BeNull();
+        data.Peek<SomeClass>("Bananas").Should().BeNull();
     }
 
+    internal class SomeClass
+    { }
 
-    internal class SomeClass { }
-
-    internal class TestableTempDataDictionary : Dictionary<string, object?>, ITempDataDictionary
+    internal class TestableTempDataDictionary : TempDataDictionary
     {
-        public void Keep() => throw new NotImplementedException();
-        public void Keep(string key) => throw new NotImplementedException();
-        public void Load() => throw new NotImplementedException();
-        public object? Peek(string key) => throw new NotImplementedException();
-        public void Save() => throw new NotImplementedException();
+        public TestableTempDataDictionary()
+            : base(new DefaultHttpContext(), new TestableTempDataProvider())
+        {
+        }
+
+        private class TestableTempDataProvider : ITempDataProvider
+        {
+            public IDictionary<string, object> LoadTempData(HttpContext context)
+                => new Dictionary<string, object>();
+
+            public void SaveTempData(HttpContext context, IDictionary<string, object> values)
+            {
+            }
+        }
     }
 }

--- a/Tests/TuitionPartnerDetailsPage.cs
+++ b/Tests/TuitionPartnerDetailsPage.cs
@@ -16,8 +16,7 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
         
     }
 
-    private string? _district1Code;
-    private string? _district9Code;
+    private Dictionary<string, string> LocalAuthorityDistrictCodes = new();
 
     public override async Task InitializeAsync()
     {
@@ -25,8 +24,9 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
 
         await Fixture.ExecuteDbContextAsync(async db =>
         {
-            _district1Code = db.LocalAuthorityDistricts.Find(1)!.Code;
-            _district9Code = db.LocalAuthorityDistricts.Find(9)!.Code;
+            LocalAuthorityDistrictCodes["East Riding of Yorkshire"] = db.LocalAuthorityDistricts.Find(1)!.Code;
+            LocalAuthorityDistrictCodes["North East Lincolnshire"] = db.LocalAuthorityDistricts.Find(2)!.Code;
+            LocalAuthorityDistrictCodes["Ryedale"] = db.LocalAuthorityDistricts.Find(9)!.Code;
 
             db.TuitionPartners.Add(new Domain.TuitionPartner
             {
@@ -39,8 +39,10 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
                 Email = "ntp@a-tuition-partner.testdata",
                 LocalAuthorityDistrictCoverage = new List<LocalAuthorityDistrictCoverage>
                 {
-                    new() { TuitionTypeId = (int)TuitionTypes.InSchool, LocalAuthorityDistrictId = 1 },
-                    new() { TuitionTypeId = (int)TuitionTypes.Online, LocalAuthorityDistrictId = 9 },
+                    new() { LocalAuthorityDistrictId = 1, TuitionTypeId = (int)TuitionTypes.InSchool },
+                    new() { LocalAuthorityDistrictId = 2, TuitionTypeId = (int)TuitionTypes.InSchool },
+                    new() { LocalAuthorityDistrictId = 2, TuitionTypeId = (int)TuitionTypes.Online   },
+                    new() { LocalAuthorityDistrictId = 9, TuitionTypeId = (int)TuitionTypes.Online   },
                 },
                 SubjectCoverage = new List<SubjectCoverage>
                 {
@@ -145,7 +147,9 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
     public async Task Shows_all_tuition_types_when_provided_in_district()
     {
         var result = await Fixture.SendAsync(
-            new TuitionPartner.Query("a-tuition-partner", LocalAuthorityDistrictCode: _district1Code));
+            new TuitionPartner.Query(
+                "a-tuition-partner",
+                LocalAuthorityDistrictCode: LocalAuthorityDistrictCodes["North East Lincolnshire"]));
 
         result!.TuitionTypes.Should().BeEquivalentTo("Online", "In School");
     }
@@ -154,7 +158,9 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
     public async Task Shows_only_tuition_types_provided_in_district()
     {
         var result = await Fixture.SendAsync(
-            new TuitionPartner.Query("a-tuition-partner", LocalAuthorityDistrictCode: _district9Code));
+            new TuitionPartner.Query(
+                "a-tuition-partner", 
+                LocalAuthorityDistrictCode: LocalAuthorityDistrictCodes["Ryedale"]));
 
         result!.TuitionTypes.Should().BeEquivalentTo("Online");
     }

--- a/Tests/TuitionPartnerDetailsPage.cs
+++ b/Tests/TuitionPartnerDetailsPage.cs
@@ -16,12 +16,18 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
         
     }
 
+    private string? _district1Code;
+    private string? _district9Code;
+
     public override async Task InitializeAsync()
     {
         await base.InitializeAsync();
 
         await Fixture.ExecuteDbContextAsync(async db =>
         {
+            _district1Code = db.LocalAuthorityDistricts.Find(1)!.Code;
+            _district9Code = db.LocalAuthorityDistricts.Find(9)!.Code;
+
             db.TuitionPartners.Add(new Domain.TuitionPartner
             {
                 Id = 1,
@@ -33,12 +39,13 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
                 Email = "ntp@a-tuition-partner.testdata",
                 LocalAuthorityDistrictCoverage = new List<LocalAuthorityDistrictCoverage>
                 {
-                    new() { TuitionTypeId = (int)TuitionTypes.InSchool, LocalAuthorityDistrictId = 1 }
+                    new() { TuitionTypeId = (int)TuitionTypes.InSchool, LocalAuthorityDistrictId = 1 },
+                    new() { TuitionTypeId = (int)TuitionTypes.Online, LocalAuthorityDistrictId = 9 },
                 },
                 SubjectCoverage = new List<SubjectCoverage>
                 {
                     new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3English },
-                    new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3Maths }
+                    new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3Maths },
                 },
                 Prices = new List<Price>
                 {
@@ -114,7 +121,6 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
         result.Name.Should().Be("A Tuition Partner");
         result.Description.Should().Be("A Tuition Partner Description");
         result.Subjects.Should().BeEquivalentTo("Key stage 3 - English and Maths");
-        result.TuitionTypes.Should().BeEquivalentTo("In School");
         result.Ratios.Should().BeEquivalentTo("1 to 2", "1 to 3");
         result.Prices.Should().BeEquivalentTo(new Dictionary<int, TuitionPartner.GroupPrice>
         {
@@ -124,6 +130,33 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
         result.Website.Should().Be("https://a-tuition-partner.testdata/ntp");
         result.PhoneNumber.Should().Be("0123456789");
         result.EmailAddress.Should().Be("ntp@a-tuition-partner.testdata");
+    }
+
+    [Fact]
+    public async Task Shows_all_tuition_types_no_district_specified()
+    {
+        var result = await Fixture.SendAsync(
+            new TuitionPartner.Query("a-tuition-partner"));
+
+        result!.TuitionTypes.Should().BeEquivalentTo("Online", "In School");
+    }
+
+    [Fact]
+    public async Task Shows_all_tuition_types_when_provided_in_district()
+    {
+        var result = await Fixture.SendAsync(
+            new TuitionPartner.Query("a-tuition-partner", LocalAuthorityDistrictCode: _district1Code));
+
+        result!.TuitionTypes.Should().BeEquivalentTo("Online", "In School");
+    }
+
+    [Fact]
+    public async Task Shows_only_tuition_types_provided_in_district()
+    {
+        var result = await Fixture.SendAsync(
+            new TuitionPartner.Query("a-tuition-partner", LocalAuthorityDistrictCode: _district9Code));
+
+        result!.TuitionTypes.Should().BeEquivalentTo("Online");
     }
 
     [Fact]

--- a/UI/Extensions/TempDataSerialisation.cs
+++ b/UI/Extensions/TempDataSerialisation.cs
@@ -11,18 +11,17 @@ public static class TempDataSerialisation
             tempData[key] = JsonSerializer.Serialize(value);
     }
 
-    public static T? Get<T>(this ITempDataDictionary? tempData, string key) where T : class
+    public static T? Peek<T>(this ITempDataDictionary? tempData, string key) where T : class
     {
-        if (tempData == null) return null;
-
         try
         {
-            tempData.TryGetValue(key, out var data);
-            return data is string json ? JsonSerializer.Deserialize<T>(json) : null;
+            var data = tempData?.Peek(key);
+            if(data is string json) return JsonSerializer.Deserialize<T>(json);
         }
         catch
         {
-            return null;
         }
+
+        return null;
     }
 }

--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -27,12 +27,15 @@ public class SearchResults : PageModel
 
         Data.TuitionType ??= TuitionType.Any; 
         this.Data = await mediator.Send(Data);
+
+        TempData.Set("LocalAuthorityDistrictCode", this.Data.LocalAuthorityDistrictCode ?? "");
+
         if (!this.Data.Validation.IsValid)
             foreach (var error in this.Data.Validation.Errors)
                 ModelState.AddModelError($"Data.{error.PropertyName}", error.ErrorMessage);
     }
 
-    public record Query : SearchModel, IRequest<ResultsModel> { }
+    public record Query : SearchModel, IRequest<ResultsModel>;
 
     public record ResultsModel : SearchModel
     {
@@ -44,6 +47,7 @@ public class SearchResults : PageModel
 
         public TuitionPartnerSearchResultsPage? Results { get; set; }
         public FluentValidationResult Validation { get; internal set; } = new();
+        public string? LocalAuthorityDistrictCode { get; set; }
     }
 
     private class Validator : AbstractValidator<Query>
@@ -96,6 +100,7 @@ public class SearchResults : PageModel
                 {
                     LocalAuthority = searchResults.Data.LocalAuthorityDistrict?.Name,
                     Results = searchResults.Data,
+                    LocalAuthorityDistrictCode = searchResults.Data.Request.LocalAuthorityDistrictCode,
                 },
                 Domain.ValidationResult error => queryResponse with
                 {

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -45,7 +45,7 @@
 					    Type of tuition
 				    </govuk-summary-list-row-key>
 				    <govuk-summary-list-row-value>
-					    <ul class="govuk-list">
+					    <ul class="govuk-list" data-testid="type-of-tuition">
 						    @foreach (var item in Model.Data.TuitionTypes)
 						    {
 							    <li>@item</li>

--- a/UI/Pages/TuitionPartner.cshtml.cs
+++ b/UI/Pages/TuitionPartner.cshtml.cs
@@ -128,26 +128,7 @@ public class TuitionPartner : PageModel
             if (tp == null) return null;
 
             var subjects = tp.SubjectCoverage.Select(x => x.Subject).Distinct().GroupBy(x => x.KeyStageId).Select(x => $"{((KeyStage)x.Key).DisplayName()} - {x.DisplayList()}");
-
-            Domain.LocalAuthorityDistrictCoverage[]? coverage;
-            if(request.LocalAuthorityDistrictCode == null)
-            {
-                coverage = await _db.LocalAuthorityDistrictCoverage.Include(x => x.TuitionType)
-                    .Where(e => e.TuitionPartnerId == tp.Id)
-                    .ToArrayAsync(cancellationToken);
-            }
-            else 
-            {
-                coverage = await _db
-                    .LocalAuthorityDistrictCoverage
-                    .Include(x => x.LocalAuthorityDistrict)
-                    .Include(x => x.TuitionType)
-                    .Where(e => e.TuitionPartnerId == tp.Id
-                             && e.LocalAuthorityDistrict.Code == request.LocalAuthorityDistrictCode)
-                    .ToArrayAsync(cancellationToken);
-            }
-
-            var types = coverage.Select(x => x.TuitionType.Name).Distinct();
+            var types = await GetTuitionTypesCovered(request.LocalAuthorityDistrictCode, tp, cancellationToken);
             var ratios = tp.Prices.Select(x => x.GroupSize).Distinct().Select(x => $"1 to {x}");
             var prices = GetPricing(tp.Prices);
 
@@ -169,6 +150,29 @@ public class TuitionPartner : PageModel
                 lads,
                 allPrices
                 );
+        }
+
+        private async Task<IEnumerable<string>> GetTuitionTypesCovered(
+            string? localAuthorityDistrictCode,
+            Domain.TuitionPartner tp,
+            CancellationToken cancellationToken)
+        {
+            var coverageQuery = _db
+                .LocalAuthorityDistrictCoverage
+                .Where(e => e.TuitionPartnerId == tp.Id);
+
+            if (localAuthorityDistrictCode != null)
+            {
+                coverageQuery = coverageQuery
+                    .Where(e => e.LocalAuthorityDistrict.Code == localAuthorityDistrictCode);
+            }
+
+            var types = await coverageQuery
+                .Select(x => x.TuitionType.Name)
+                .Distinct()
+                .ToArrayAsync(cancellationToken);
+
+            return types;
         }
 
         private async Task<LocalAuthorityDistrictCoverage[]> GetLocalAuthorityDistricts(Query request, int tpId)

--- a/UI/Pages/TuitionPartner.cshtml.cs
+++ b/UI/Pages/TuitionPartner.cshtml.cs
@@ -27,9 +27,8 @@ public class TuitionPartner : PageModel
 
     public async Task<IActionResult> OnGetAsync(Query query)
     {
-        AllSearchData = TempData.Get<SearchModel>("AllSearchData");
-        var ladc = TempData.Get<string>("LocalAuthorityDistrictCode");
-
+        AllSearchData = TempData.Peek<SearchModel>("AllSearchData");
+        
         if (string.IsNullOrWhiteSpace(query.Id))
         {
             _logger.LogWarning("Null or whitespace id '{Id}' provided", query.Id);
@@ -43,7 +42,10 @@ public class TuitionPartner : PageModel
             return RedirectToPage((query with { Id = seoUrl }).ToRouteData());
         }
 
-        Data = await _mediator.Send(query with { LocalAuthorityDistrictCode = ladc });
+        Data = await _mediator.Send(query with 
+        {
+            LocalAuthorityDistrictCode = TempData.Peek<string>("LocalAuthorityDistrictCode")
+        });
 
         if (Data == null)
         {

--- a/UI/cypress/e2e/location-aware-results.feature
+++ b/UI/cypress/e2e/location-aware-results.feature
@@ -1,0 +1,11 @@
+Feature: Tuition Partner provides online but not in-school tuition in an area
+  Scenario: Display list of TPs that offer services to that postcode
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+    When they select 'any' tuition type
+    Then they will see the tuition partner 'Action Tutoring'
+
+  Scenario: Only show tuition type available in the postcode’s location on TP information page (location aware)
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+    When they select 'any' tuition type
+    And they select the tuition partner 'Action Tutoring'
+    Then they see only tuition types available for postcode 'SK1 1EB'

--- a/UI/cypress/e2e/location-aware-results.feature
+++ b/UI/cypress/e2e/location-aware-results.feature
@@ -8,4 +8,10 @@ Feature: Tuition Partner provides online but not in-school tuition in an area
     Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
     When they select 'any' tuition type
     And they select the tuition partner 'Action Tutoring'
-    Then they see only tuition types available for postcode 'SK1 1EB'
+    Then they see the tuition types 'Online'
+
+  Scenario: Show all tuition types on TP information page when the TP supports them all for the postcode’s location
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'S1 2PP'
+    When they select 'any' tuition type
+    And they select the tuition partner 'Action Tutoring'
+    Then they see the tuition types 'In School, Online'

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -1,5 +1,5 @@
 import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
-import { kebabCase, KeyStageSubjects2 } from "../support/utils";
+import { kebabCase, KeyStageSubjects } from "../support/utils";
         
 const allSubjects = {
     "Key stage 1": [ "English", "Maths", "Science"],

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -1,5 +1,5 @@
 import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
-import { kebabCase, removeWhitespace } from "../support/utils";
+import { kebabCase, KeyStageSubjects2 } from "../support/utils";
         
 const allSubjects = {
     "Key stage 1": [ "English", "Maths", "Science"],
@@ -14,6 +14,11 @@ Given("a user has arrived on the 'Search results' page for {string}", keyStage =
 
 Given("a user has arrived on the 'Search results' page for {string} without a postcode", keyStage => {
     cy.visit(`/search-results?key-subjects=KeyStage1&subjects=KeyStage1-English`);
+});
+
+Given("a user has arrived on the 'Search results' page for {string} for postcode {string}", (keystages, postcode) => {
+    const query = keystages.split(',').map(s => KeyStageSubjects2('subjects', s.trim())).join('&');
+    cy.visit(`/search-results?Postcode=${postcode}&${query}`);
 });
 
 Given("a user has arrived on the 'Search results' page", () => {
@@ -86,6 +91,14 @@ Then("the subjects in the filter displayed in alphabetical order", () => {
         });
 
     });
+});
+
+When("they select {string} tuition type", tuition => {
+    cy.get(`input[id="${kebabCase(tuition)}"]`).should('be.checked');
+});
+
+Then("they will see the tuition partner {string}", tp => {
+    cy.contains('a', tp)
 });
 
 Then("the subjects covered by a tuition partner are in alphabetical order", () => {

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -8,23 +8,6 @@ const allSubjects = {
     "Key stage 4": [ "English", "Humanities", "Maths", "Modern foreign languages", "Science"]
 }
 
-Given("a user has arrived on the 'Search results' page for {string}", keyStage => {
-    cy.visit(`/search-results?postcode=AB12CD&key-subjects=KeyStage1&subjects=KeyStage1-English`);
-});
-
-Given("a user has arrived on the 'Search results' page for {string} without a postcode", keyStage => {
-    cy.visit(`/search-results?key-subjects=KeyStage1&subjects=KeyStage1-English`);
-});
-
-Given("a user has arrived on the 'Search results' page for {string} for postcode {string}", (keystages, postcode) => {
-    const query = keystages.split(',').map(s => KeyStageSubjects2('subjects', s.trim())).join('&');
-    cy.visit(`/search-results?Postcode=${postcode}&${query}`);
-});
-
-Given("a user has arrived on the 'Search results' page", () => {
-    cy.visit(`/search-results?Postcode=sk11eb&Subjects=KeyStage1-English&Subjects=KeyStage1-Maths&Subjects=KeyStage1-Science&Subjects=KeyStage2-English&Subjects=KeyStage2-Maths&Subjects=KeyStage2-Science&Subjects=KeyStage3-English&Subjects=KeyStage3-Humanities&Subjects=KeyStage3-Maths&Subjects=KeyStage3-Modern%20foreign%20languages&Subjects=KeyStage3-Science&Subjects=KeyStage4-English&Subjects=KeyStage4-Humanities&Subjects=KeyStage4-Maths&Subjects=KeyStage4-Modern%20foreign%20languages&Subjects=KeyStage4-Science&KeyStages=KeyStage1&KeyStages=KeyStage2&KeyStages=KeyStage3&KeyStages=KeyStage4`);
-});
-
 When("they click on the option heading for {string}", keystage => {
     const stages = keystage.split(',').map(s => s.trim());
     stages.forEach(element => {
@@ -91,14 +74,6 @@ Then("the subjects in the filter displayed in alphabetical order", () => {
         });
 
     });
-});
-
-When("they select {string} tuition type", tuition => {
-    cy.get(`input[id="${kebabCase(tuition)}"]`).should('be.checked');
-});
-
-Then("they will see the tuition partner {string}", tp => {
-    cy.contains('a', tp)
 });
 
 Then("the subjects covered by a tuition partner are in alphabetical order", () => {

--- a/UI/cypress/e2e/tuition-partner-details.js
+++ b/UI/cypress/e2e/tuition-partner-details.js
@@ -1,17 +1,5 @@
 import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
-import { kebabCase, camelCaseKeyStage } from "../support/utils";
-
-const KeyStageSubjects = input => 
-    input.split(',')
-         .map(s => s.trim())
-         .map(s =>
-        {
-            const endOfKs = s.lastIndexOf(' ');
-            const ks = camelCaseKeyStage(s.slice(0, endOfKs));
-            const subj = s.slice(endOfKs + 1, s.length);
-            return `Data.Subjects=${ks}-${subj}`;
-        })
-        .join('&');
+import { kebabCase, camelCaseKeyStage, KeyStageSubjects } from "../support/utils";
 
 Given("a user has arrived on the 'Tuition Partner' page for {string}", name => {
     cy.visit(`/tuition-partner/${name}`);

--- a/UI/cypress/e2e/tuition-partner-details.js
+++ b/UI/cypress/e2e/tuition-partner-details.js
@@ -1,21 +1,6 @@
 import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
 import { kebabCase, camelCaseKeyStage, KeyStageSubjects } from "../support/utils";
 
-Given("a user has arrived on the 'Tuition Partner' page for {string}", name => {
-    cy.visit(`/tuition-partner/${name}`);
-});
-
-Given("a user has arrived on the 'Tuition Partner' page for {string} after searching for {string}", (name, subjects) => {
-
-    cy.visit(`/search-results?${KeyStageSubjects(subjects)}&Data.TuitionType=Any&Data.Postcode=sk11eb`);
-    cy.get('.govuk-link').contains(name).click();
-});
-
-Given("a user has arrived on the 'Tuition Partner' page for {string} after entering search details for multiple subjects", name => {
-    cy.visit(`/search-results?Data.Subjects=KeyStage1-English&Data.Subjects=KeyStage1-Maths&Data.TuitionType=Any&Data.Postcode=sk11eb`);
-    cy.get('.govuk-link').contains(name).click();
-});
-
 When("the home page is selected", () => {
     cy.get('[data-testid="home-link"]').click();
 });

--- a/UI/cypress/support/step_definitions/results-page.js
+++ b/UI/cypress/support/step_definitions/results-page.js
@@ -1,0 +1,54 @@
+import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
+import { kebabCase, KeyStageSubjects, KeyStageSubjects2 } from "../utils";
+
+Given("a user has arrived on the 'Search results' page for {string}", keyStage => {
+    cy.visit(`/search-results?postcode=AB12CD&key-subjects=KeyStage1&subjects=KeyStage1-English`);
+});
+
+Given("a user has arrived on the 'Search results' page for {string} without a postcode", keyStage => {
+    cy.visit(`/search-results?key-subjects=KeyStage1&subjects=KeyStage1-English`);
+});
+
+Given("a user has arrived on the 'Search results' page for {string} for postcode {string}", (keystages, postcode) => {
+    const query = keystages.split(',').map(s => KeyStageSubjects2('subjects', s.trim())).join('&');
+    cy.visit(`/search-results?Postcode=${postcode}&${query}`);
+});
+
+Given("a user has arrived on the 'Search results' page", () => {
+    cy.visit(`/search-results?Postcode=sk11eb&Subjects=KeyStage1-English&Subjects=KeyStage1-Maths&Subjects=KeyStage1-Science&Subjects=KeyStage2-English&Subjects=KeyStage2-Maths&Subjects=KeyStage2-Science&Subjects=KeyStage3-English&Subjects=KeyStage3-Humanities&Subjects=KeyStage3-Maths&Subjects=KeyStage3-Modern%20foreign%20languages&Subjects=KeyStage3-Science&Subjects=KeyStage4-English&Subjects=KeyStage4-Humanities&Subjects=KeyStage4-Maths&Subjects=KeyStage4-Modern%20foreign%20languages&Subjects=KeyStage4-Science&KeyStages=KeyStage1&KeyStages=KeyStage2&KeyStages=KeyStage3&KeyStages=KeyStage4`);
+});
+
+Then("they will see the tuition partner {string}", tp => {
+    cy.contains('a', tp)
+});
+
+Given("a user has arrived on the 'Tuition Partner' page for {string}", name => {
+    cy.visit(`/tuition-partner/${name}`);
+});
+
+Given("a user has arrived on the 'Tuition Partner' page for {string} after searching for {string}", (name, subjects) => {
+    Step(this, `a user has arrived on the 'Tuition Partner' page for '${name}' after searching for '${subjects}' in postcode 'sk11eb'`)
+});
+
+Given("a user has arrived on the 'Tuition Partner' page for {string} after entering search details for multiple subjects", name => {
+    Step(this, `a user has arrived on the 'Tuition Partner' page for '${name}' after searching for 'Key stage 1 English, Key stage 1 Maths' in postcode 'sk11eb'`)
+});
+
+Given("a user has arrived on the 'Tuition Partner' page for {string} after searching for {string} in postcode {string}", (name, subjects, postcode) => {
+    cy.visit(`/search-results?${KeyStageSubjects(subjects)}&Data.TuitionType=Any&Data.Postcode=${postcode}`);
+    cy.get('.govuk-link').contains(name).click();
+});
+
+When("they select {string} tuition type", tuition => {
+    cy.get(`input[id="${kebabCase(tuition)}"]`).should('be.checked');
+});
+
+When("they select the tuition partner {string}", name => {
+    cy.get('.govuk-link').contains(name).click();
+});
+
+Then("they see only tuition types available for postcode 'SK1 1EB'", () => {
+    cy.get("[data-testid='type-of-tuition']").invoke('text').then(text => {
+        expect(text.trim()).to.eq('Online')
+    });
+})

--- a/UI/cypress/support/step_definitions/results-page.js
+++ b/UI/cypress/support/step_definitions/results-page.js
@@ -1,5 +1,5 @@
 import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
-import { kebabCase, KeyStageSubjects, KeyStageSubjects2 } from "../utils";
+import { kebabCase, KeyStageSubjects } from "../utils";
 
 Given("a user has arrived on the 'Search results' page for {string}", keyStage => {
     cy.visit(`/search-results?postcode=AB12CD&key-subjects=KeyStage1&subjects=KeyStage1-English`);
@@ -10,7 +10,7 @@ Given("a user has arrived on the 'Search results' page for {string} without a po
 });
 
 Given("a user has arrived on the 'Search results' page for {string} for postcode {string}", (keystages, postcode) => {
-    const query = keystages.split(',').map(s => KeyStageSubjects2('subjects', s.trim())).join('&');
+    const query = keystages.split(',').map(s => KeyStageSubjects('subjects', s.trim())).join('&');
     cy.visit(`/search-results?Postcode=${postcode}&${query}`);
 });
 
@@ -35,7 +35,7 @@ Given("a user has arrived on the 'Tuition Partner' page for {string} after enter
 });
 
 Given("a user has arrived on the 'Tuition Partner' page for {string} after searching for {string} in postcode {string}", (name, subjects, postcode) => {
-    cy.visit(`/search-results?${KeyStageSubjects(subjects)}&Data.TuitionType=Any&Data.Postcode=${postcode}`);
+    cy.visit(`/search-results?${KeyStageSubjects('Data.Subjects', subjects)}&Data.TuitionType=Any&Data.Postcode=${postcode}`);
     cy.get('.govuk-link').contains(name).click();
 });
 

--- a/UI/cypress/support/step_definitions/results-page.js
+++ b/UI/cypress/support/step_definitions/results-page.js
@@ -47,8 +47,11 @@ When("they select the tuition partner {string}", name => {
     cy.get('.govuk-link').contains(name).click();
 });
 
-Then("they see only tuition types available for postcode 'SK1 1EB'", () => {
+Then("they see the tuition types {string}", tuitionTypes => {
+    const tuitionArray = tuitionTypes.split(',').map(s => s.trim())
+
     cy.get("[data-testid='type-of-tuition']").invoke('text').then(text => {
-        expect(text.trim()).to.eq('Online')
+        var listedTuitionTypes = text.split('\n').map(s => s.trim()).filter(s => s)
+        expect(listedTuitionTypes).to.deep.equal(tuitionArray)
     });
 })

--- a/UI/cypress/support/utils.js
+++ b/UI/cypress/support/utils.js
@@ -16,9 +16,7 @@ export const  camelCaseKeyStage = s => {
         }
 }
 
-export const KeyStageSubjects = input => KeyStageSubjects2('Data.Subjects', input);
-
-export const KeyStageSubjects2 = (prefix, input) => 
+export const KeyStageSubjects = (prefix, input) => 
     input.split(',')
          .map(s => s.trim())
          .map(s =>

--- a/UI/cypress/support/utils.js
+++ b/UI/cypress/support/utils.js
@@ -15,4 +15,17 @@ export const  camelCaseKeyStage = s => {
         default: return '';
         }
 }
-        
+
+export const KeyStageSubjects = input => KeyStageSubjects2('Data.Subjects', input);
+
+export const KeyStageSubjects2 = (prefix, input) => 
+    input.split(',')
+         .map(s => s.trim())
+         .map(s =>
+        {
+            const endOfKs = s.lastIndexOf(' ');
+            const ks = camelCaseKeyStage(s.slice(0, endOfKs));
+            const subj = s.slice(endOfKs + 1, s.length);
+            return `${prefix}=${ks}-${subj}`;
+        })
+        .join('&');


### PR DESCRIPTION
## Context

Tuition partners may provide different online and in-school services in different districts.  We want the Tuition partner details page to be aware of which district was searched for and only show the tuition type(s) relevant to that district.

## Changes proposed in this pull request

As an example, Action Tutoring provides KS2 English tutors in-school and online to to S1 2PP, but only online to SK1 1EB.

When searching in the results page already reflects this

for S1 2PP:
![image](https://user-images.githubusercontent.com/201727/180644223-ec6cc5fe-15b9-4888-9de0-5044421b9972.png)

for SK1 1EB:
![image](https://user-images.githubusercontent.com/201727/180644257-5c5cb529-037c-4ee2-9ecb-3fe517aad376.png)

The information page now also reflect this

for S1 2PP:
![image](https://user-images.githubusercontent.com/201727/180644318-a7071429-3c14-4b83-b6aa-082c4abd16a2.png)

for SK1 1EB:
![image](https://user-images.githubusercontent.com/201727/180644315-568f6352-2b0f-47ad-8cf2-44c1f4e6d06e.png)

## Guidance to review

The end-to-end tests use live data to verify the tuition types are shown / not shown when appropriate.  This is the easiest way to write these tests as we currently have no way to manipulate the back-end data from cypress.

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-376

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code