### PR TITLE
NTP-439: Upgrade to GovUk.Frontend.AspNetCore v1.0.0-beta1

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GiasPostcodeSearch/GiasPostcodeSearch.csproj
+++ b/GiasPostcodeSearch/GiasPostcodeSearch.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="27.2.1" />
+    <PackageReference Include="CsvHelper" Version="28.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>

--- a/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure.csproj
@@ -17,9 +17,9 @@
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.17.1" />
     <PackageReference Include="Mapster" Version="7.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="6.0.7" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="6.0.5" />
-    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Network" Version="2.0.2.68" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UI/Pages/Index.cshtml
+++ b/UI/Pages/Index.cshtml
@@ -5,61 +5,56 @@
 	ViewData["AllowIndexing"] = true;
 }
 
-
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
-		<govuk-error-summary>
-			<govuk-error-summary-item asp-for="Data.Postcode" />
-		</govuk-error-summary>
-		<h1 class="govuk-heading-l">Find a tuition partner</h1>
-		<p class="govuk-body">You can use your National Tutoring Programme funding to get a tuition partner, who will
-			arrange tutoring for your pupils in school or online. </p>
-		<p class="govuk-body">This service will help match you with a partner who meets your requirements from the full
-			list of quality-assured tuition partners.</p>
-		<govuk-details data-testid="qatp-details">
-			<govuk-details-summary>
-				What is a quality-assured tuition partner?
-			</govuk-details-summary>
-			<govuk-details-text>
-				The tuition partners shown on this service have been through a quality assurance process by the
-				Department for Education. This process is to ensure quality tuition is delivered and includes
-				safeguarding checks.
-			</govuk-details-text>
-		</govuk-details>
-		<form method="post" class="govuk-body">
+		<form method="post">
+			<h1 class="govuk-heading-l">Find a tuition partner</h1>
+			<p class="govuk-body">
+				You can use your National Tutoring Programme funding to get a tuition partner, who will arrange tutoring for your pupils in school or online.
+			</p>
+			<p class="govuk-body">
+				This service will help match you with a partner who meets your requirements from the full list of quality-assured tuition partners.
+			</p>
+
+			<govuk-details data-testid="qatp-details">
+				<govuk-details-summary>
+					What is a quality-assured tuition partner?
+				</govuk-details-summary>
+				<govuk-details-text>
+					The tuition partners shown on this service have been through a quality assurance process by the Department for Education.
+					This process is to ensure quality tuition is delivered and includes safeguarding checks.
+				</govuk-details-text>
+			</govuk-details>
+
 			<div class="app-option-card">
 				<h2 class="govuk-heading-m">What is your school’s postcode?</h2>
-				<govuk-input asp-for="Data.Postcode" input-class="govuk-input--width-10" autocomplete="postal-code"
-					data-testid="postcode">
+				<govuk-input asp-for="Data.Postcode" input-class="govuk-input--width-10" autocomplete="postal-code" data-testid="postcode">
 					<govuk-input-label>Enter your school’s postcode</govuk-input-label>
 				</govuk-input>
-				<div class="govuk-button-group govuk-!-margin-bottom-0">
-					<govuk-button type="submit" class="govuk-!-margin-bottom-0" data-testid="call-to-action">Continue
-					</govuk-button>
+				<govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>
+			</div>
+
+			<h2 class="govuk-heading-m" data-testid="other-tutoring-options">Other tutoring options</h2>
+			<p class="govuk-body">You can use your National Tutoring Programme funding to mix and match tutoring options.</p>
+			<div class="govuk-grid-column-one-half govuk-!-padding-0">
+				<div class="app-option-card app-option-card-left">
+					<h2 class="govuk-heading-m">Academic mentors</h2>
+					<p class="govuk-body">
+						Select your own candidate or apply to a central agency for an academic mentor. You’ll employ them full-time to focus on individual and small-group tuition.
+					</p>
+					<govuk-button-link asp-page="/AcademicMentors" data-testid="academic-mentors-link">Read more</govuk-button-link>
+				</div>
+			</div>
+			<div class="govuk-grid-column-one-half govuk-!-padding-0">
+				<div class="app-option-card app-option-card-right">
+					<h2 class="govuk-heading-m">School-led tutoring</h2>
+					<p class="govuk-body">
+						Select and employ teaching staff as tutors, including current members of staff, retired teachers, returning teachers or supply teachers.
+					</p>
+					<govuk-button-link asp-page="/SchoolLedTutoring" data-testid="school-led-tutoring-link">Read more</govuk-button-link>
 				</div>
 			</div>
 		</form>
