### PR TITLE
NTP-460: display LEA name rather than LAD name on results page

### DIFF
--- a/Application/Handlers/SearchTuitionPartnerHandler.cs
+++ b/Application/Handlers/SearchTuitionPartnerHandler.cs
@@ -40,7 +40,7 @@ public class SearchTuitionPartnerHandler
             if (request.LocalAuthorityDistrictCode != null)
             {
                 lad = await _dbContext.LocalAuthorityDistricts
-                    .Include(e => e.Region)
+                    .Include(e => e.LocalAuthority)
                     .SingleOrDefaultAsync(e => e.Code == request.LocalAuthorityDistrictCode, cancellationToken);
 
                 if (lad != null)

--- a/Tests/SearchForResults.cs
+++ b/Tests/SearchForResults.cs
@@ -133,7 +133,7 @@ public class SearchForResults : CleanSliceFixture
         // Given
         await Fixture.ExecuteDbContextAsync(async db =>
         {
-            var lad = await db.LocalAuthorityDistricts.FirstAsync(x => x.Code == "E06000011");
+            var lad = await db.LocalAuthorityDistricts.FirstAsync(x => x.Code == "E07000096");
             var tuitionType = await db.TuitionTypes.FirstAsync();
 
             db.TuitionPartners.Add(new Domain.TuitionPartner
@@ -182,7 +182,7 @@ public class SearchForResults : CleanSliceFixture
         // Given
         await Fixture.ExecuteDbContextAsync(async db =>
         {
-            var lad = await db.LocalAuthorityDistricts.FirstAsync(x => x.Code == "E06000011");
+            var lad = await db.LocalAuthorityDistricts.FirstAsync(x => x.Code == "E07000096");
             var tuitionType = await db.TuitionTypes.FirstAsync();
 
             var tp = db.TuitionPartners.Add(new Domain.TuitionPartner
@@ -218,7 +218,7 @@ public class SearchForResults : CleanSliceFixture
         var result = await Fixture.SendAsync(Basic.SearchResultsQuery);
 
         // Then
-        result.LocalAuthority.Should().Be("East Riding of Yorkshire");
+        result.LocalAuthority.Should().Be("Hertfordshire");
     }
 
     [Fact]

--- a/Tests/Utilities/SliceFixture.cs
+++ b/Tests/Utilities/SliceFixture.cs
@@ -41,7 +41,7 @@ public class SliceFixture : IAsyncLifetime
                 .Returns(new LocationFilterParameters
                 {
                     Country = "England",
-                    LocalAuthorityDistrictCode = "E06000011",
+                    LocalAuthorityDistrictCode = "E07000096",
                 });
         }
 

--- a/UI/Pages/Cookies.cshtml.cs
+++ b/UI/Pages/Cookies.cshtml.cs
@@ -6,16 +6,16 @@ namespace UI.Pages
 {
     public class Cookies : PageModel
     {
-		private const string ConsentCookieName = ".FindATuitionPartner.Consent";
-		public IActionResult OnGet(bool? consent, string returnUrl)
-		{
-			if (consent.HasValue)
-			{
-				var cookieOptions = new CookieOptions { Expires = DateTime.Today.AddMonths(12), Secure = true };
-				Response.Cookies.Append(ConsentCookieName, consent.Value.ToString(), cookieOptions);
-				return new RedirectResult(returnUrl);
-			}
-			return Page();
-		}
-	}
+        private const string ConsentCookieName = ".FindATuitionPartner.Consent";
+        public IActionResult OnGet(bool? consent, string returnUrl)
+        {
+            if (consent.HasValue)
+            {
+                var cookieOptions = new CookieOptions { Expires = DateTime.Today.AddMonths(12), Secure = true };
+                Response.Cookies.Append(ConsentCookieName, consent.Value.ToString(), cookieOptions);
+                return new RedirectResult(returnUrl);
+            }
+            return Page();
+        }
+    }
 }

--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -98,7 +98,7 @@ public class SearchResults : PageModel
             {
                 SuccessResult => queryResponse with
                 {
-                    LocalAuthority = searchResults.Data.LocalAuthorityDistrict?.Name,
+                    LocalAuthority = searchResults.Data.LocalAuthorityDistrict?.LocalAuthority.Name,
                     Results = searchResults.Data,
                     LocalAuthorityDistrictCode = searchResults.Data.Request.LocalAuthorityDistrictCode,
                 },

--- a/UI/cypress/e2e/results.feature
+++ b/UI/cypress/e2e/results.feature
@@ -92,4 +92,8 @@ Feature: User is shown search results
   Scenario: Results summary is shown 
     Given a user has arrived on the 'Search results' page for 'Key stage 1 English' for postcode 'SK1 1EB'
     Then they will see the results summary for 'Stockport'
+
+  Scenario: Local Education Authority name is displayed for postcode
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 Maths' for postcode 'HP4 3LG'
+    Then they will see the results summary for 'Hertfordshire'
   


### PR DESCRIPTION
## Context

While we use Local Authority Districts to define the tuition partner coverage, we want to display the more familiar Local Education Authority name to the users.

## Changes proposed in this pull request

Previously a search for a postcode in the Dacorum LAD would display Dacorum:

![image](https://user-images.githubusercontent.com/9396346/181597560-5601c133-ea6c-48c7-8c49-bbefc7c8ebee.png)

It should have displayed the Hertfordshire LEA Dacorum is part of:

![image](https://user-images.githubusercontent.com/9396346/181597912-7efefed5-ffdf-451e-9173-74365e51f411.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

[NTP-460](https://dfedigital.atlassian.net/browse/NTP-460)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [X] Test coverage of new code is at least 80%
- [X] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [X] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code