### PR TITLE
NTP-346: Configure and run dotnet format against solution

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_sort_system_directives_first = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.private_or_internal_field_should_be__fieldname.severity = warning
+dotnet_naming_rule.private_or_internal_field_should_be__fieldname.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be__fieldname.style = _fieldname
+
+# Naming styles
+
+dotnet_naming_style._fieldname.required_prefix = _
+dotnet_naming_style._fieldname.required_suffix = 
+dotnet_naming_style._fieldname.word_separator = 
+dotnet_naming_style._fieldname.capitalization = camel_case

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,18 +12,3 @@ tab_width = 4
 
 # Organize usings
 dotnet_sort_system_directives_first = true
-
-#### Naming styles ####
-
-# Naming rules
-
-dotnet_naming_rule.private_or_internal_field_should_be__fieldname.severity = warning
-dotnet_naming_rule.private_or_internal_field_should_be__fieldname.symbols = private_or_internal_field
-dotnet_naming_rule.private_or_internal_field_should_be__fieldname.style = _fieldname
-
-# Naming styles
-
-dotnet_naming_style._fieldname.required_prefix = _
-dotnet_naming_style._fieldname.required_suffix = 
-dotnet_naming_style._fieldname.word_separator = 
-dotnet_naming_style._fieldname.capitalization = camel_case

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@
 
 - [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
 - [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
+- [ ] `dotnet format` has been run in the repository root
 - [ ] Test coverage of new code is at least 80%
 - [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
 - [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off

--- a/Application/Behaviours/ValidationBehaviour.cs
+++ b/Application/Behaviours/ValidationBehaviour.cs
@@ -21,7 +21,7 @@ public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TReque
         var failures = validationResults.SelectMany(r => r.Errors).Where(f => f != null).ToList();
         if (failures.Count != 0)
             throw new ValidationException(failures);
-        
+
         return await next();
     }
 }

--- a/Application/Extensions/ServiceCollectionExtensions.cs
+++ b/Application/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using Application.Behaviours;
-using Microsoft.Extensions.DependencyInjection;
 using FluentValidation;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Application.Extensions;
 

--- a/DataImporter/Program.cs
+++ b/DataImporter/Program.cs
@@ -1,9 +1,9 @@
 ﻿using System.Security.Cryptography;
-using Infrastructure.Extensions;
-using Microsoft.Extensions.Hosting;
 using Infrastructure;
 using Infrastructure.Configuration;
+using Infrastructure.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 if (args.Any(x => x == "generate-key"))
 {

--- a/Domain.Tests/Validators/TuitionPartnerValidatorTests.cs
+++ b/Domain.Tests/Validators/TuitionPartnerValidatorTests.cs
@@ -1,6 +1,6 @@
-﻿using Domain.Validators;
+﻿using System.Collections.Generic;
+using Domain.Validators;
 using FluentValidation.TestHelper;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Domain.Tests.Validators;
@@ -128,7 +128,7 @@ public class TuitionPartnerValidatorTests
     }
 
     [Fact]
-  
+
     public void With_no_valid_price()
     {
         var listOfPrices = new List<Price>();

--- a/Domain/Constants/Country.cs
+++ b/Domain/Constants/Country.cs
@@ -2,7 +2,7 @@
 
 public class Country
 {
-    public class Name 
+    public class Name
     {
         public const string England = "England";
         public const string Wales = "Wales";

--- a/Domain/LocalAuthority.cs
+++ b/Domain/LocalAuthority.cs
@@ -1,6 +1,6 @@
 ﻿namespace Domain;
 
-public  class LocalAuthority
+public class LocalAuthority
 {
     public LocalAuthority()
     {

--- a/Domain/LocalAuthorityDistrict.cs
+++ b/Domain/LocalAuthorityDistrict.cs
@@ -1,12 +1,12 @@
 ﻿namespace Domain;
 
-public  class LocalAuthorityDistrict
+public class LocalAuthorityDistrict
 {
     public int Id { get; set; }
     public string Code { get; set; } = null!;
     public string Name { get; set; } = null!;
-    public int RegionId { get; set; } 
+    public int RegionId { get; set; }
     public Region Region { get; set; } = null!;
-    public int LocalAuthorityId { get; set; } 
+    public int LocalAuthorityId { get; set; }
     public LocalAuthority LocalAuthority { get; set; } = null!;
 }

--- a/Domain/Result.cs
+++ b/Domain/Result.cs
@@ -43,7 +43,7 @@ public class SuccessResult<T> : SuccessResult, IResult<T>
     public override string ToString() => Data?.ToString() ?? $"Success<{typeof(T).Name}>";
 }
 
-public interface IErrorResult : IResult 
+public interface IErrorResult : IResult
 {
     public IErrorResult<TCast> Cast<TCast>();
 }
@@ -79,7 +79,7 @@ public class ValidationResult : ErrorResult
 {
     public ValidationResult(params FluentValidation.Results.ValidationFailure[] failures)
         => Failures = failures;
-    
+
     public ValidationResult(IEnumerable<FluentValidation.Results.ValidationFailure> failures)
         => Failures = failures;
 

--- a/Domain/Search/SearchRequestBase.cs
+++ b/Domain/Search/SearchRequestBase.cs
@@ -6,7 +6,7 @@ public abstract class SearchRequestBase
 {
     public const int DefaultPageSize = 50;
     public const int MaxPageSize = 500;
-    
+
     public int Page { get; set; }
     [DefaultValue(DefaultPageSize)]
     public int PageSize { get; set; } = DefaultPageSize;

--- a/Domain/Validators/TuitionPartnerValidator.cs
+++ b/Domain/Validators/TuitionPartnerValidator.cs
@@ -1,5 +1,5 @@
-﻿using FluentValidation;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
+using FluentValidation;
 
 namespace Domain.Validators;
 
@@ -54,7 +54,7 @@ public class TuitionPartnerValidator : AbstractValidator<TuitionPartner>
         }
         return prices.Any(x => x.GroupSize > 0 && x.HourlyRate > 0);
     }
-   
+
     private static bool CheckRegex(string property, string regex)
     {
         return Regex.IsMatch(property,

--- a/GiasPostcodeSearch/GiasPostcodeSearchService.cs
+++ b/GiasPostcodeSearch/GiasPostcodeSearchService.cs
@@ -49,7 +49,8 @@ public class GiasPostcodeSearchService : IHostedService
             CancellationToken = cancellationToken
         };
 
-        await Parallel.ForEachAsync(schoolData, options, async (schoolDatum, ct) => {
+        await Parallel.ForEachAsync(schoolData, options, async (schoolDatum, ct) =>
+        {
             var subjectsQueryString = GetSubjectsQueryString(schoolDatum);
             if (subjectsQueryString == null)
             {
@@ -58,9 +59,9 @@ public class GiasPostcodeSearchService : IHostedService
             else
             {
                 _logger.LogDebug($"Searching for Tuition Partners covering School {schoolDatum}");
-                
+
                 var requestUri = $"search-results?Data.Postcode={schoolDatum.Postcode}&{subjectsQueryString}";
-                
+
                 var stopWatch = new Stopwatch();
                 stopWatch.Start();
                 var response = await _httpClient.GetAsync(requestUri, ct);
@@ -100,7 +101,7 @@ public class GiasPostcodeSearchService : IHostedService
                     averageElapsedMilliseconds = (int)(elapsedMilliseconds / (double)count);
                     searchesPerSecond = (int)((double)count / (runStopWatch.ElapsedMilliseconds / 1000));
                     _logger.LogInformation($"{count} searches of {totalCount} run in {runStopWatch.ElapsedMilliseconds / 1000}s. Error count {errorCount}. {searchesPerSecond} searches per second. Average response time {averageElapsedMilliseconds}ms min {minElapsedMilliseconds}ms ({fastestRequestUri}) max {maxElapsedMilliseconds}ms ({slowestRequestUri})");
-                    
+
                     // Reset metrics for next run
                     minElapsedMilliseconds = long.MaxValue;
                     maxElapsedMilliseconds = 0L;
@@ -113,7 +114,7 @@ public class GiasPostcodeSearchService : IHostedService
         runStopWatch.Stop();
         averageElapsedMilliseconds = (int)(elapsedMilliseconds / (double)count);
         searchesPerSecond = (int)((double)count / runStopWatch.ElapsedMilliseconds);
-        _logger.LogInformation($"Run complete. {count} searches run in {runStopWatch.ElapsedMilliseconds/1000}s. Error count {errorCount}. {searchesPerSecond} searches per second. Average response time {averageElapsedMilliseconds}ms min {minElapsedMilliseconds}ms ({fastestRequestUri}) max {maxElapsedMilliseconds}ms ({slowestRequestUri})");
+        _logger.LogInformation($"Run complete. {count} searches run in {runStopWatch.ElapsedMilliseconds / 1000}s. Error count {errorCount}. {searchesPerSecond} searches per second. Average response time {averageElapsedMilliseconds}ms min {minElapsedMilliseconds}ms ({fastestRequestUri}) max {maxElapsedMilliseconds}ms ({slowestRequestUri})");
 
         _host.StopApplication();
     }

--- a/GiasPostcodeSearch/Program.cs
+++ b/GiasPostcodeSearch/Program.cs
@@ -1,8 +1,8 @@
 ﻿using System.Net.Http.Headers;
 using System.Text;
 using GiasPostcodeSearch;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Events;
 

--- a/Infrastructure/DataImporterService.cs
+++ b/Infrastructure/DataImporterService.cs
@@ -5,10 +5,10 @@ using Application.Factories;
 using Domain;
 using Domain.Validators;
 using Infrastructure.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
 namespace Infrastructure;

--- a/Infrastructure/EntityConfigurations/RegionConfiguration.cs
+++ b/Infrastructure/EntityConfigurations/RegionConfiguration.cs
@@ -16,7 +16,7 @@ public class RegionConfiguration : IEntityTypeConfiguration<Region>
             new Region { Id = Regions.Id.NorthEast, Code = "E12000001", Name = "North East" },
             new Region { Id = Regions.Id.NorthWest, Code = "E12000002", Name = "North West" },
             new Region { Id = Regions.Id.YorkshireandTheHumber, Code = "E12000003", Name = "Yorkshire and The Humber" },
-            new Region { Id = Regions.Id.EastMidlands, Code = "E12000004", Name = "East Midlands" }, 
+            new Region { Id = Regions.Id.EastMidlands, Code = "E12000004", Name = "East Midlands" },
             new Region { Id = Regions.Id.WestMidlands, Code = "E12000005", Name = "West Midlands" },
             new Region { Id = Regions.Id.EastofEngland, Code = "E12000006", Name = "East of England" },
             new Region { Id = Regions.Id.London, Code = "E12000007", Name = "London" },

--- a/Infrastructure/EntityConfigurations/SubjectConfiguration.cs
+++ b/Infrastructure/EntityConfigurations/SubjectConfiguration.cs
@@ -13,22 +13,22 @@ public class SubjectConfiguration : IEntityTypeConfiguration<Subject>
         builder.HasIndex(e => e.Name);
 
         builder.HasData(
-            new Subject {Id = Subjects.Id.KeyStage1English, SeoUrl = "key-stage-1-english", KeyStageId = KeyStages.Id.One, Name = "English"},
-            new Subject {Id = Subjects.Id.KeyStage1Maths, SeoUrl = "key-stage-1-maths", KeyStageId = KeyStages.Id.One, Name = "Maths"},
-            new Subject {Id = Subjects.Id.KeyStage1Science, SeoUrl = "key-stage-1-science", KeyStageId = KeyStages.Id.One, Name = "Science"},
-            new Subject {Id = Subjects.Id.KeyStage2English, SeoUrl = "key-stage-2-english", KeyStageId = KeyStages.Id.Two, Name = "English"},
-            new Subject {Id = Subjects.Id.KeyStage2Maths, SeoUrl = "key-stage-2-maths", KeyStageId = KeyStages.Id.Two, Name = "Maths"},
-            new Subject {Id = Subjects.Id.KeyStage2Science, SeoUrl = "key-stage-2-science", KeyStageId = KeyStages.Id.Two, Name = "Science" },
-            new Subject {Id = Subjects.Id.KeyStage3English, SeoUrl = "key-stage-3-english", KeyStageId = KeyStages.Id.Three, Name = "English"},
-            new Subject {Id = Subjects.Id.KeyStage3Humanities, SeoUrl = "key-stage-3-humanities", KeyStageId = KeyStages.Id.Three, Name = "Humanities"},
-            new Subject {Id = Subjects.Id.KeyStage3Maths, SeoUrl = "key-stage-3-maths", KeyStageId = KeyStages.Id.Three, Name = "Maths"},
-            new Subject {Id = Subjects.Id.KeyStage3ModernForeignLanguages, SeoUrl = "key-stage-3-modern-foreign-languages", KeyStageId = KeyStages.Id.Three, Name = "Modern Foreign Languages"},
-            new Subject {Id = Subjects.Id.KeyStage3Science, SeoUrl = "key-stage-3-science", KeyStageId = KeyStages.Id.Three, Name = "Science"},
-            new Subject {Id = Subjects.Id.KeyStage4English, SeoUrl = "key-stage-4-english", KeyStageId = KeyStages.Id.Four, Name = "English"},
-            new Subject {Id = Subjects.Id.KeyStage4Humanities, SeoUrl = "key-stage-4-humanities", KeyStageId = KeyStages.Id.Four, Name = "Humanities"},
-            new Subject {Id = Subjects.Id.KeyStage4Maths, SeoUrl = "key-stage-4-maths", KeyStageId = KeyStages.Id.Four, Name = "Maths"},
-            new Subject {Id = Subjects.Id.KeyStage4ModernForeignLanguages, SeoUrl = "key-stage-4-modern-foreign-languages", KeyStageId = KeyStages.Id.Four, Name = "Modern Foreign Languages"},
-            new Subject {Id = Subjects.Id.KeyStage4Science, SeoUrl = "key-stage-4-science", KeyStageId = KeyStages.Id.Four, Name = "Science"}
+            new Subject { Id = Subjects.Id.KeyStage1English, SeoUrl = "key-stage-1-english", KeyStageId = KeyStages.Id.One, Name = "English" },
+            new Subject { Id = Subjects.Id.KeyStage1Maths, SeoUrl = "key-stage-1-maths", KeyStageId = KeyStages.Id.One, Name = "Maths" },
+            new Subject { Id = Subjects.Id.KeyStage1Science, SeoUrl = "key-stage-1-science", KeyStageId = KeyStages.Id.One, Name = "Science" },
+            new Subject { Id = Subjects.Id.KeyStage2English, SeoUrl = "key-stage-2-english", KeyStageId = KeyStages.Id.Two, Name = "English" },
+            new Subject { Id = Subjects.Id.KeyStage2Maths, SeoUrl = "key-stage-2-maths", KeyStageId = KeyStages.Id.Two, Name = "Maths" },
+            new Subject { Id = Subjects.Id.KeyStage2Science, SeoUrl = "key-stage-2-science", KeyStageId = KeyStages.Id.Two, Name = "Science" },
+            new Subject { Id = Subjects.Id.KeyStage3English, SeoUrl = "key-stage-3-english", KeyStageId = KeyStages.Id.Three, Name = "English" },
+            new Subject { Id = Subjects.Id.KeyStage3Humanities, SeoUrl = "key-stage-3-humanities", KeyStageId = KeyStages.Id.Three, Name = "Humanities" },
+            new Subject { Id = Subjects.Id.KeyStage3Maths, SeoUrl = "key-stage-3-maths", KeyStageId = KeyStages.Id.Three, Name = "Maths" },
+            new Subject { Id = Subjects.Id.KeyStage3ModernForeignLanguages, SeoUrl = "key-stage-3-modern-foreign-languages", KeyStageId = KeyStages.Id.Three, Name = "Modern Foreign Languages" },
+            new Subject { Id = Subjects.Id.KeyStage3Science, SeoUrl = "key-stage-3-science", KeyStageId = KeyStages.Id.Three, Name = "Science" },
+            new Subject { Id = Subjects.Id.KeyStage4English, SeoUrl = "key-stage-4-english", KeyStageId = KeyStages.Id.Four, Name = "English" },
+            new Subject { Id = Subjects.Id.KeyStage4Humanities, SeoUrl = "key-stage-4-humanities", KeyStageId = KeyStages.Id.Four, Name = "Humanities" },
+            new Subject { Id = Subjects.Id.KeyStage4Maths, SeoUrl = "key-stage-4-maths", KeyStageId = KeyStages.Id.Four, Name = "Maths" },
+            new Subject { Id = Subjects.Id.KeyStage4ModernForeignLanguages, SeoUrl = "key-stage-4-modern-foreign-languages", KeyStageId = KeyStages.Id.Four, Name = "Modern Foreign Languages" },
+            new Subject { Id = Subjects.Id.KeyStage4Science, SeoUrl = "key-stage-4-science", KeyStageId = KeyStages.Id.Four, Name = "Science" }
         );
     }
 }

--- a/Infrastructure/Extensions/HostBuilderExtensions.cs
+++ b/Infrastructure/Extensions/HostBuilderExtensions.cs
@@ -13,7 +13,7 @@ public static class HostBuilderExtensions
         hostBuilder.UseSerilog((context, config) =>
         {
             var appLogging = context.Configuration.GetSection("AppLogging").Get<AppLogging>() ?? new AppLogging();
-            
+
             config
                 .MinimumLevel.Is(appLogging.DefaultLogEventLevel)
                 .MinimumLevel.Override("Microsoft", appLogging.OverrideLogEventLevel)

--- a/Infrastructure/Factories/QualityAssuredSpreadsheetTuitionPartnerFactory.cs
+++ b/Infrastructure/Factories/QualityAssuredSpreadsheetTuitionPartnerFactory.cs
@@ -132,7 +132,7 @@ public class QualityAssuredSpreadsheetTuitionPartnerFactory : ITuitionPartnerFac
             var region = await _dbContext.Regions
                 .Include(e => e.LocalAuthorityDistricts)
                 .FirstOrDefaultAsync(e => e.Id == regionId, cancellationToken);
-            
+
             if (region == null)
             {
                 throw new Exception($"Region with id {regionId} from initial {regionInitials} was not found");
@@ -155,7 +155,7 @@ public class QualityAssuredSpreadsheetTuitionPartnerFactory : ITuitionPartnerFac
         {
             var lad = await _dbContext.LocalAuthorityDistricts
                 .FirstOrDefaultAsync(e => e.Code == ladCode, cancellationToken);
-            
+
             if (lad == null)
             {
                 throw new Exception($"Local Authority District with code {ladCode} was not found");

--- a/Infrastructure/Repositories/TuitionPartnerRepository.cs
+++ b/Infrastructure/Repositories/TuitionPartnerRepository.cs
@@ -30,12 +30,12 @@ public class TuitionPartnerRepository : ITuitionPartnerRepository
             var result = entity.Adapt<TuitionPartnerSearchResult>();
 
             result.Subjects = entity.SubjectCoverage.OrderBy(e => e.Id).Select(e => e.Subject).Distinct().ToArray();
-            
+
             result.TuitionTypes = entity.LocalAuthorityDistrictCoverage.Select(e => e.TuitionType).OrderByDescending(e => e.Id).Distinct().ToArray();
 
             results.Add(result);
         }
-       
+
         switch (orderBy)
         {
             case TuitionPartnerOrderBy.Name:

--- a/Tests/BackLinks.cs
+++ b/Tests/BackLinks.cs
@@ -49,7 +49,7 @@ public class BackLinks
     public void Construct_querystring_from_non_null_search_model_properties()
     {
         var model = new SearchModel
-        { 
+        {
             Postcode = "AB1 2CD",
             KeyStages = new[] { KeyStage.KeyStage1 },
             Subjects = null,

--- a/Tests/SearchForResults.cs
+++ b/Tests/SearchForResults.cs
@@ -5,8 +5,8 @@ using FluentValidation.TestHelper;
 using NSubstitute;
 using Tests.TestData;
 using UI.Pages;
-using KeyStage = UI.Pages.KeyStage;
 using Index = UI.Pages.Index;
+using KeyStage = UI.Pages.KeyStage;
 
 namespace Tests;
 

--- a/Tests/TuitionPartnerDetailsPage.cs
+++ b/Tests/TuitionPartnerDetailsPage.cs
@@ -13,7 +13,7 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
 {
     public TuitionPartnerDetailsPage(SliceFixture fixture) : base(fixture)
     {
-        
+
     }
 
     private Dictionary<string, string> LocalAuthorityDistrictCodes = new();
@@ -172,7 +172,7 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
     {
         var result = await Fixture.SendAsync(
             new TuitionPartner.Query(
-                "a-tuition-partner", 
+                "a-tuition-partner",
                 LocalAuthorityDistrictCode: LocalAuthorityDistrictCodes["Ryedale"]));
 
         result!.TuitionTypes.Should().BeEquivalentTo("Online");

--- a/Tests/Usings.cs
+++ b/Tests/Usings.cs
@@ -1,5 +1,5 @@
+global using FluentAssertions;
 global using MediatR;
 global using Microsoft.EntityFrameworkCore;
-global using FluentAssertions;
-global using Xunit;
 global using Tests.Utilities;
+global using Xunit;

--- a/UI/Extensions/TempDataSerialisation.cs
+++ b/UI/Extensions/TempDataSerialisation.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using System.Text.Json;
+﻿using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
 namespace UI.Extensions;
 
@@ -16,7 +16,7 @@ public static class TempDataSerialisation
         try
         {
             var data = tempData?.Peek(key);
-            if(data is string json) return JsonSerializer.Deserialize<T>(json);
+            if (data is string json) return JsonSerializer.Deserialize<T>(json);
         }
         catch
         {

--- a/UI/Pages/Error.cshtml.cs
+++ b/UI/Pages/Error.cshtml.cs
@@ -1,6 +1,6 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using System.Diagnostics;
 
 namespace UI.Pages
 {

--- a/UI/Pages/Index.cshtml.cs
+++ b/UI/Pages/Index.cshtml.cs
@@ -35,7 +35,7 @@ public partial class Index : PageModel
             return RedirectToPage(nameof(WhichKeyStages), Data);
         }
 
-        if(validation is ErrorResult error)
+        if (validation is ErrorResult error)
             ModelState.AddModelError("Data.Postcode", error.ToString());
 
         return Page();

--- a/UI/Pages/SearchModel.cs
+++ b/UI/Pages/SearchModel.cs
@@ -17,9 +17,9 @@ public record SearchModel
     public string? Postcode { get; set; }
 
     public string[]? Subjects { get; set; }
-        
+
     public TuitionType? TuitionType { get; set; }
-    
+
     public KeyStage[]? KeyStages { get; set; }
 }
 
@@ -34,7 +34,7 @@ public record KeyStageSubject(KeyStage KeyStage, string Subject)
     public static KeyStageSubject Parse(string value)
     {
         var re = new Regex(@"(KeyStage[\d])-(.*)").Match(value);
-        
+
         if (!re.Success)
             throw new ArgumentException("Subject must be of the form KS1-English");
 
@@ -46,7 +46,7 @@ public record KeyStageSubject(KeyStage KeyStage, string Subject)
 
     public static bool TryParse(string value, [MaybeNullWhen(false)] out KeyStageSubject parsed)
     {
-        if(value == null)
+        if (value == null)
         {
             parsed = default;
             return false;
@@ -77,13 +77,13 @@ public enum KeyStage
 
     [Description("Key stage 1")]
     KeyStage1 = 1,
-    
+
     [Description("Key stage 2")]
     KeyStage2,
-    
+
     [Description("Key stage 3")]
     KeyStage3,
-    
+
     [Description("Key stage 4")]
     KeyStage4,
 }

--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -20,12 +20,12 @@ public class SearchResults : PageModel
     public SearchResults(IMediator mediator) => this.mediator = mediator;
 
     public ResultsModel Data { get; set; } = new();
-    
+
     public async Task OnGet(Query Data)
     {
         TempData.Set("AllSearchData", Data);
 
-        Data.TuitionType ??= TuitionType.Any; 
+        Data.TuitionType ??= TuitionType.Any;
         this.Data = await mediator.Send(Data);
 
         TempData.Set("LocalAuthorityDistrictCode", this.Data.LocalAuthorityDistrictCode ?? "");
@@ -159,7 +159,7 @@ public class SearchResults : PageModel
                         location.Data.LocalAuthorityDistrictCode,
                         request,
                         cancellationToken);
-            
+
             return Result.Success(results);
         }
 

--- a/UI/Pages/TuitionPartner.cshtml.cs
+++ b/UI/Pages/TuitionPartner.cshtml.cs
@@ -28,7 +28,7 @@ public class TuitionPartner : PageModel
     public async Task<IActionResult> OnGetAsync(Query query)
     {
         AllSearchData = TempData.Peek<SearchModel>("AllSearchData");
-        
+
         if (string.IsNullOrWhiteSpace(query.Id))
         {
             _logger.LogWarning("Null or whitespace id '{Id}' provided", query.Id);
@@ -42,7 +42,7 @@ public class TuitionPartner : PageModel
             return RedirectToPage((query with { Id = seoUrl }).ToRouteData());
         }
 
-        Data = await _mediator.Send(query with 
+        Data = await _mediator.Send(query with
         {
             LocalAuthorityDistrictCode = TempData.Peek<string>("LocalAuthorityDistrictCode")
         });
@@ -214,7 +214,7 @@ public class TuitionPartner : PageModel
                 .ToDictionary(
                     key => key.Key,
                     value => new GroupPrice
-                            ( MinPrice(value, TuitionTypes.InSchool)
+                            (MinPrice(value, TuitionTypes.InSchool)
                             , MaxPrice(value, TuitionTypes.InSchool)
                             , MinPrice(value, TuitionTypes.Online)
                             , MaxPrice(value, TuitionTypes.Online)

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text.Json.Serialization;
 using Application.Extensions;
 using FluentValidation.AspNetCore;
 using GovUk.Frontend.AspNetCore;
@@ -6,8 +8,6 @@ using Infrastructure.Configuration;
 using Infrastructure.Extensions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
-using System.Globalization;
-using System.Text.Json.Serialization;
 using UI.Filters;
 using UI.Routing;
 using AssemblyReference = UI.AssemblyReference;

--- a/UI/TagHelpers/ValidationRowHelper.cs
+++ b/UI/TagHelpers/ValidationRowHelper.cs
@@ -24,7 +24,7 @@ public class ValidationRowHelper : TagHelper
 
     private bool PropertyIsInvalid()
     {
-        return 
+        return
             ViewContext.ModelState.TryGetValue(PropertyName, out var modelState)
             && modelState.ValidationState == ModelValidationState.Invalid;
     }


### PR DESCRIPTION
## Context

The dev team want to enforce basic code formatting rules across the solution. These cover indentation, spacing and line breaks. In future the intention is to check and update code formatting via a git pre commit hook.

## Changes proposed in this pull request

This PR adds the foundational .editorconfig rules and standardises the existing code.

## Guidance to review

I originally added rules to enforce an underscore prefix on private fields. That gave false warnings for private const and private static readonly field. The recommended way round this is to add rules for the combinations you don't want to apply underscore prefixes to ahead of this rule. It became more complex than it was worth.

```
#### Naming styles ####

# Naming rules

dotnet_naming_rule.private_or_internal_field_should_be__fieldname.severity = warning
dotnet_naming_rule.private_or_internal_field_should_be__fieldname.symbols = private_or_internal_field
dotnet_naming_rule.private_or_internal_field_should_be__fieldname.style = _fieldname

# Naming styles

dotnet_naming_style._fieldname.required_prefix = _
dotnet_naming_style._fieldname.required_suffix = 
dotnet_naming_style._fieldname.word_separator = 
dotnet_naming_style._fieldname.capitalization = camel_case
```

## Link to Jira ticket

[NTP-346](https://dfedigital.atlassian.net/browse/NTP-346)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] Test coverage of new code is at least 80% - N/A
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/) - N/A
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off - N/A
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code