### PR TITLE
NTP-314: Content update for search results page

### DIFF
--- a/Tests/SearchForSubjects.cs
+++ b/Tests/SearchForSubjects.cs
@@ -135,4 +135,14 @@ public class SearchForSubjects : CleanSliceFixture
                 "KeyStage1-English", "KeyStage3-Humanities",
             });
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("This is not a key stage subject")]
+    public void Parses_invalid_KeyStageSubject_without_error(string keyStageSubject)
+    {
+        var parsed = new[] { keyStageSubject }.ParseKeyStageSubjects();
+        parsed.Should().BeEmpty();
+    }
 }

--- a/UI/Pages/SearchModel.cs
+++ b/UI/Pages/SearchModel.cs
@@ -26,7 +26,9 @@ public record SearchModel
 public static class ModelExtensions
 {
     public static KeyStageSubject[] ParseKeyStageSubjects(this string[] keyStageSubjects)
-        => keyStageSubjects.Select(KeyStageSubject.Parse).ToArray();
+        => keyStageSubjects.Select(KeyStageSubject.TryParse)
+        .OfType<KeyStageSubject>()
+        .ToArray();
 }
 
 public record KeyStageSubject(KeyStage KeyStage, string Subject)
@@ -44,6 +46,9 @@ public record KeyStageSubject(KeyStage KeyStage, string Subject)
         return new KeyStageSubject(ks, re.Groups[2].Value);
     }
 