-		<h2 class="govuk-heading-m" data-testid="other-tutoring-options">Other tutoring options</h2>
-		<p class="govuk-body">You can use your National Tutoring Programme funding to mix and match tutoring options.
-		</p>
-		<div class="govuk-grid-column-one-half govuk-!-padding-0">
-			<div class="app-option-card">
-				<h2 class="govuk-heading-m">Academic mentors</h2>
-				<p class="govuk-body">Select your own candidate or apply to a central agency for an academic mentor.
-					You’ll employ them full-time to focus on individual and small-group tuition. </p>
-				<a class="govuk-button govuk-!-margin-bottom-0" asp-page="/AcademicMentors"
-					data-testid="academic-mentors-link">Read more</a>
-			</div>
-		</div>
-		<div class="govuk-grid-column-one-half govuk-!-padding-0">
-			<div class="app-option-card">
-				<h2 class="govuk-heading-m">School-led tutoring</h2>
-				<p class="govuk-body">Select and employ teaching staff as tutors, including current members of staff,
-					retired teachers, returning teachers or supply teachers. </p>
-				<a class="govuk-button govuk-!-margin-bottom-0" asp-page="/SchoolLedTutoring"
-					data-testid="school-led-tutoring-link">Read more</a>
-			</div>
-		</div>
 	</div>
 	<div class="govuk-grid-column-one-third">
 		<h2 class="govuk-heading-m">Find out how much funding you’ll get</h2>

--- a/UI/Pages/Index.cshtml
+++ b/UI/Pages/Index.cshtml
@@ -58,6 +58,6 @@
 	</div>
 	<div class="govuk-grid-column-one-third">
 		<h2 class="govuk-heading-m">Find out how much funding you’ll get</h2>
-		<p class="govuk-body"><a href="#" class="govuk-link">Funding and reporting</a>.</p>
+		<p class="govuk-body"><a href="#" class="govuk-link">Funding and reporting</a></p>
 	</div>
 </div>

--- a/UI/Pages/Index.cshtml.cs
+++ b/UI/Pages/Index.cshtml.cs
@@ -24,6 +24,16 @@ public partial class Index : PageModel
 
     public record Command : SearchModel, IRequest<Domain.IResult> { }
 
+    public IActionResult OnGet()
+    {
+        // The model is being validated on get due to [BindProperty(SupportsGet = true)].
+        // This is not appropriate for this page either when first arriving on this page or using a back link.
+        // Therefore clear any model state validation errors
+        ModelState.Clear();
+
+        return Page();
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid) return Page();

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -1,5 +1,4 @@
 ﻿@page
