### PR TITLE
NTP-462: Randomise search results

### DIFF
--- a/Application/Handlers/SearchTuitionPartnerHandler.cs
+++ b/Application/Handlers/SearchTuitionPartnerHandler.cs
@@ -68,9 +68,11 @@ public class SearchTuitionPartnerHandler
                     break;
             }
 
+            var ordering = new TuitionPartnerOrdering(request);
+
             var count = await queryable.CountAsync(cancellationToken);
             var ids = await queryable.Skip(request.Page * request.PageSize).Take(request.PageSize).Select(e => e.Id).ToArrayAsync(cancellationToken);
-            var results = (await _repository.GetSearchResultsDictionaryAsync(ids, lad?.Id, request.OrderBy, request.Direction, cancellationToken)).Values.ToArray();
+            var results = (await _repository.GetSearchResultsDictionaryAsync(ids, lad?.Id, ordering, cancellationToken)).ToArray();
 
             return new TuitionPartnerSearchResultsPage(request, count, results, lad);
         }

--- a/Application/Repositories/ITuitionPartnerRepository.cs
+++ b/Application/Repositories/ITuitionPartnerRepository.cs
@@ -5,6 +5,6 @@ namespace Application.Repositories;
 public interface ITuitionPartnerRepository
 {
     Task<IEnumerable<TuitionPartnerSearchResult>> GetSearchResultsDictionaryAsync(
-        IEnumerable<int> ids, int? localAuthorityDistrictId, 
+        IEnumerable<int> ids, int? localAuthorityDistrictId,
         TuitionPartnerOrdering ordering, CancellationToken cancellationToken = default);
 }

--- a/Application/Repositories/ITuitionPartnerRepository.cs
+++ b/Application/Repositories/ITuitionPartnerRepository.cs
@@ -4,5 +4,7 @@ namespace Application.Repositories;
 
 public interface ITuitionPartnerRepository
 {
-    Task<IDictionary<int, TuitionPartnerSearchResult>> GetSearchResultsDictionaryAsync(IEnumerable<int> ids, int? localAuthorityDistrictId, TuitionPartnerOrderBy orderBy, OrderByDirection direction, CancellationToken cancellationToken = default);
+    Task<IEnumerable<TuitionPartnerSearchResult>> GetSearchResultsDictionaryAsync(
+        IEnumerable<int> ids, int? localAuthorityDistrictId, 
+        TuitionPartnerOrdering ordering, CancellationToken cancellationToken = default);
 }

--- a/Domain/Search/TuitionPartnerOrdering.cs
+++ b/Domain/Search/TuitionPartnerOrdering.cs
@@ -18,7 +18,7 @@ public class TuitionPartnerOrdering
 
             case TuitionPartnerOrderBy.Random:
                 var random = new Random(RandomSeed());
-                return results.OrderByDescending(e => e.Id).OrderBy(x => random.Next());
+                return results.OrderByDescending(e => e.SeoUrl).OrderBy(x => random.Next());
 
             default:
                 return results.OrderByDescending(e => e.Id);

--- a/Domain/Search/TuitionPartnerOrdering.cs
+++ b/Domain/Search/TuitionPartnerOrdering.cs
@@ -1,0 +1,35 @@
+﻿namespace Domain.Search;
+
+public class TuitionPartnerOrdering
+{
+    private readonly TuitionPartnerSearchRequest request;
+
+    public TuitionPartnerOrdering(TuitionPartnerSearchRequest searchRequest)
+        => request = searchRequest;
+
+    public IEnumerable<TuitionPartnerSearchResult> Order(List<TuitionPartnerSearchResult> results)
+    {
+        switch (request.OrderBy)
+        {
+            case TuitionPartnerOrderBy.Name:
+                return request.Direction == OrderByDirection.Descending
+                    ? results.OrderByDescending(e => e.Name)
+                    : results.OrderBy(e => e.Name);
+
+            case TuitionPartnerOrderBy.Random:
+                var random = new Random(RandomSeed());
+                return results.OrderByDescending(e => e.Id).OrderBy(x => random.Next());
+
+            default:
+                return results.OrderByDescending(e => e.Id);
+        }
+    }
+
+    public int RandomSeed()
+    {
+        return
+            (request.LocalAuthorityDistrictCode?.Sum(x => x) ?? 0)
+            + (request.SubjectIds?.Sum() ?? 0)
+            + (request.TuitionTypeId ?? 0);
+    }
+}

