### PR TITLE
NTP-385: Add support link to footer

### DIFF
--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -11,6 +11,8 @@
 	var googleAnalyticsConsent = Convert.ToBoolean(httpcontext?.HttpContext?.Request.Cookies[".FindATuitionPartner.Consent"]);
 
 	enableGoogleAnalytics = enableGoogleAnalytics && googleAnalyticsConsent;
+
+	var supportEmailAddress = "tutoring.support@service.education.gov.uk";
 }
 
 <!DOCTYPE html>
@@ -115,6 +117,10 @@
         <div class="govuk-footer__meta">
 	        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
 		        <h2 class="govuk-visually-hidden">Support links</h2>
+
+				<p class="govuk-footer__list-item" data-testid="support-link">
+					Report a problem: <a href="mailto:@supportEmailAddress" class="govuk-footer__link">@supportEmailAddress</a>
+				</p>
 
 		        <ul class="govuk-footer__inline-list">
 			        <li class="govuk-footer__inline-list-item">

--- a/UI/cypress/e2e/footer-support-link.feature
+++ b/UI/cypress/e2e/footer-support-link.feature
@@ -1,0 +1,5 @@
+Feature: Support is provided to users
+  Scenario: The support link is shown to users
+    Given a user has started the 'Find a tuition partner' journey
+    Then they see the support link at the bottom of the page
+    And the support link will open a new email to 'tutoring.support@service.education.gov.uk'

--- a/UI/cypress/e2e/footer-support-link.js
+++ b/UI/cypress/e2e/footer-support-link.js
@@ -1,0 +1,13 @@
+import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
+
+Then("they see the support link at the bottom of the page", () => {
+    cy.get('[data-testid="support-link"]').should("exist");
+});
+
+Then("the support link will open a new email to {string}", emailAddress => {
+    cy.get('[data-testid="support-link"]').within(() => {
+        cy.get('a')
+            .should("contain.text", emailAddress)
+            .and("have.attr", 'href', `mailto:${emailAddress}`)
+    });
+});


### PR DESCRIPTION
## Changes proposed in this pull request

* Add a link to the support email address in the footer
 
![image](https://user-images.githubusercontent.com/201727/181582797-5d09d279-ece9-454e-a951-c391d9c3df8e.png)

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-385

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code