### PR TITLE
NTP-285: Add SEND support to pages

### DIFF
--- a/Application/Extensions/StringExtensions.cs
+++ b/Application/Extensions/StringExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 
 namespace Application.Extensions;
@@ -17,4 +16,7 @@ public static class StringExtensions
 
         return spacesToDash.ToLower();
     }
+
+    public static string ToYesNoString(this bool value)
+            => value ? "Yes" : "No";
 }

--- a/Domain/Search/TuitionPartnerSearchResult.cs
+++ b/Domain/Search/TuitionPartnerSearchResult.cs
@@ -8,4 +8,5 @@ public class TuitionPartnerSearchResult
     public string Description { get; set; } = null!;
     public Subject[] Subjects { get; set; } = null!;
     public TuitionType[] TuitionTypes { get; set; } = null!;
+    public bool HasSenProvision { get; set; }
 }

--- a/Tests/TuitionPartnerDetailsPage.cs
+++ b/Tests/TuitionPartnerDetailsPage.cs
@@ -37,6 +37,7 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
                 Description = "A Tuition Partner Description",
                 PhoneNumber = "0123456789",
                 Email = "ntp@a-tuition-partner.testdata",
+                HasSenProvision = false,
                 LocalAuthorityDistrictCoverage = new List<LocalAuthorityDistrictCoverage>
                 {
                     new() { LocalAuthorityDistrictId = 1, TuitionTypeId = (int)TuitionTypes.InSchool },
@@ -56,6 +57,18 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
                     new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3Maths, GroupSize = 2, HourlyRate = 56.78m },
                     new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3Maths, GroupSize = 3, HourlyRate = 56.78m },
                 }
+            });
+
+            db.TuitionPartners.Add(new Domain.TuitionPartner
+            {
+                Id = 2,
+                SeoUrl = "bravo-learning",
+                Name = "Bravo Learning",
+                Website = "https://bravo.learning.testdata/ntp",
+                Description = "Bravo Learning Description",
+                PhoneNumber = "0123456789",
+                Email = "ntp@bravo.learning.testdata",
+                HasSenProvision = true,
             });
 
             await db.SaveChangesAsync();
@@ -194,5 +207,14 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
                 { 2, 56.78m },
                 { 3, 56.78m }
             });
+    }
+
+    [Theory]
+    [InlineData("a-tuition-partner", false)]
+    [InlineData("bravo-learning", true)]
+    public async Task Shows_send_status(string tuitionPartner, bool supportsSend)
+    {
+        var result = await Fixture.SendAsync(new TuitionPartner.Query(tuitionPartner, ShowFullPricing: true));
+        result!.HasSenProvision.Should().Be(supportsSend);
     }
 }

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -100,6 +100,14 @@
 							</govuk-summary-list-row>
 							<govuk-summary-list-row class="govuk-body-s">
 								<govuk-summary-list-row-key>
+									SEND support
+								</govuk-summary-list-row-key>
+								<govuk-summary-list-row-value>
+									@item.HasSenProvision.ToYesNoString()
+								</govuk-summary-list-row-value>
+							</govuk-summary-list-row>
+							<govuk-summary-list-row class="govuk-body-s">
+								<govuk-summary-list-row-key>
 									Provider information
 								</govuk-summary-list-row-key>
 								<govuk-summary-list-row-value>

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -66,6 +66,14 @@
 					    </ul>
 				    </govuk-summary-list-row-value>
 			    </govuk-summary-list-row>
+				<govuk-summary-list-row>
+					<govuk-summary-list-row-key>
+						SEND support
+					</govuk-summary-list-row-key>
+					<govuk-summary-list-row-value>
+						@Model.Data.HasSenProvision.ToYesNoString()
+					</govuk-summary-list-row-value>
+				</govuk-summary-list-row>
 		    </govuk-summary-list>
 	    </div>
 		

--- a/UI/Pages/TuitionPartner.cshtml.cs
+++ b/UI/Pages/TuitionPartner.cshtml.cs
@@ -89,7 +89,7 @@ public class TuitionPartner : PageModel
     public record Command(
         string Name, string Description, string[] Subjects,
         string[] TuitionTypes, string[] Ratios, Dictionary<int, GroupPrice> Prices,
-        string Website, string PhoneNumber, string EmailAddress, string Address,
+        string Website, string PhoneNumber, string EmailAddress, string Address, bool HasSenProvision,
         LocalAuthorityDistrictCoverage[] LocalAuthorityDistricts,
         Dictionary<TuitionType, Dictionary<KeyStage, Dictionary<string, Dictionary<int, decimal>>>> AllPrices);
 
@@ -147,6 +147,7 @@ public class TuitionPartner : PageModel
                 tp.PhoneNumber,
                 tp.Email,
                 tp.Address,
+                tp.HasSenProvision,
                 lads,
                 allPrices
                 );

--- a/UI/cypress/e2e/results.feature
+++ b/UI/cypress/e2e/results.feature
@@ -1,68 +1,68 @@
 Feature: User is shown search results
   Scenario: page url is '/search-results'
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     Then the page URL ends with '/search-results'
 
   Scenario: page title is 'Search results'
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     Then the page's title is 'Search results'
 
   Scenario: user clicks service name
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     When they click the 'Find a tuition partner' service name link
     Then they will be taken to the 'Find a tuition partner' journey start page
 
   Scenario: user does not enter postcode