--- a/Infrastructure/Repositories/TuitionPartnerRepository.cs
+++ b/Infrastructure/Repositories/TuitionPartnerRepository.cs
@@ -14,7 +14,11 @@ public class TuitionPartnerRepository : ITuitionPartnerRepository
         _dbContext = dbContext;
     }
 
-    public async Task<IDictionary<int, TuitionPartnerSearchResult>> GetSearchResultsDictionaryAsync(IEnumerable<int> ids, int? localAuthorityDistrictId, TuitionPartnerOrderBy orderBy, OrderByDirection direction, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<TuitionPartnerSearchResult>> GetSearchResultsDictionaryAsync(
+        IEnumerable<int> ids,
+        int? localAuthorityDistrictId,
+        TuitionPartnerOrdering ordering,
+        CancellationToken cancellationToken = default)
     {
         var entities = await _dbContext.TuitionPartners.AsNoTracking()
             .Include(e => e.LocalAuthorityDistrictCoverage.Where(lad => lad.LocalAuthorityDistrictId == localAuthorityDistrictId))
@@ -35,17 +39,7 @@ public class TuitionPartnerRepository : ITuitionPartnerRepository
 
             results.Add(result);
         }
-
-        switch (orderBy)
-        {
-            case TuitionPartnerOrderBy.Name:
-                return direction == OrderByDirection.Descending
-                    ? results.OrderByDescending(e => e.Name).ToDictionary(e => e.Id)
-                    : results.OrderBy(e => e.Name).ToDictionary(e => e.Id);
-            case TuitionPartnerOrderBy.Random:
-                return results.OrderBy(_ => Guid.NewGuid()).ToDictionary(e => e.Id);
-            default:
-                return results.OrderByDescending(e => e.Id).ToDictionary(e => e.Id);
-        }
+        
+        return ordering.Order(results);
     }
 }

--- a/Infrastructure/Repositories/TuitionPartnerRepository.cs
+++ b/Infrastructure/Repositories/TuitionPartnerRepository.cs
@@ -39,7 +39,7 @@ public class TuitionPartnerRepository : ITuitionPartnerRepository
 
             results.Add(result);
         }
-        
+
         return ordering.Order(results);
     }
 }

--- a/Tests/RandomiseSearchResults.cs
+++ b/Tests/RandomiseSearchResults.cs
@@ -29,11 +29,8 @@ public class RandomiseSearchResults : IClassFixture<RandomiseSearchResultsFixtur
         new TuitionPartnerOrdering(search).RandomSeed().Should().Be(total);
     }
 