+    public static KeyStageSubject? TryParse(string value) =>
+        TryParse(value, out var parsed) ? parsed : null;
+
     public static bool TryParse(string value, [MaybeNullWhen(false)] out KeyStageSubject parsed)
     {
         if (value == null)
@@ -55,13 +60,13 @@ public record KeyStageSubject(KeyStage KeyStage, string Subject)
         var re = new Regex(@"(KeyStage[\d])-(.*)").Match(value);
 
         if (!re.Success)
-        {
+        {  // Subject must be of the form KS1-English
             parsed = default;
             return false;
         }
 
         if (!Enum.TryParse<KeyStage>(re.Groups[1].Value, out var ks))
-        {
+        { // Value is not a valid key stage
             parsed = default;
             return false;
         }

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -17,13 +17,6 @@
 		
 		<h1 class="govuk-heading-l">Search results</h1>
 
-		<p show-if="Model.Data.Results != null" class="govuk-body govuk-heading-m">
-			@{
-				var count = Model.Data.Results!.Count == 0 ? "No" : Model.Data.Results.Count.ToString();
-				var resultPlural = Model.Data.Results.Count != 1 ? "results" : "result";
-			}
-			<strong>@count</strong> @(resultPlural) for @Model.Data.LocalAuthority
-		</p>
 	</div>
 </div>
 
@@ -64,6 +57,7 @@
 		</div>
 
 		<div class="govuk-grid-column-two-thirds">
+
 			<div class="govuk-form-group">
 				<div asp-validation-group-for="Data.Postcode" data-testid="postcode">
 					<label asp-for="Data.Postcode" class="govuk-label govuk-label--s">
@@ -74,6 +68,18 @@
 					<govuk-button type="submit" class="govuk-!-display-inline govuk-!-margin-0" data-testid="call-to-action">Search</govuk-button>
 				</div>
 			</div>
+
+			<div show-if="Model.Data.Results != null" class="govuk-body">
+				<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+				@{
+					var count = Model.Data.Results!.Count == 0 ? "No" : Model.Data.Results.Count.ToString();
+					var resultPlural = Model.Data.Results.Count != 1 ? "results" : "result";
+				}
+				<strong>@count</strong> @(resultPlural) for <strong>@Model.Data.LocalAuthority</strong>
+				sorted by A-Z
+				<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+			</div>
+
 
 			@if (Model.Data.Results != null)
 			{

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -15,10 +15,13 @@
 		
 		<h1 class="govuk-heading-l">Search results</h1>
 
-		@if (Model.Data.Results != null)
-		{
-			<p class="govuk-body govuk-!-font-size-27"><strong>@(Model.Data.Results.Count == 0 ? "No" : Model.Data.Results.Count)</strong> @(Model.Data.Results.Count != 1 ? "results" : "result") for @Model.Data.LocalAuthority</p>
-		}
+		<p show-if="Model.Data.Results != null" class="govuk-body govuk-heading-m">
+			@{
+				var count = Model.Data.Results!.Count == 0 ? "No" : Model.Data.Results.Count.ToString();
+				var resultPlural = Model.Data.Results.Count != 1 ? "results" : "result";
+			}
+			<strong>@count</strong> @(resultPlural) for @Model.Data.LocalAuthority
+		</p>
 	</div>
 </div>
 
@@ -62,11 +65,11 @@
 			<div class="govuk-form-group">
 				<div asp-validation-group-for="Data.Postcode" data-testid="postcode">
 					<label asp-for="Data.Postcode" class="govuk-label govuk-label--s">
-						Postcode
+						Enter your school's postcode
 					</label>
 					<span asp-validation-for="Data.Postcode" class="govuk-error-message"></span>
 					<input asp-for="Data.Postcode" class="govuk-input govuk-input--width-10" type="text">
-					<govuk-button type="submit" class="govuk-!-display-inline govuk-!-margin-0" data-testid="call-to-action">Search again</govuk-button>
+					<govuk-button type="submit" class="govuk-!-display-inline govuk-!-margin-0" data-testid="call-to-action">Search</govuk-button>
 				</div>
 			</div>
 

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = "Search results";
 }
 
-<govuk-back-link href="/which-subjects?@Model.Data.ToQueryString()" />
+<a href="/which-subjects?@Model.Data.ToQueryString()" class="govuk-back-link">Back</a>
 
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-full">

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -5,6 +5,8 @@
     ViewData["Title"] = "Search results";
 }
 
+<govuk-back-link href="/which-subjects?@Model.Data.ToQueryString()" />
+
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-full">
 		

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -69,14 +69,13 @@
 				</div>
 			</div>
 
-			<div show-if="Model.Data.Results != null" class="govuk-body">
+			<div show-if="Model.Data.Results != null" class="govuk-body" data-testid="results-summary">
 				<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 				@{
 					var count = Model.Data.Results!.Count == 0 ? "No" : Model.Data.Results.Count.ToString();
 					var resultPlural = Model.Data.Results.Count != 1 ? "results" : "result";
 				}
-				<strong>@count</strong> @(resultPlural) for <strong>@Model.Data.LocalAuthority</strong>
-				sorted by A-Z
+				<strong>@count</strong> @(resultPlural) for <strong>@Model.Data.LocalAuthority</strong> sorted by A-Z
 				<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 			</div>
 

--- a/UI/cypress/e2e/results.feature
+++ b/UI/cypress/e2e/results.feature
@@ -12,6 +12,21 @@ Feature: User is shown search results
     When they click the 'Find a tuition partner' service name link
     Then they will be taken to the 'Find a tuition partner' journey start page
 
+  Scenario: Back click returns to subjects page
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English' for postcode 'SK1 1EB'
+    When they click 'Back'
+    Then they will be taken to the 'Which subjects' page
+    And they are shown the subjects for 'Key stage 1'
+    And they will see 'Key stage 1 English' selected
+
+  Scenario: Back to the start
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English' for postcode 'SK1 1EB'
+    When they click 'Back'
+    And they click 'Back'
+    And they click 'Back'
+    Then they will be taken to the 'Find a tuition partner' journey start page
+    And they will see 'SK1 1EB' entered for the postcode
+
   Scenario: user does not enter postcode
     Given a user has arrived on the 'Search results' page for 'Key stage 1 English' without a postcode
     When they click 'Continue'

--- a/UI/cypress/e2e/results.feature
+++ b/UI/cypress/e2e/results.feature
@@ -81,10 +81,15 @@ Feature: User is shown search results
     And they click on the option heading for 'Key stage 2'
     And they will see an expanded subject filter for 'Key stage 2'
 
-Scenario: Subjects are displayed in alphabetical order in  page the filter of 'search results' page
-    Given a user has arrived on the 'Search results' page
-    Then the subjects in the filter displayed in alphabetical order 
+  Scenario: Subjects are displayed in alphabetical order in  page the filter of 'search results' page
+      Given a user has arrived on the 'Search results' page
+      Then the subjects in the filter displayed in alphabetical order 
 
-Scenario: subjects covered by a tuition partner are in alphabetical order in the 'search results' page
-    Given a user has arrived on the 'Search results' page
-    Then the subjects covered by a tuition partner are in alphabetical order 
+  Scenario: subjects covered by a tuition partner are in alphabetical order in the 'search results' page
+      Given a user has arrived on the 'Search results' page
+      Then the subjects covered by a tuition partner are in alphabetical order 
+
+  Scenario: Results summary is shown 
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English' for postcode 'SK1 1EB'
+    Then they will see the results summary for 'Stockport'
+  

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -88,3 +88,9 @@ Then("the subjects covered by a tuition partner are in alphabetical order", () =
     });
 });
 
+Then("they will see the results summary for {string}", location => {
+    var expected = new RegExp(`\\d+ results for ${location} sorted by A-Z`)
+    cy.get('[data-testid="results-summary"]')
+        .invoke("text").invoke("trim")
+        .should('match', expected)
+});

--- a/UI/cypress/e2e/subjects.js
+++ b/UI/cypress/e2e/subjects.js
@@ -1,13 +1,7 @@
 import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
 import { kebabCase, camelCaseKeyStage } from "../support/utils";
+import { allSubjects } from "../support/step_definitions/subjects-page";
         
-const allSubjects = {
-    "Key stage 1": [ "English", "Maths", "Science"],
-    "Key stage 2": [ "English", "Maths", "Science"],
-    "Key stage 3": [ "English", "Humanities", "Maths", "Modern foreign languages", "Science"],
-    "Key stage 4": [ "English", "Humanities", "Maths", "Modern foreign languages", "Science"]
-}
-
 Given("a user has arrived on the 'Which key stages' page", () => {
     Step(this, "a user has arrived on the 'Which key stages' page for postcode 'AB12CD'");
 });
