### PR TITLE
NTP-386: Fix the feedback link and move e2e tests to own feature

### DIFF
--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -88,12 +88,12 @@
 
 <div class="govuk-width-container ">
 	<div class="govuk-phase-banner">
-		<p class="govuk-phase-banner__content">
-			<strong class="govuk-tag govuk-phase-banner__content__tag" data-testid="phase-banner-title">
+		<p class="govuk-phase-banner__content" data-testid="phase-banner">
+			<strong class="govuk-tag govuk-phase-banner__content__tag">
 				private beta
 			</strong>
 			<span class="govuk-phase-banner__text">
-				This is a new service – your <a data-testid="feedback-link"  href ="https://docs.google.com/document/d/1Iybtc7c9IVMVNUE2Hkj85WF8csEIdhD6XNZ0hd4ozOs/edit"class="govuk-link">feedback</a> will help us to improve it.
+				This is a new service – your <a href="https://forms.gle/44KfQyg1YUidrDCi7" target="_blank" class="govuk-link" data-testid="phase-banner-feedback-link">feedback</a> will help us to improve it.
 			</span>
 		</p>
 	</div>

--- a/UI/cypress/e2e/phase-banner.feature
+++ b/UI/cypress/e2e/phase-banner.feature
@@ -1,0 +1,10 @@
+Feature: Phase banner shows users service is still being worked on and feedback can help improve it
+  Scenario: phase banner state is 'private beta'
+    Given a user has started the 'Find a tuition partner' journey
+    Then they will see the phase banner
+    And the current phase is 'private beta'
+
+  Scenario: phase banner contains link to feedback form
+    Given a user has started the 'Find a tuition partner' journey
+    Then the phase banner feedback link 'feedback' links to 'https://forms.gle/44KfQyg1YUidrDCi7'
+    And the phase banner feedback link opens in a new window

--- a/UI/cypress/e2e/phase-banner.js
+++ b/UI/cypress/e2e/phase-banner.js
@@ -1,0 +1,19 @@
+import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
+
+Then("they will see the phase banner", () => {
+    cy.get('[data-testid="phase-banner"]').should('exist')
+});
+
+Then("the current phase is {string}", (phase) => {
+    cy.get('[data-testid="phase-banner"]').should('contain.text', phase)
+});
+
+Then("the phase banner feedback link {string} links to {string}", (text, href) => {
+    cy.get('[data-testid="phase-banner-feedback-link"]')
+        .should('contain.text', text)
+        .should('have.attr', 'href', href)
+});
+
+Then("the phase banner feedback link opens in a new window", () => {
+    cy.get('[data-testid="phase-banner-feedback-link"]').should('have.attr', 'target', '_blank')
+});

--- a/UI/cypress/e2e/postcode.feature
+++ b/UI/cypress/e2e/postcode.feature
@@ -7,14 +7,6 @@ Feature: User enters postcode to begin search
     Given a user has started the 'Find a tuition partner' journey
     Then the page's title is 'Find a tuition partner'
 
-  Scenario: page banner is 'Private beta'
-       Given a user has started the 'Find a tuition partner' journey
-       Then they will see phase banner 
-
-  Scenario: display feedback form 
-    Given a user has started the 'Find a tuition partner' journey
-    Then the user should redirected to feedback form
-
   Scenario: user clicks service name
     Given a user has started the 'Find a tuition partner' journey
     When they click the 'Find a tuition partner' service name link


### PR DESCRIPTION
## Context

The link used in the original PR was wrong.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

[NTP-386](https://dfedigital.atlassian.net/browse/NTP-386)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] Test coverage of new code is at least 80%
- [X] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [X] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code