-    [Theory]
-    [InlineData(0, 0, 1, 1)]
-    [InlineData(1, 2, 3, 6)]
-    [InlineData(8, 12, 23, 43)]
-    public void TuitionType_randomness(int a, int b, int c, int total)
+    [Fact]
+    public void TuitionType_randomness()
     {
         var search = new TuitionPartnerSearchRequest { TuitionTypeId = 5 };
         new TuitionPartnerOrdering(search).RandomSeed().Should().Be(5);

--- a/Tests/RandomiseSearchResults.cs
+++ b/Tests/RandomiseSearchResults.cs
@@ -1,0 +1,244 @@
+﻿using Application.Handlers;
+using Domain;
+using Domain.Search;
+
+namespace Tests;
+
+[Collection(nameof(SliceFixture))]
+public class RandomnessFixture : IAsyncLifetime
+{
+    public RandomnessFixture(SliceFixture fixture)
+    {
+        Fixture = fixture;
+    }
+
+    public SliceFixture Fixture { get; }
+
+    public async Task InitializeAsync()
+    {
+        await Fixture.ExecuteDbContextAsync(async db =>
+        {
+            List<LocalAuthorityDistrictCoverage> CreateAreaCoverage() =>
+                (from ladc in db.LocalAuthorityDistricts
+                 from tt in db.TuitionTypes
+                 select new LocalAuthorityDistrictCoverage
+                 {
+                     LocalAuthorityDistrictId = ladc.Id,
+                     TuitionTypeId = tt.Id,
+                 })
+                 .ToList();
+
+            List<SubjectCoverage> CreateSubjectCoverage() =>
+                (from tt in db.TuitionTypes
+                 from s in db.Subjects
+                 select new SubjectCoverage { TuitionTypeId = tt.Id, SubjectId = s.Id }
+                 ).ToList();
+
+            db.Prices.RemoveRange(db.Prices);
+            db.SubjectCoverage.RemoveRange(db.SubjectCoverage);
+            db.TuitionPartners.RemoveRange(db.TuitionPartners);
+            await db.SaveChangesAsync();
+
+            db.TuitionPartners.Add(new TuitionPartner
+            {
+                Id = 1,
+                SeoUrl = "a-tuition-partner",
+                Name = "Alpha",
+                Website = "https://a-tuition-partner.testdata/ntp",
+                Description = "A Tuition Partner Description",
+                LocalAuthorityDistrictCoverage = CreateAreaCoverage(),
+                SubjectCoverage = CreateSubjectCoverage(),
+            });
+
+            db.TuitionPartners.Add(new TuitionPartner
+            {
+                Id = 2,
+                SeoUrl = "bravo-learning",
+                Name = "Bravo",
+                Website = "https://bravo.learning.testdata/ntp",
+                Description = "Bravo Learning Description",
+                PhoneNumber = "0123456789",
+                Email = "ntp@bravo.learning.testdata",
+                HasSenProvision = true,
+                LocalAuthorityDistrictCoverage = CreateAreaCoverage(),
+                SubjectCoverage = CreateSubjectCoverage(),
+            });
+
+            db.TuitionPartners.Add(new TuitionPartner
+            {
+                Id = 3,
+                SeoUrl = "charlie-learning",
+                Name = "Charlie",
+                Website = "https://charlie.learning.testdata/ntp",
+                Description = "Charlie Learning Description",
+                LocalAuthorityDistrictCoverage = CreateAreaCoverage(),
+                SubjectCoverage = CreateSubjectCoverage(),
+            });
+
+            db.TuitionPartners.Add(new TuitionPartner
+            {
+                Id = 4,
+                SeoUrl = "delta-learning",
+                Name = "Delta",
+                Website = "https://delta.learning.testdata/ntp",
+                Description = "Delta Learning Description",
+                LocalAuthorityDistrictCoverage = CreateAreaCoverage(),
+                SubjectCoverage = CreateSubjectCoverage(),
+            });
+
+            await db.SaveChangesAsync();
+        });
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+}
+
+public class RandomiseSearchResults : RandomnessFixture
+{
+    public RandomiseSearchResults(SliceFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public void LAD_randomness()
+    {
+        var search = new TuitionPartnerSearchRequest { LocalAuthorityDistrictCode = "bob" };
+        new TuitionPartnerOrdering(search).RandomSeed().Should().Be('b' + 'o' + 'b');
+    }
+
+    [Theory]
+    [InlineData(0, 0, 1, 1)]
+    [InlineData(1, 2, 3, 6)]
+    [InlineData(8, 12, 23, 43)]
+    public void Subject_randomness(int a, int b, int c, int total)
+    {
+        var search = new TuitionPartnerSearchRequest { SubjectIds = new[] { a, b, c } };
+        new TuitionPartnerOrdering(search).RandomSeed().Should().Be(total);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 1, 1)]
+    [InlineData(1, 2, 3, 6)]
+    [InlineData(8, 12, 23, 43)]
+    public void TuitionType_randomness(int a, int b, int c, int total)
+    {
+        var search = new TuitionPartnerSearchRequest { TuitionTypeId = 5 };
+        new TuitionPartnerOrdering(search).RandomSeed().Should().Be(5);
+    }
+
+    [Fact]
+    public void All_randomness()
+    {
+        var search = new TuitionPartnerSearchRequest
+        {
+            LocalAuthorityDistrictCode = "ab12",
+            SubjectIds = new[] { 5, 9, 22, 65 },
+            TuitionTypeId = 5,
+        };
+        new TuitionPartnerOrdering(search).RandomSeed()
+            .Should().Be('a' + 'b' + '1' + '2' + 5 + 9 + 22 + 65 + 5);
+    }
+
+    [Fact]
+    public async void Search_results_can_be_randomised2()
+    {
+        var results = await Fixture.SendAsync(new SearchTuitionPartnerHandler.Command
+        {
+            OrderBy = TuitionPartnerOrderBy.Random,
+        });
+
+        results.Results.Should().NotBeEmpty();
+        results.Results.Select(x => x.Name).Should()
+            .ContainInOrder("Alpha", "Delta", "Bravo", "Charlie");
+    }
+
+    [Theory]
+    [MemberData(nameof(SearchData))]
+    public async void Search_results_can_be_randomised(SearchTuitionPartnerHandler.Command search, string[] order)
+    {
+        search.OrderBy = TuitionPartnerOrderBy.Random;
+
+        var results = await Fixture.SendAsync(search);
+
+        results.Results.Should().NotBeEmpty();
+        results.Results.Select(x => x.Name)
+            .Should().ContainInOrder(order)
+            .And.Equal(order);
+    }
+
+    public static IEnumerable<object[]> SearchData()
+    {
+        yield return new object[]
+        {
+            new SearchTuitionPartnerHandler.Command { },
+            new []{ "Alpha", "Delta", "Bravo", "Charlie", }
+        };
+
+        yield return new object[]
+        {
+            new SearchTuitionPartnerHandler.Command { LocalAuthorityDistrictCode = "E06000030" },
+            new []{ "Delta", "Alpha", "Charlie", "Bravo",  }
+        };
+
+        yield return new object[]
+        {
+            new SearchTuitionPartnerHandler.Command { LocalAuthorityDistrictCode = "E07000179" },
+            new []{  "Bravo", "Alpha", "Charlie", "Delta",  }
+        };
+
+        yield return new object[]
+        {
+            new SearchTuitionPartnerHandler.Command
+            {
+                LocalAuthorityDistrictCode = "E07000179",
+                SubjectIds = new[] { 1, 2, 3, 4 }
+            },
+            new []{ "Delta", "Bravo", "Alpha", "Charlie", }
+        };
+
+        // Subject ID order doesn't matter
+        yield return new object[]
+        {
+            new SearchTuitionPartnerHandler.Command
+            {
+                LocalAuthorityDistrictCode = "E07000179",
+                SubjectIds = new[] { 4, 3, 2, 1 }
+            },
+            new []{ "Delta", "Bravo", "Alpha", "Charlie", }
+        };
+
+        // Subject ID values do matter
+        yield return new object[]
+        {
+            new SearchTuitionPartnerHandler.Command
+            {
+                LocalAuthorityDistrictCode = "E07000179",
+                SubjectIds = new[] { 4, 5, 6, 7, 8, 9 }
+            },
+            new []{ "Charlie", "Delta", "Bravo", "Alpha", }
+        };
+
+        yield return new object[]
+        {
+            new SearchTuitionPartnerHandler.Command
+            {
+                LocalAuthorityDistrictCode = "E06000057",
+                SubjectIds = new[] { 4, 3, 2, 1 },
+                TuitionTypeId = 1,
+            },
+            new []{ "Charlie", "Alpha", "Delta", "Bravo", }
+        };
+
+        yield return new object[]
+        {
+            new SearchTuitionPartnerHandler.Command
+            {
+                LocalAuthorityDistrictCode = "E06000057",
+                SubjectIds = new[] { 4, 3, 2, 1 },
+                TuitionTypeId = 2,
+            },
+            new []{ "Delta", "Bravo", "Charlie", "Alpha", }
+        };
+    }
+}

--- a/Tests/TuitionPartnerDetailsPagePriceTable.cs
+++ b/Tests/TuitionPartnerDetailsPagePriceTable.cs
@@ -1,5 +1,5 @@
-﻿using Domain.Constants;
-using System.Globalization;
+﻿using System.Globalization;
+using Domain.Constants;
 using UI.Extensions;
 using GroupPrice = UI.Pages.TuitionPartner.GroupPrice;
 

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -77,7 +77,7 @@
 					var count = Model.Data.Results!.Count == 0 ? "No" : Model.Data.Results.Count.ToString();
 					var resultPlural = Model.Data.Results.Count != 1 ? "results" : "result";
 				}
-				<strong>@count</strong> @(resultPlural) <span show-if="@Model.Data.LocalAuthority != null">for <strong>@Model.Data.LocalAuthority</strong></span> sorted by A-Z
+				<strong>@count</strong> @(resultPlural) <span show-if="@Model.Data.LocalAuthority != null">for <strong>@Model.Data.LocalAuthority</strong></span> sorted randomly
 				<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 			</div>
 

--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -191,7 +191,7 @@ public class SearchResults : PageModel
 
             return await mediator.Send(new SearchTuitionPartnerHandler.Command
             {
-                OrderBy = TuitionPartnerOrderBy.Name,
+                OrderBy = TuitionPartnerOrderBy.Random,
                 LocalAuthorityDistrictCode = localAuthorityDisctict,
                 SubjectIds = subjects.Select(x => x.Id),
                 TuitionTypeId = request.TuitionType > 0 ? (int?)request.TuitionType : null,

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -93,7 +93,7 @@ Then("the subjects covered by a tuition partner are in alphabetical order", () =
 });
 
 Then("they will see the results summary for {string}", location => {
-    var expected = new RegExp(`\\d+ results for ${location} sorted by A-Z`)
+    var expected = new RegExp(`\\d+ results for ${location} sorted randomly`)
     cy.get('[data-testid="results-summary"]')
         .invoke("text").invoke("trim")
         .should('match', expected)


### PR DESCRIPTION
## Context

Randomisation of search results list will avoid the appearance of preferential treatment towards those providers who would constantly appear at the top.  However, we would like to present the results in a consistent order for any given set of search criteria.  This would allow the search to be re-run later, or results URL to be shared with colleagues, and the same set of results in the same order will be seen.  

## Changes proposed in this pull request

Search results for one set of search criteria will always return in the same order.  Change the criteria slightly and the order will be different.

Check that the results are always the same when searching for 
* [SK11EB KS1 Engligh](https://localhost:7036/search-results?Postcode=SK1%201EB&Subjects=KeyStage1-English&KeyStages=KeyStage1)
* [SK11EB KS1 English and Maths](https://localhost:7036/search-results?Data.Subjects=KeyStage1-English&Data.Subjects=KeyStage1-Maths&Data.TuitionType=Any&Data.Postcode=SK1+1EB)
* [S12PP KS1 English and Maths](https://localhost:7036/search-results?Data.Subjects=KeyStage1-English&Data.Subjects=KeyStage1-Maths&Data.TuitionType=Any&Data.Postcode=S1+2PP)

## Guidance to review

A stable randomisation is performed by seeding the [`Random`](https://docs.microsoft.com/en-us/dotnet/api/system.random?view=net-6.0) number generator with a calculation based on the search criteria.

https://github.com/DFE-Digital/find-a-tuition-partner/blob/2039f699f45a1728021edd65360794dd1bf655b2/Domain/Search/TuitionPartnerOrdering.cs#L28-L34

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-462

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [x] Database migrations can be applied to the current codebase in main without causing exceptions
- [x] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code