-@using UI.Pages.Shared
 @model SearchResults
 @{
     ViewData["Title"] = "Search results";
@@ -11,6 +10,7 @@
 		<govuk-error-summary>
 			<govuk-error-summary-item asp-for="Data.Postcode" />
 			<govuk-error-summary-item asp-for="Data.Subjects" />
+			<govuk-error-summary-item asp-for="Data.TuitionType" />
 		</govuk-error-summary>
 		
 		<h1 class="govuk-heading-l">Search results</h1>
@@ -29,7 +29,6 @@
 		<div class="govuk-grid-column-one-third">
 			<div class="app-results-filter" data-module="results-filter">
 				<h2 class="govuk-heading-m">Filter results</h2>
-				
 
 				@foreach (var item in Model.Data.AllSubjects.Keys)
 				{
@@ -45,11 +44,11 @@
 						<govuk-radios-fieldset-legend class="govuk-fieldset__legend--s">
 							Type of tuition
 						</govuk-radios-fieldset-legend>
+						@foreach (var item in Model.Data.AllTuitionTypes)
+						{
+							<govuk-radios-item id="@item.ToString().ToSeoUrl()" value="@item" checked="@item == @Model.Data.TuitionType">@item.DisplayName()</govuk-radios-item>
+						}
 					</govuk-radios-fieldset>
-					@foreach (var item in Model.Data.AllTuitionTypes)
-					{
-						<govuk-radios-item id="@item.ToString().ToSeoUrl()" value="@item" checked="@item == @Model.Data.TuitionType">@item.DisplayName()</govuk-radios-item>
-					}
 				</govuk-radios>
 
 				<div class="govuk-button-group" data-module="results-filter-button">

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -5,9 +5,9 @@
 }
 <a asp-page="@nameof(Index)" class="govuk-link" data-testid="home-link">Home</a><br/>
 
-<govuk-back-link href="/search-results?@Model.AllSearchData.ToQueryString()">
+<a href="/search-results?@Model.AllSearchData.ToQueryString()" class="govuk-back-link">
 	Back to search results
-</govuk-back-link> 
+</a>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/UI/Pages/WhichKeyStages.cshtml
+++ b/UI/Pages/WhichKeyStages.cshtml
@@ -8,27 +8,23 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <govuk-error-summary>
-            <govuk-error-summary-item asp-for="Data.KeyStages" />
-        </govuk-error-summary>
+	    <form method="post">
+		    <h1 class="govuk-heading-l">Which key stages do you need tutoring support for?</h1>
+		    <p class="govuk-body">Select all of the key stages that apply</p>
 
-        <h1 class="govuk-heading-l">Which key stages do you need tutoring support for?</h1>
-        <p class="govuk-body">Select all of the key stages that apply</p>
+		    <govuk-checkboxes asp-for="Data.KeyStages">
+			    @foreach (var item in Model.Data.AllKeyStages)
+			    {
+				    <govuk-checkboxes-item id="@item.Name.ToString().ToSeoUrl()" value="@item.Name" checked="@item.Selected" data-testid="key-stage-name">@item.Name.DisplayName()</govuk-checkboxes-item>
+			    }
+		    </govuk-checkboxes>
 
-        <form method="post">
-            <govuk-checkboxes asp-for="Data.KeyStages">
-                @foreach (var item in Model.Data.AllKeyStages)
-                {
-                    <govuk-checkboxes-item id="@item.Name.ToString().ToSeoUrl()" value="@item.Name" checked="@item.Selected" data-testid="key-stage-name">@item.Name.DisplayName()</govuk-checkboxes-item>
-                }
-            </govuk-checkboxes>
+		    <div class="govuk-button-group">
+			    <govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>
+		    </div>
 
-            <div class="govuk-button-group">
-                <govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>
-            </div>
-
-            <input asp-for="Data.Postcode" hidden />
-            <input asp-for="Data.Subjects" hidden />
-        </form>
+		    <input asp-for="Data.Postcode" hidden />
+		    <input asp-for="Data.Subjects" hidden />
+	    </form>
     </div>
 </div>

--- a/UI/Pages/WhichKeyStages.cshtml
+++ b/UI/Pages/WhichKeyStages.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Which key stages do you need tutoring support for?";
 }
 
-<govuk-back-link href="/?@Model.Data.ToQueryString()" />
+<a href="/?@Model.Data.ToQueryString()" class="govuk-back-link">Back</a>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/UI/Pages/WhichSubjects.cshtml
+++ b/UI/Pages/WhichSubjects.cshtml
@@ -8,7 +8,11 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-	    <form method="post">
+	    <govuk-error-summary>
+		    <govuk-error-summary-item asp-for="Subjects" />
+	    </govuk-error-summary>
+
+	    <form method="post" gfa-prepend-error-summary="false">
 		    <h1 class="govuk-heading-l">Which subjects do you need tutoring support for?</h1>
 		    <p class="govuk-body">Select all of the subjects that apply</p>
 

--- a/UI/Pages/WhichSubjects.cshtml
+++ b/UI/Pages/WhichSubjects.cshtml
@@ -8,32 +8,28 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <govuk-error-summary>
-            <govuk-error-summary-item asp-for="Subjects" />
-        </govuk-error-summary>
+	    <form method="post">
+		    <h1 class="govuk-heading-l">Which subjects do you need tutoring support for?</h1>
+		    <p class="govuk-body">Select all of the subjects that apply</p>
 
