### PR TITLE
NTP-378: Cost per subject content

### DIFF
--- a/Tests/TuitionPartnerDetailsPagePriceTable.cs
+++ b/Tests/TuitionPartnerDetailsPagePriceTable.cs
@@ -1,4 +1,5 @@
 ﻿using Domain.Constants;
+using System.Globalization;
 using UI.Extensions;
 using GroupPrice = UI.Pages.TuitionPartner.GroupPrice;
 
@@ -6,6 +7,11 @@ namespace Tests;
 
 public class TuitionPartnerDetailsPagePriceTable
 {
+    public TuitionPartnerDetailsPagePriceTable()
+    {
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("en-GB");
+    }
+
     [Theory]
     [MemberData(nameof(PriceData))]
     public void Prices_are_hidden_when_there_are_none_for_a_tuition_type(

--- a/Tests/TuitionPartnerDetailsPagePriceTable.cs
+++ b/Tests/TuitionPartnerDetailsPagePriceTable.cs
@@ -1,0 +1,151 @@
+﻿using Domain.Constants;
+using UI.Extensions;
+using GroupPrice = UI.Pages.TuitionPartner.GroupPrice;
+
+namespace Tests;
+
+public class TuitionPartnerDetailsPagePriceTable
+{
+    [Theory]
+    [MemberData(nameof(PriceData))]
+    public void Prices_are_hidden_when_there_are_none_for_a_tuition_type(
+        bool showInSchool, bool showOnline, Dictionary<int, GroupPrice> price)
+    {
+        price.ContainsInSchoolPrice().Should().Be(showInSchool);
+        price.ContainsOnlinePrice().Should().Be(showOnline);
+    }
+
+    public static IEnumerable<object[]> PriceData()
+    {
+        yield return new object[]
+        {
+            false, false, new Dictionary<int, GroupPrice> { }
+        };
+
+        yield return new object[]
+        {
+            false, false, new Dictionary<int, GroupPrice>
+            {
+                { 1, new GroupPrice(null, null, null, null) },
+            },
+        };
+
+        yield return new object[]
+        {
+            true, false, new Dictionary<int, GroupPrice>
+            {
+                { 1, new GroupPrice(SchoolMin: 1, SchoolMax: null, OnlineMin: null, OnlineMax: null) },
+                { 2, new GroupPrice(SchoolMin: null, SchoolMax: null, OnlineMin: null, OnlineMax: null) },
+            },
+        };
+
+        yield return new object[]
+        {
+            true, false, new Dictionary<int, GroupPrice>
+            {
+                { 1, new GroupPrice(SchoolMin: null, SchoolMax: 1, OnlineMin: null, OnlineMax: null) },
+                { 2, new GroupPrice(SchoolMin: null, SchoolMax: null, OnlineMin: null, OnlineMax: null) },
+            },
+        };
+
+        yield return new object[]
+        {
+            false, true, new Dictionary<int, GroupPrice>
+            {
+                { 1, new GroupPrice(SchoolMin: null, SchoolMax: null, OnlineMin: 1, OnlineMax: null) },
+                { 2, new GroupPrice(SchoolMin: null, SchoolMax: null, OnlineMin: null, OnlineMax: null) },
+            },
+        };
+
+        yield return new object[]
+        {
+            false, true, new Dictionary<int, GroupPrice>
+            {
+                { 1, new GroupPrice(SchoolMin: null, SchoolMax: null, OnlineMin: null, OnlineMax: 1) },
+                { 2, new GroupPrice(SchoolMin: null, SchoolMax: null, OnlineMin: null, OnlineMax: null) },
+            },
+        };
+
+        yield return new object[]
+        {
+            false, true, new Dictionary<int, GroupPrice>
+            {
+                { 1, new GroupPrice(SchoolMin: null, SchoolMax: null, OnlineMin: 1, OnlineMax: 1) },
+                { 2, new GroupPrice(SchoolMin: null, SchoolMax: null, OnlineMin: null, OnlineMax: null) },
+            },
+        };
+
+        yield return new object[]
+        {
+            true, false, new Dictionary<int, GroupPrice>
+            {
+                { 1, new GroupPrice(SchoolMin: 1, SchoolMax: 1, OnlineMin: null, OnlineMax: null) },
+                { 2, new GroupPrice(SchoolMin: null, SchoolMax: null, OnlineMin: null, OnlineMax: null) },
+            },
+        };
+
+        yield return new object[]
+        {
+            true, true, new Dictionary<int, GroupPrice>
+            {
+                { 1, new GroupPrice(SchoolMin: 1, SchoolMax: null, OnlineMin: 1, OnlineMax: null) },
+                { 2, new GroupPrice(SchoolMin: null, SchoolMax: null, OnlineMin: null, OnlineMax: null) },
+            },
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(GroupPriceFormat))]
+    public void Formats_group_price(TuitionTypes tuitionType, GroupPrice price, string expected)
+    {
+        price.FormatFor(tuitionType).Should().Be(expected);
+    }
+
+    public static IEnumerable<object[]> GroupPriceFormat()
+    {
+        yield return new object[]
+        {
+            TuitionTypes.InSchool, new GroupPrice(SchoolMin: null, null, OnlineMin: null, null), ""
+        };
+        yield return new object[]
+        {
+            TuitionTypes.InSchool, new GroupPrice(SchoolMin: 1, SchoolMax: 2, OnlineMin: 3, OnlineMax: 4), "£1 to £2"
+        };
+        yield return new object[]
+        {
+            TuitionTypes.InSchool, new GroupPrice(SchoolMin: 1.12m, SchoolMax: 2.99m, OnlineMin: 3.33m, OnlineMax: 4.99m), "£1.12 to £2.99"
+        };
+        yield return new object[]
+        {
+            TuitionTypes.InSchool, new GroupPrice(SchoolMin: 1.1m, SchoolMax: 2.8m, OnlineMin: 3.33m, OnlineMax: 4.99m), "£1.10 to £2.80"
+        };
+        yield return new object[]
+        {
+            TuitionTypes.InSchool, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12, OnlineMax: 12), "£8"
+        };
+        yield return new object[]
+        {
+            TuitionTypes.Online, new GroupPrice(SchoolMin: null, null, OnlineMin: null, null), ""
+        };
+        yield return new object[]
+        {
+            TuitionTypes.Online, new GroupPrice(SchoolMin: 1, SchoolMax: 2, OnlineMin: 3, OnlineMax: 4), "£3 to £4"
+        };
+        yield return new object[]
+        {
+            TuitionTypes.Online, new GroupPrice(SchoolMin: 1.12m, SchoolMax: 2.99m, OnlineMin: 3.33m, OnlineMax: 4.99m), "£3.33 to £4.99"
+        };
+        yield return new object[]
+        {
+            TuitionTypes.Online, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12, OnlineMax: 12), "£12"
+        };
+        yield return new object[]
+        {
+            TuitionTypes.Online, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12.22m, OnlineMax: 12.22m), "£12.22"
+        };
+        yield return new object[]
+        {
+            TuitionTypes.Online, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12.20m, OnlineMax: 12.20m), "£12.20"
+        };
+    }
+}