@@ -47,44 +41,12 @@ Then("they will see all the keys stages as options", () => {
     })
 });
 
-Then("they are shown the subjects for {string}", keystage => {
-    
-    const stages = keystage.split(',').map(s => s.trim());
-    stages.forEach(element => {
-
-        const subjects = allSubjects[element]
-
-        cy.get('h2')
-        .contains(`${element} subjects`)
-        .parent()
-        .within(() =>
-        {
-            cy.get('[data-testid="subject-name"]').each((item, index) => {
-                cy.wrap(item).should('contain.text', subjects[index])
-            });
-        });
-
-    });
-});
-
 Then("they are shown all the subjects under all the keys stages", () => {
     Step(this, "they are shown the subjects for 'Key stage 1'")
     Step(this, "they are shown the subjects for 'Key stage 2'")
     Step(this, "they are shown the subjects for 'Key stage 3'")
     Step(this, "they are shown the subjects for 'Key stage 4'")
 })
-
-Then("they will see {string} entered for the postcode", postcode => {
-    cy.get('[data-testid="postcode"]>input').should('contain.value', postcode);
-});
-
-Then("they will see {string} selected", keystages => {
-    const stages = keystages.split(',').map(s => s.trim());
-    stages.forEach(element => {
-        cy.get(`input[id="${kebabCase(element)}"]`).should('be.checked');
-    });
-});
-
 
 Then("the subjects are displayed in alphabetical order", () => {
     Step(this, "they are shown the subjects for 'Key stage 1'")

--- a/UI/cypress/support/step_definitions/pages.js
+++ b/UI/cypress/support/step_definitions/pages.js
@@ -24,6 +24,10 @@ Then("they will be taken to the 'Which key stages' page", () => {
     cy.location('pathname').should('eq', '/which-key-stages');
 });
 
+Then("they will be taken to the 'Which subjects' page", () => {
+    cy.location('pathname').should('eq', '/which-subjects');
+});
+
 Then("the page URL ends with {string}", url => {
     cy.location('pathname').should('match', new RegExp(`${url}$`));
 });

--- a/UI/cypress/support/step_definitions/postcode.js
+++ b/UI/cypress/support/step_definitions/postcode.js
@@ -11,3 +11,7 @@ When("they click on the postcode error", () => {
 Then("the school's postcode text input is focused", () => {
   cy.focused().should("have.attr", "name", "Data.Postcode");
 });
+
+Then("they will see {string} entered for the postcode", postcode => {
+  cy.get('[data-testid="postcode"]>input').should('contain.value', postcode);
+});

--- a/UI/cypress/support/step_definitions/subjects-page.js
+++ b/UI/cypress/support/step_definitions/subjects-page.js
@@ -1,0 +1,36 @@
+import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
+import { kebabCase, camelCaseKeyStage } from "../utils";
+
+export const allSubjects = {
+    "Key stage 1": [ "English", "Maths", "Science"],
+    "Key stage 2": [ "English", "Maths", "Science"],
+    "Key stage 3": [ "English", "Humanities", "Maths", "Modern foreign languages", "Science"],
+    "Key stage 4": [ "English", "Humanities", "Maths", "Modern foreign languages", "Science"]
+}
+
+Then("they are shown the subjects for {string}", keystage => {
+    
+    const stages = keystage.split(',').map(s => s.trim());
+    stages.forEach(element => {
+
+        const subjects = allSubjects[element]
+
+        cy.get('h2')
+        .contains(`${element} subjects`)
+        .parent()
+        .within(() =>
+        {
+            cy.get('[data-testid="subject-name"]').each((item, index) => {
+                cy.wrap(item).should('contain.text', subjects[index])
+            });
+        });
+
+    });
+});
+
+Then("they will see {string} selected", keystages => {
+    const stages = keystages.split(',').map(s => s.trim());
+    stages.forEach(element => {
+        cy.get(`input[id="${kebabCase(element)}"]`).should('be.checked');
+    });
+});


### PR DESCRIPTION
## Changes proposed in this pull request

* Add a back link to the search results page
* Move the "<n> results for <location>" to just above the results list
* Add "Sorted by A-Z"

Desktop view:
![image](https://user-images.githubusercontent.com/201727/181415845-3ba9eb45-8bae-477f-a8d0-b82e16733f3d.png)

Tablet view:
![image](https://user-images.githubusercontent.com/201727/181415972-1df96e1e-8c22-4397-ac3c-89e8319d927f.png)

Mobile view:
![image](https://user-images.githubusercontent.com/201727/181415901-e3ad363a-5053-4f79-9e51-08495d616447.png)

With postcode error:
![image](https://user-images.githubusercontent.com/201727/181416837-dd8e373a-ac3a-41ec-8008-babdfa11e690.png)

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-314

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code