-        <h1 class="govuk-heading-l">Which subjects do you need tutoring support for?</h1>
-        <p class="govuk-body">Select all of the subjects that apply</p>
+		    @foreach (var item in Model.Subjects.Keys)
+		    {
+			    <div data-testid="@(item)-subjects">
+				    <h2 class="govuk-heading-m">@item.DisplayName() subjects</h2>
 
-        <form method="post">
-            @foreach (var item in Model.Subjects.Keys)
-            {
-                <div data-testid="@(item)-subjects">
-                    <h2 class="govuk-heading-m">@item.DisplayName() subjects</h2>
+				    <govuk-checkboxes asp-for="Subjects">
+					    @foreach (var subject in Model.Subjects[item].OrderBy(x=> x.Name))
+					    {
+						    var value = $"{item}-{subject.Name}";
+						    <govuk-checkboxes-item id="@value.ToSeoUrl()" value="@value" checked="@subject.Selected" data-testid="subject-name">@subject.Name</govuk-checkboxes-item>
+					    }
+				    </govuk-checkboxes>
+			    </div>
+		    }
 
-                    <govuk-checkboxes asp-for="Subjects">
-                        @foreach (var subject in Model.Subjects[item].OrderBy(x=> x.Name))
-                        {
-	                        var value = $"{item}-{subject.Name}";
-                            <govuk-checkboxes-item id="@value.ToSeoUrl()" value="@value" checked="@subject.Selected" data-testid="subject-name">@subject.Name</govuk-checkboxes-item>
-                        }
-                    </govuk-checkboxes>
-                </div>
-            }
-
-            <div class="govuk-button-group">
-                <govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>
-            </div>
-        </form>
+		    <div class="govuk-button-group">
+			    <govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>
+		    </div>
+	    </form>
     </div>
 </div>

--- a/UI/Pages/WhichSubjects.cshtml
+++ b/UI/Pages/WhichSubjects.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Which subjects do you need tutoring support for?";
 }
 
-<govuk-back-link href="/which-key-stages?@Model.AllSearchParams.ToQueryString()" />
+<a href="/which-key-stages?@Model.AllSearchParams.ToQueryString()" class="govuk-back-link">Back</a>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/UI/Pages/_ViewImports.cshtml
+++ b/UI/Pages/_ViewImports.cshtml
@@ -1,4 +1,5 @@
 ﻿@using UI.Models
+@using UI.Pages.Shared
 @using Application.Extensions
 @namespace UI.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -42,9 +42,9 @@ builder.Services.AddCqrs();
 
 builder.Services.AddMediatR(typeof(AssemblyReference));
 
-builder.Services.AddGovUkFrontend(new GovUkFrontendAspNetCoreOptions()
+builder.Services.AddGovUkFrontend(options =>
 {
-    AddImportsToHtml = false
+    options.AddImportsToHtml = false;
 });
 
 builder.Services.AddControllers(options =>

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.1.2" />
-		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="0.5.1" />
+		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.0.0-beta1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.7">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -11,12 +11,12 @@
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.1.2" />
 		<PackageReference Include="GovUk.Frontend.AspNetCore" Version="0.5.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.6">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.7">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.16.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/UI/src/sass/options-card.scss
+++ b/UI/src/sass/options-card.scss
@@ -1,5 +1,24 @@
 .app-option-card {
-	margin: govuk-spacing(1);
-	padding: govuk-spacing(3);
-    background-color: govuk-colour("light-grey");
+	margin-bottom: govuk-spacing(3);
+	padding: govuk-spacing(4);
+	background-color: govuk-colour("light-grey");
+
+	.govuk-button {
+		margin-bottom: govuk-spacing(1);
+	}
+}
+
+@include govuk-media-query($from: tablet) {
+	.app-option-card-left {
+		margin-right: govuk-spacing(2);
+	}
+
+	.app-option-card-middle {
+		margin-left: govuk-spacing(2);
+		margin-right: govuk-spacing(2);
+	}
+
+	.app-option-card-right {
+		margin-left: govuk-spacing(2);
+	}
 }


### PR DESCRIPTION
## Context

The service's UI is heavily reliant on the GovUk.Frontend.AspNetCore NuGet package which recently released a [v1.0.0-beta1 version](https://github.com/gunndabad/govuk-frontend-aspnetcore/releases/tag/v1.0.0-beta1). As we want to keep our referenced packages up to date, it is important that we move to this version as soon as possible.

## Changes proposed in this pull request

The intention is that there are no visible UI changes as a result of this update.

This change attempts to take advantage of a number of new features in the updated package:

- Pages with validation errors should prepend ["Error: " to the title](https://design-system.service.gov.uk/patterns/validation/). This now happens automatically with the updated library.
- Automatic error summary where supported. It could not be used on the subjects page as it caused a repetition of the error when more than one key stage was selected
- using new govuk-button-link

I also took the opportunity to improve the homepage options cards to get the spacing closer to the design and improve the mobile view.

## Guidance to review

I could not find a better way than the `Index.OnGet` method to resolve the previously invisible validation error on get.

## Link to Jira ticket

[NTP-439](https://dfedigital.atlassian.net/browse/NTP-439)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80% - N/A
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/) - N/A
- [X] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code