--- a/UI/Extensions/ToStringExtensions.cs
+++ b/UI/Extensions/ToStringExtensions.cs
@@ -1,0 +1,37 @@
+﻿using Domain.Constants;
+using static UI.Pages.TuitionPartner;
+
+namespace UI.Extensions;
+
+public static class ToStringExtensions
+{
+    public static bool ContainsInSchoolPrice(this Dictionary<int, GroupPrice> prices)
+        => prices.Any(x => x.Value.SchoolMin.HasValue || x.Value.SchoolMax.HasValue);
+
+    public static bool ContainsOnlinePrice(this Dictionary<int, GroupPrice> prices)
+        => prices.Any(x => x.Value.OnlineMin.HasValue || x.Value.OnlineMax.HasValue);
+
+    public static string FormatFor(this GroupPrice price, TuitionTypes tuitionType)
+    {
+        return tuitionType switch
+        {
+            TuitionTypes.InSchool => FormatPrices(price.SchoolMin, price.SchoolMax),
+            TuitionTypes.Online => FormatPrices(price.OnlineMin, price.OnlineMax),
+            _ => "",
+        };
+
+        static string FormatPrices(decimal? min, decimal? max) =>
+            (min, max) switch
+            {
+                _ when min != null && min == max => $"{FormatPrice(min.Value)}",
+                _ when min != null && max != null => $"{FormatPrice(min.Value)} to {FormatPrice(max.Value)}",
+                _ => "",
+            };
+    }
+
+    public static string FormatPrice(this decimal price)
+    {
+        var str = $"{price:C}";
+        return str.EndsWith(".00") ? str[0..^3] : str;
+    }
+}

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -132,8 +132,8 @@
 		    <thead class="govuk-table__head">
 		    <tr class="govuk-table__row">
 			    <th scope="col" class="govuk-table__header">Tuition group size</th>
-			    <th scope="col" class="govuk-table__header">In school</th>
-			    <th scope="col" class="govuk-table__header">Online</th>
+			    <th show-if="@Model.Data.Prices.ContainsInSchoolPrice()" scope="col" class="govuk-table__header">In school</th>
+			    <th show-if="@Model.Data.Prices.ContainsOnlinePrice()" scope="col" class="govuk-table__header">Online</th>
 		    </tr>
 		    </thead>
 		    <tbody class="govuk-table__body">
