### PR TITLE
NTP-375: Search results page with no search criteria

### DIFF
--- a/Tests/OptionsSelectModelTests.cs
+++ b/Tests/OptionsSelectModelTests.cs
@@ -1,0 +1,106 @@
+﻿using UI.Pages.Shared;
+
+namespace Tests;
+
+public class OptionsSelectModelTests
+{
+    [Fact]
+    public void Selection_is_collapsed_when_there_are_no_items()
+    {
+        var sut = new OptionsSelectModel(
+            "select-model", "Select Model",
+             Array.Empty<(string Name, string Value, string DisplayName, bool Selected)>());
+        sut.ClosedData.Should().Be("data-closed-on-load=true");
+    }
+
+    [Fact]
+    public void Selection_is_collapsed_when_no_items_are_selected()
+    {
+        var sut = new OptionsSelectModel("select-model", "Select Model", new[]
+        {
+            ("item", "item", "Item", Selected : false),
+       });
+
+        sut.ClosedData.Should().Be("data-closed-on-load=true");
+    }
+
+    [Fact]
+    public void Selection_is_expanded_when_items_are_selected()
+    {
+        var sut = new OptionsSelectModel("select-model", "Select Model", new[]
+        {
+            ("item", "item", "Item", Selected : false),
+            ("item", "item", "Item", Selected : true),
+       });
+
+        sut.ClosedData.Should().Be("");
+    }
+
+    [Fact]
+    public void Selection_is_collapsed_when_there_are_no_items_and_override_is_to_collapse()
+    {
+        var sut = new OptionsSelectModel(
+            "select-model", "Select Model",
+            Array.Empty<(string Name, string Value, string DisplayName, bool Selected)>(),
+            ClosedOnLoad: true);
+        sut.ClosedData.Should().Be("data-closed-on-load=true");
+    }
+
+    [Fact]
+    public void Selection_is_collapsed_when_no_items_are_selected_and_override_is_to_collapse()
+    {
+        var sut = new OptionsSelectModel(
+            "select-model", "Select Model", new[] { ("item", "item", "Item", Selected: false), },
+            ClosedOnLoad: true);
+
+        sut.ClosedData.Should().Be("data-closed-on-load=true");
+    }
+
+    [Fact]
+    public void Selection_is_collapsed_when_items_are_selected_and_override_is_to_collapse()
+    {
+        var sut = new OptionsSelectModel(
+            "select-model", "Select Model", new[]
+            {
+                ("item", "item", "Item", Selected : false),
+                ("item", "item", "Item", Selected : true),
+            },
+            ClosedOnLoad: true);
+
+        sut.ClosedData.Should().Be("data-closed-on-load=true");
+    }
+
+    [Fact]
+    public void Selection_is_expanded_when_there_are_no_items_and_override_is_to_expand()
+    {
+        var sut = new OptionsSelectModel(
+            "select-model", "Select Model",
+            Array.Empty<(string Name, string Value, string DisplayName, bool Selected)>(),
+            ClosedOnLoad: false);
+        sut.ClosedData.Should().Be("");
+    }
+
+    [Fact]
+    public void Selection_is_expanded_when_no_items_are_selected_and_override_is_to_expand()
+    {
+        var sut = new OptionsSelectModel(
+            "select-model", "Select Model", new[] { ("item", "item", "Item", Selected: false), },
+            ClosedOnLoad: false);
+
+        sut.ClosedData.Should().Be("");
+    }
+
+    [Fact]
+    public void Selection_is_expanded_when_items_are_selected_and_override_is_to_expand()
+    {
+        var sut = new OptionsSelectModel(
+            "select-model", "Select Model", new[]
+            {
+                ("item", "item", "Item", Selected: false),
+                ("item", "item", "Item", Selected: true),
+            },
+            ClosedOnLoad: false);
+
+        sut.ClosedData.Should().Be("");
+    }
+}

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -30,10 +30,13 @@
 
 				@foreach (var item in Model.Data.AllSubjects.Keys)
 				{
+					var forceOpenAllSubjectFilters = Model.Data.ForceOpenAllSubjectFilters;
+
 					<partial name="_OptionsSelect" model="@(new OptionsSelectModel(
 						item.ToString().ToSeoUrl(),
 						item.DisplayName(),
-						Model.Data.AllSubjects[item].Select(x => ($"{item}-{x.Name}".ToSeoUrl(), $"{item}-{x.Name}", x.Name, x.Selected)).OrderBy(x=> x.Name)
+						Model.Data.AllSubjects[item].Select(x => ($"{item}-{x.Name}".ToSeoUrl(), $"{item}-{x.Name}", x.Name, x.Selected)).OrderBy(x=> x.Name),
+						ClosedOnLoad: forceOpenAllSubjectFilters
 						)) "/>
 				}
 				

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -74,7 +74,7 @@
 					var count = Model.Data.Results!.Count == 0 ? "No" : Model.Data.Results.Count.ToString();
 					var resultPlural = Model.Data.Results.Count != 1 ? "results" : "result";
 				}
