### PR TITLE
NTP-470:Removed tuition group size in tp information page

### DIFF
--- a/Infrastructure/Extensions/HostBuilderExtensions.cs
+++ b/Infrastructure/Extensions/HostBuilderExtensions.cs
@@ -27,7 +27,7 @@ public static class HostBuilderExtensions
 
             if (!string.IsNullOrWhiteSpace(appLogging.TcpSinkUri))
             {
-                //config.WriteTo.TCPSink(appLogging.TcpSinkUri);
+                config.WriteTo.TCPSink(appLogging.TcpSinkUri);
             }
         });
 

--- a/Infrastructure/Extensions/HostBuilderExtensions.cs
+++ b/Infrastructure/Extensions/HostBuilderExtensions.cs
@@ -27,7 +27,7 @@ public static class HostBuilderExtensions
 
             if (!string.IsNullOrWhiteSpace(appLogging.TcpSinkUri))
             {
-                config.WriteTo.TCPSink(appLogging.TcpSinkUri);
+                //config.WriteTo.TCPSink(appLogging.TcpSinkUri);
             }
         });
 

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -53,19 +53,6 @@
 					    </ul>
 				    </govuk-summary-list-row-value>
 			    </govuk-summary-list-row>
-			    <govuk-summary-list-row>
-				    <govuk-summary-list-row-key>
-					    Tuition group size(s)
-				    </govuk-summary-list-row-key>
-				    <govuk-summary-list-row-value>
-					    <ul class="govuk-list">
-						    @foreach (var item in Model.Data.Ratios)
-						    {
-							    <li>@item</li>
-						    }
-					    </ul>
-				    </govuk-summary-list-row-value>
-			    </govuk-summary-list-row>
 				<govuk-summary-list-row>
 					<govuk-summary-list-row-key>
 						SEND support


### PR DESCRIPTION
## Context
Removed tuition partner group info from tuition partner details page has this already shown in price info

## Changes proposed in this pull request

Before:
![image](https://user-images.githubusercontent.com/44170638/182869730-e99887dd-66a9-4408-b557-db1b3f6b03f1.png)

After:
![image](https://user-images.githubusercontent.com/44170638/182870040-0d08cb4c-f41c-4e70-a352-26a09e216bb6.png)


## Guidance to review

Tuition partner info should match the above screen shot

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-470

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code