@@ -141,22 +141,13 @@
 		    {
 			    <tr class="govuk-table__row">
 				    <th scope="row" class="govuk-table__header">1 to @item.Key</th>
-				    @if (item.Value.SchoolMin == item.Value.SchoolMax)
-				    {
-					    <td class="govuk-table__cell">@Html.FormatValue(item.Value.SchoolMin, "{0:C}")</td>
-				    }
-				    else
-				    {
-					    <td class="govuk-table__cell">@Html.FormatValue(item.Value.SchoolMin, "{0:C}") to @Html.FormatValue(item.Value.SchoolMax, "{0:C}")</td>
-				    }
-				    @if (item.Value.OnlineMin == item.Value.OnlineMax)
-				    {
-					    <td class="govuk-table__cell">@Html.FormatValue(item.Value.OnlineMin, "{0:C}")</td>
-				    }
-				    else
-				    {
-					    <td class="govuk-table__cell">@Html.FormatValue(item.Value.OnlineMin, "{0:C}") to @Html.FormatValue(item.Value.OnlineMax, "{0:C}")</td>
-				    }
+				    <td show-if="@Model.Data.Prices.ContainsInSchoolPrice()" class="govuk-table__cell">
+						@item.Value.FormatFor(Domain.Constants.TuitionTypes.InSchool)
+					</td>
+
+				    <td show-if="@Model.Data.Prices.ContainsOnlinePrice()" class="govuk-table__cell">
+						@item.Value.FormatFor(Domain.Constants.TuitionTypes.Online)
+					</td>
 			    </tr>
 		    }
 		    </tbody>
@@ -188,7 +179,7 @@
 						    {
 							    if (prices.TryGetValue(groupSize, out var price))
 							    {
-								    <td class="govuk-table__cell">@Html.FormatValue(price, "{0:C}")</td>
+								    <td class="govuk-table__cell">@price.FormatPrice()</td>
 							    }
 							    else
 							    {

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -130,6 +130,12 @@
 	    <table class="govuk-table" data-testid="pricing-table" show-if="@(!Model.Data.AllPrices.Any())">
 		    <caption class="govuk-table__caption govuk-table__caption--m">Tuition cost information</caption>
 		    <thead class="govuk-table__head">
+			<tr class="govuk-table__row" colspan="*">
+				<td>The costs shown are per pupil per hour.</td>
+			</tr>
+			<tr class="govuk-table__row" colspan="*">
+				<td>All subjects are the same price but depend on tuition group size.</td>
+			</tr>
 		    <tr class="govuk-table__row">
 			    <th scope="col" class="govuk-table__header">Tuition group size</th>
 			    <th show-if="@Model.Data.Prices.ContainsInSchoolPrice()" scope="col" class="govuk-table__header">In school</th>

--- a/UI/Pages/_ViewImports.cshtml
+++ b/UI/Pages/_ViewImports.cshtml
@@ -1,5 +1,6 @@
 ﻿@using UI.Models
 @using Application.Extensions
+@using UI.Extensions
 @namespace UI.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, GovUk.Frontend.AspNetCore

--- a/UI/cypress/e2e/tuition-partner-details.feature
+++ b/UI/cypress/e2e/tuition-partner-details.feature
@@ -74,6 +74,15 @@ Feature: User can view full details of a Tuition Parner
     When they set the 'show-locations-covered' query string parameter value to 'true'
     Then the tuition partner locations covered table is displayed
 
+  Scenario: tuition cost table shows available tuition types
+    Given a user has arrived on the 'Tuition Partner' page for '<tution-partner>'
+    Then the tuition partner pricing table is displayed for '<tuition-types>'
+    Examples:
+    | tution-partner | tuition-types |
+    | Fledge Tuition Ltd | Online |
+    | FFT Education | In school |
+    | Nudge | In school, Online |
+
   Scenario: full pricing tables are not displayed as default
     Given a user has arrived on the 'Tuition Partner' page for 'Fleet Education Services'
     Then the tuition partner full pricing tables are not displayed

--- a/UI/cypress/e2e/tuition-partner-details.js
+++ b/UI/cypress/e2e/tuition-partner-details.js
@@ -78,6 +78,13 @@ Then("the tuition partner pricing table is displayed", () => {
         .should('exist');
 });
 
+Then("the tuition partner pricing table is displayed for {string}", tuitionTypes => {
+    tuitionTypes.split(',').forEach(tuitionType => {
+        cy.get('[data-testid="pricing-table"]')
+            .should('contain.text', tuitionType);
+    });
+});
+
 Then("the tuition partner full pricing tables are not displayed", () => {
     for (let i = 1; i < 5; i++) {
         cy.get(`[data-testid="full-pricing-table-in-school-key-stage-${i}"]`)


### PR DESCRIPTION
## Changes proposed in this pull request

* Remove the entire column for a tuition type if it is not provided.
* Trim prices where they are whole pounds.

Before: 
![image](https://user-images.githubusercontent.com/201727/180987700-e7e52359-45d1-4e4c-a76b-86045f6fb7d7.png)

After: 
![image](https://user-images.githubusercontent.com/201727/180987738-ee2a72f0-b92a-4c97-86bb-88acc572374a.png)

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-378

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code