-				<strong>@count</strong> @(resultPlural) for <strong>@Model.Data.LocalAuthority</strong> sorted by A-Z
+				<strong>@count</strong> @(resultPlural) <span show-if="@Model.Data.LocalAuthority != null">for <strong>@Model.Data.LocalAuthority</strong></span> sorted by A-Z
 				<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 			</div>
 
@@ -83,7 +83,7 @@
 			{
 				foreach (var item in Model.Data.Results.Results)
 				{
-					<div>
+					<div data-testid="results-list-item">
 						<h2 class="govuk-heading-m"><a asp-page="TuitionPartner" asp-route-id="@item.SeoUrl" class="govuk-link">@item.Name</a></h2>
 						<govuk-summary-list>
 							<govuk-summary-list-row class="govuk-body-s">

--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -55,12 +55,9 @@ public class SearchResults : PageModel
         public Validator()
         {
             RuleFor(m => m.Postcode)
-                .NotEmpty()
-                .WithMessage("Enter a postcode");
-
-            RuleFor(m => m.Postcode)
                 .Matches(@"[a-zA-Z]{1,2}([0-9]{1,2}|[0-9][a-zA-Z])\s*[0-9][a-zA-Z]{2}")
-                .WithMessage("Enter a valid postcode");
+                .WithMessage("Enter a valid postcode")
+                .When(m => !string.IsNullOrEmpty(m.Postcode));
 
             RuleFor(m => m.Subjects)
                 .NotEmpty()
@@ -166,6 +163,9 @@ public class SearchResults : PageModel
         private async Task<IResult<LocationFilterParameters>> GetSearchLocation(Query request, CancellationToken cancellationToken)
         {
             var validationResults = await new Validator().ValidateAsync(request, cancellationToken);
+
+            if (string.IsNullOrEmpty(request.Postcode))
+                return Result.Success(new LocationFilterParameters { });
 
             if (!validationResults.IsValid)
             {

--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -48,6 +48,11 @@ public class SearchResults : PageModel
         public TuitionPartnerSearchResultsPage? Results { get; set; }
         public FluentValidationResult Validation { get; internal set; } = new();
         public string? LocalAuthorityDistrictCode { get; set; }
+
+        public bool IsAnySubjectSelected
+            => AllSubjects.SelectMany(x => x.Value).Any(x => x.Selected);
+
+        public bool? ForceOpenAllSubjectFilters => IsAnySubjectSelected ? null : false;
     }
 
     private class Validator : AbstractValidator<Query>
@@ -58,10 +63,6 @@ public class SearchResults : PageModel
                 .Matches(@"[a-zA-Z]{1,2}([0-9]{1,2}|[0-9][a-zA-Z])\s*[0-9][a-zA-Z]{2}")
                 .WithMessage("Enter a valid postcode")
                 .When(m => !string.IsNullOrEmpty(m.Postcode));
-
-            RuleFor(m => m.Subjects)
-                .NotEmpty()
-                .WithMessage("Select the subject or subjects");
 
             RuleForEach(m => m.Subjects)
                 .Must(x => KeyStageSubject.TryParse(x, out var _));

--- a/UI/Pages/Shared/_OptionsSelect.cshtml.cs
+++ b/UI/Pages/Shared/_OptionsSelect.cshtml.cs
@@ -1,6 +1,10 @@
 ﻿namespace UI.Pages.Shared;
 
-public record OptionsSelectModel(string Name, string DisplayName, IEnumerable<(string Name, string Value, string DisplayName, bool Selected)> Items)
+public record OptionsSelectModel(
+    string Name,
+    string DisplayName,
+    IEnumerable<(string Name, string Value, string DisplayName, bool Selected)> Items,
+    bool? ClosedOnLoad = null)
 {
-    public string ClosedData => Items.Any(x => x.Selected) ? "" : @"data-closed-on-load=true";
+    public string ClosedData => !ClosedOnLoad ?? Items.Any(x => x.Selected) ? "" : @"data-closed-on-load=true";
 }

--- a/UI/cypress/e2e/results.feature
+++ b/UI/cypress/e2e/results.feature
@@ -29,8 +29,8 @@ Feature: User is shown search results
 
   Scenario: user does not enter postcode
     Given a user has arrived on the 'Search results' page for 'Key stage 1 English' without a postcode
-    When they click 'Continue'
-    Then they will see 'Enter a postcode' as an error message for the 'postcode'
+    Then display all correct tuition partners that provide the selected subjects in any location
+    And they will not see an error message
 
   Scenario: user enters an invalid postcode
     Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
@@ -57,7 +57,7 @@ Feature: User is shown search results
     Then they will see 'This service covers England only' as an error message for the 'postcode'
 
   Scenario: user clicks postcode error
-    Given a user has arrived on the 'Search results' page for 'Key stage 1 English' without a postcode
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English' for postcode 'invalid'
     When they click on the postcode error
     Then the school's postcode text input is focused
 

--- a/UI/cypress/e2e/results.feature
+++ b/UI/cypress/e2e/results.feature
@@ -61,6 +61,22 @@ Feature: User is shown search results
     When they click on the postcode error
     Then the school's postcode text input is focused
 
+  Scenario: lands on search results page without filter boxes selected
+    Given a user has arrived on the 'Search results' page without subjects
+    Then display all correct tuition partners that provide the selected subjects in any location
+
+  Scenario: lands on search results with blank URL
+    Given a user has arrived on the 'Search results' page without subjects or postcode
+    Then display all correct tuition partners in any location
+    And they will see all the subjects for 'Key stage 1, Key stage 2, Key stage 3, Key stage 4'
+
+  Scenario: unselects all boxes on the filters 
+    Given a user has arrived on the 'Search results' page
+    When they enter '' as the school's postcode
+    And they clear all the filters
+    Then display all correct tuition partners in any location
+    And they will see all the subjects for 'Key stage 1, Key stage 2, Key stage 3, Key stage 4'
+
   Scenario: results default to any tuition type
     Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     Then they will see the tuition type 'Any' is selected

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -95,6 +95,14 @@ Then("they will see the results summary for {string}", location => {
         .should('match', expected)
 });
 
+Then("show all correct tuition partners that provide tuition in the postcode's location", () => {
+    cy.get('[data-testid="results-list-item"]').should("exist")
+});
+
 Then("display all correct tuition partners that provide the selected subjects in any location", () => {
+    cy.get('[data-testid="results-list-item"]').should("exist")
+});
+
+Then("display all correct tuition partners in any location", () => {
     cy.get('[data-testid="results-list-item"]').should("exist")
 });

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -15,6 +15,10 @@ When("they click on the option heading for {string}", keystage => {
     });
 })
 
+When("they clear all the filters", () => {
+    cy.get('[type="checkbox"]').uncheck()
+})
+
 Then("they will see all the subjects for {string}", keystage => {
     const stages = keystage.split(',').map(s => s.trim());
     

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -94,3 +94,7 @@ Then("they will see the results summary for {string}", location => {
         .invoke("text").invoke("trim")
         .should('match', expected)
 });
+
+Then("display all correct tuition partners that provide the selected subjects in any location", () => {
+    cy.get('[data-testid="results-list-item"]').should("exist")
+});

--- a/UI/cypress/support/step_definitions/errors.js
+++ b/UI/cypress/support/step_definitions/errors.js
@@ -4,3 +4,7 @@ Then("they will see {string} as an error message for the {string}", (error, prop
     cy.get('[data-module="govuk-error-summary"] > div').should("contain.text", error);
 });
 
+Then("they will not see an error message", () => {
+    cy.get('[data-module="govuk-error-summary"]').should("not.exist");
+});
+

--- a/UI/cypress/support/step_definitions/results-page.js
+++ b/UI/cypress/support/step_definitions/results-page.js
@@ -14,6 +14,18 @@ Given("a user has arrived on the 'Search results' page for {string} for postcode
     cy.visit(`/search-results?Postcode=${postcode}&${query}`);
 });
 
+Given("a user has arrived on the 'Search results' page without subjects", ()  => {
+    Step(this, "a user has arrived on the 'Search results' page without subjects for postcode 'sk11eb'")
+});
+
+Given("a user has arrived on the 'Search results' page without subjects for postcode {string}", postcode => {
+    cy.visit(`/search-results?Postcode=${postcode}`);
+});
+
+Given("a user has arrived on the 'Search results' page without subjects or postcode", ()  => {
+    cy.visit(`/search-results`);
+});
+
 Given("a user has arrived on the 'Search results' page", () => {
     cy.visit(`/search-results?Postcode=sk11eb&Subjects=KeyStage1-English&Subjects=KeyStage1-Maths&Subjects=KeyStage1-Science&Subjects=KeyStage2-English&Subjects=KeyStage2-Maths&Subjects=KeyStage2-Science&Subjects=KeyStage3-English&Subjects=KeyStage3-Humanities&Subjects=KeyStage3-Maths&Subjects=KeyStage3-Modern%20foreign%20languages&Subjects=KeyStage3-Science&Subjects=KeyStage4-English&Subjects=KeyStage4-Humanities&Subjects=KeyStage4-Maths&Subjects=KeyStage4-Modern%20foreign%20languages&Subjects=KeyStage4-Science&KeyStages=KeyStage1&KeyStages=KeyStage2&KeyStages=KeyStage3&KeyStages=KeyStage4`);
 });


### PR DESCRIPTION
## Changes proposed in this pull request

Show all the tuition partners when there is no postcode entered and/or no subjects selected

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-375

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code