-    Given a user has arrived on the 'Search results' page for 'Key stage 1' without a postcode
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English' without a postcode
     When they click 'Continue'
     Then they will see 'Enter a postcode' as an error message for the 'postcode'
 
   Scenario: user enters an invalid postcode
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     When they enter 'INVALID' as the school's postcode
     And they click 'Continue'
     Then they will see 'Enter a valid postcode' as an error message for the 'postcode'
 
   Scenario: user enters a postcode in Wales
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     When they enter 'SA1 1DX' as the school's postcode
     And they click 'Continue'
     Then they will see 'This service covers England only' as an error message for the 'postcode'
 
   Scenario: user enters a postcode in Scotland
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     When they enter 'G33 2SQ' as the school's postcode
     And they click 'Continue'
     Then they will see 'This service covers England only' as an error message for the 'postcode'
 
   Scenario: user enters a postcode in Northern Ireland
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     When they enter 'BT47 5QG' as the school's postcode
     And they click 'Continue'
     Then they will see 'This service covers England only' as an error message for the 'postcode'
 
   Scenario: user clicks postcode error
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English' without a postcode
     When they click on the postcode error
     Then the school's postcode text input is focused
 
   Scenario: results default to any tuition type
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     Then they will see the tuition type 'Any' is selected
 
   Scenario: All key stages are shown
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     Then they will see an expanded subject filter for 'Key stage 1'
     And they will see all the subjects for 'Key stage 1'
     And they will see a collapsed subject filter for 'Key stage 2, Key stage 3, Key stage 4'
 
   Scenario: Key stage can be collapsed
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     And they click on the option heading for 'Key stage 1'
     And they will see a collapsed subject filter for 'Key stage 1'
 
   Scenario: Key stage can be expanded
-    Given a user has arrived on the 'Search results' page for 'Key stage 1'
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     And they click on the option heading for 'Key stage 2'
     And they will see an expanded subject filter for 'Key stage 2'
 

--- a/UI/cypress/e2e/send-results.feature
+++ b/UI/cypress/e2e/send-results.feature
@@ -1,0 +1,8 @@
+Feature: Display SEND information
+  Scenario: Show tuition partners' SEND status on the search results page
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 Maths'
+    Then the SEND status is '<SEND>' for tuition partner '<partner>'
+    Examples:
+    | SEND | partner                |
+    | No   | Action Tutoring        |
+    | Yes  | Bright Heart Education |

--- a/UI/cypress/e2e/send-results.feature
+++ b/UI/cypress/e2e/send-results.feature
@@ -6,3 +6,11 @@ Feature: Display SEND information
     | SEND | partner                |
     | No   | Action Tutoring        |
     | Yes  | Bright Heart Education |
+
+  Scenario: Show tuition partners' SEND status on the information page
+    Given a user has arrived on the 'Tuition Partner' page for '<partner>'
+    Then the SEND status is '<SEND>'
+    Examples:
+    | SEND | partner                |
+    | No   | Action Tutoring        |
+    | Yes  | Bright Heart Education |

--- a/UI/cypress/e2e/send-results.js
+++ b/UI/cypress/e2e/send-results.js
@@ -6,3 +6,7 @@ Given("the SEND status is {string} for tuition partner {string}", (send, tuition
         cy.get('div').contains('SEND support').parent().contains(send)
     });
 });
+
+Given("the SEND status is {string}", (send, tuitionPartnerName) => {
+    cy.get('div').contains('SEND support').parent().contains(send)
+});

--- a/UI/cypress/e2e/send-results.js
+++ b/UI/cypress/e2e/send-results.js
@@ -1,0 +1,8 @@
+import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
+
+Given("the SEND status is {string} for tuition partner {string}", (send, tuitionPartnerName) => {
+    cy.get('.govuk-link').contains(tuitionPartnerName).parent().parent().within(() =>
+    {
+        cy.get('div').contains('SEND support').parent().contains(send)
+    });
+});

--- a/UI/cypress/support/step_definitions/results-page.js
+++ b/UI/cypress/support/step_definitions/results-page.js
@@ -5,10 +5,6 @@ Given("a user has arrived on the 'Search results' page for {string}", keyStageSu
     cy.visit(`/search-results?postcode=sk11eb&${KeyStageSubjects('subjects', keyStageSubject)}`);
 });
 
-Given("a user has arrived on the 'Search results' page for 'Key stage 1'", keyStage => {
-    cy.visit(`/search-results?postcode=AB12CD&key-subjects=KeyStage1&subjects=KeyStage1-English`);
-});
-
 Given("a user has arrived on the 'Search results' page for {string} without a postcode", keyStage => {
     cy.visit(`/search-results?key-subjects=KeyStage1&subjects=KeyStage1-English`);
 });

--- a/UI/cypress/support/step_definitions/results-page.js
+++ b/UI/cypress/support/step_definitions/results-page.js
@@ -1,7 +1,11 @@
 import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
 import { kebabCase, KeyStageSubjects } from "../utils";
 
-Given("a user has arrived on the 'Search results' page for {string}", keyStage => {
+Given("a user has arrived on the 'Search results' page for {string}", keyStageSubject => {
+    cy.visit(`/search-results?postcode=sk11eb&${KeyStageSubjects('subjects', keyStageSubject)}`);
+});
+
+Given("a user has arrived on the 'Search results' page for 'Key stage 1'", keyStage => {
     cy.visit(`/search-results?postcode=AB12CD&key-subjects=KeyStage1&subjects=KeyStage1-English`);
 });
 


### PR DESCRIPTION
## Changes proposed in this pull request

Add a SEND row to the search results and tuition partner pages

![image](https://user-images.githubusercontent.com/201727/180787253-697e49a8-e68d-4a6e-803a-3f66f1e88ac2.png)

![image](https://user-images.githubusercontent.com/201727/180787441-fcdc8d80-4fcb-4518-b1f4-2d41603365b4.png)

![image](https://user-images.githubusercontent.com/201727/180787477-0dec0cf5-787e-4984-ab32-bd2b2a968ac8.png)

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-285

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code