### PR TITLE
NTP-451: Only show prices for the searched tuition type

### DIFF
--- a/Tests/TuitionPartnerDetailsPage.cs
+++ b/Tests/TuitionPartnerDetailsPage.cs
@@ -56,6 +56,7 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
                     new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3English, GroupSize = 3, HourlyRate = 12.34m },
                     new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3Maths, GroupSize = 2, HourlyRate = 56.78m },
                     new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3Maths, GroupSize = 3, HourlyRate = 56.78m },
+                    new() { TuitionTypeId = (int)TuitionTypes.Online, SubjectId = Subjects.Id.KeyStage3Maths, GroupSize = 3, HourlyRate = 56.78m },
                 }
             });
 
@@ -140,7 +141,7 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
         result.Prices.Should().BeEquivalentTo(new Dictionary<int, TuitionPartner.GroupPrice>
         {
             { 2, new (12.34m, 56.78m, null, null) },
-            { 3, new (12.34m, 56.78m, null, null) }
+            { 3, new (12.34m, 56.78m, 56.78m, 56.78m) }
         });
         result.Website.Should().Be("https://a-tuition-partner.testdata/ntp");
         result.PhoneNumber.Should().Be("0123456789");
@@ -176,6 +177,35 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
                 LocalAuthorityDistrictCode: LocalAuthorityDistrictCodes["Ryedale"]));
 
         result!.TuitionTypes.Should().BeEquivalentTo("Online");
+    }
+
+    [Fact]
+    public async Task Shows_all_tuition_types_prices_when_provided_in_district()
+    {
+        var result = await Fixture.SendAsync(
+            new TuitionPartner.Query(
+                "a-tuition-partner",
+                LocalAuthorityDistrictCode: LocalAuthorityDistrictCodes["North East Lincolnshire"]));
+
+        result!.Prices.Should().BeEquivalentTo(new Dictionary<int, TuitionPartner.GroupPrice>
+        {
+            { 2, new (12.34m, 56.78m, null, null) },
+            { 3, new (12.34m, 56.78m, 56.78m, 56.78m) },
+        });
+    }
+
+    [Fact]
+    public async Task Shows_only_tuition_type_prices_provided_in_district()
+    {
+        var result = await Fixture.SendAsync(
+            new TuitionPartner.Query(
+                "a-tuition-partner",
+                LocalAuthorityDistrictCode: LocalAuthorityDistrictCodes["Ryedale"]));
+
+        result!.Prices.Should().BeEquivalentTo(new Dictionary<int, TuitionPartner.GroupPrice>
+        {
+            { 3, new (null, null, 56.78m, 56.78m) }
+        });
     }
 
     [Fact]

--- a/UI/Pages/TuitionPartner.cshtml.cs
+++ b/UI/Pages/TuitionPartner.cshtml.cs
@@ -93,7 +93,11 @@ public class TuitionPartner : PageModel
         LocalAuthorityDistrictCoverage[] LocalAuthorityDistricts,
         Dictionary<TuitionType, Dictionary<KeyStage, Dictionary<string, Dictionary<int, decimal>>>> AllPrices);
 
-    public record struct GroupPrice(decimal? SchoolMin, decimal? SchoolMax, decimal? OnlineMin, decimal? OnlineMax);
+    public record struct GroupPrice(decimal? SchoolMin, decimal? SchoolMax, decimal? OnlineMin, decimal? OnlineMax)
+    {
+        public bool HasAtLeastOnePrice =>
+            OnlineMin != null || OnlineMax != null || SchoolMin != null || SchoolMax != null;
+    }
 
     public record struct LocalAuthorityDistrictCoverage(string Region, string Code, string Name, bool InSchool, bool Online);
 
@@ -130,7 +134,7 @@ public class TuitionPartner : PageModel
             var subjects = tp.SubjectCoverage.Select(x => x.Subject).Distinct().GroupBy(x => x.KeyStageId).Select(x => $"{((KeyStage)x.Key).DisplayName()} - {x.DisplayList()}");
             var types = await GetTuitionTypesCovered(request.LocalAuthorityDistrictCode, tp, cancellationToken);
             var ratios = tp.Prices.Select(x => x.GroupSize).Distinct().Select(x => $"1 to {x}");
-            var prices = GetPricing(tp.Prices);
+            var prices = GetPricing(types, tp.Prices);
 
             var lads = await GetLocalAuthorityDistricts(request, tp.Id);
 
@@ -207,19 +211,31 @@ public class TuitionPartner : PageModel
             return result.Values.ToArray();
         }
 
-        private static Dictionary<int, GroupPrice> GetPricing(ICollection<Price> prices)
+        private static Dictionary<int, GroupPrice> GetPricing(IEnumerable<string> types, ICollection<Price> prices)
         {
+            (Func<IEnumerable<Price>, decimal?> min, Func<IEnumerable<Price>, decimal?> max) online =
+                types.Contains("Online")
+                ? (prices => MinPrice(prices, TuitionTypes.Online), prices => MaxPrice(prices, TuitionTypes.Online))
+                : (prices => null, prices => null);
+
+            (Func<IEnumerable<Price>, decimal?> min, Func<IEnumerable<Price>, decimal?> max) inSchool =
+                types.Contains("In School")
+                ? (prices => MinPrice(prices, TuitionTypes.InSchool), prices => MaxPrice(prices, TuitionTypes.InSchool))
+                : (prices => null, prices => null);
+
             return prices
                 .GroupBy(x => x.GroupSize)
                 .ToDictionary(
                     key => key.Key,
                     value => new GroupPrice
-                            (MinPrice(value, TuitionTypes.InSchool)
-                            , MaxPrice(value, TuitionTypes.InSchool)
-                            , MinPrice(value, TuitionTypes.Online)
-                            , MaxPrice(value, TuitionTypes.Online)
+                            (inSchool.min(value)
+                            , inSchool.max(value)
+                            , online.min(value)
+                            , online.max(value)
                             )
-                    );
+                    )
+                .Where(x => x.Value.HasAtLeastOnePrice)
+                .ToDictionary(k => k.Key, v => v.Value);
 
             static decimal? MinPrice(IEnumerable<Price> value, TuitionTypes tuitionType)
                 => MinMaxPrice(value, tuitionType, Enumerable.MinBy);

--- a/UI/cypress/e2e/location-aware-results.feature
+++ b/UI/cypress/e2e/location-aware-results.feature
@@ -1,29 +1,24 @@
 Feature: Tuition Partner provides online but not in-school tuition in an area
   Scenario: Display list of TPs that offer services to that postcode
     Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
-    When they select 'any' tuition type
     Then they will see the tuition partner 'Action Tutoring'
 
   Scenario: Only show tuition type available in the postcode’s location on TP information page (location aware)
     Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
-    When they select 'any' tuition type
-    And they select the tuition partner 'Action Tutoring'
+    When they select the tuition partner 'Action Tutoring'
     Then they see the tuition types 'Online'
 
   Scenario: Show all tuition types on TP information page when the TP supports them all for the postcode’s location
     Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'S1 2PP'
-    When they select 'any' tuition type
-    And they select the tuition partner 'Action Tutoring'
+    When they select the tuition partner 'Action Tutoring'
     Then they see the tuition types 'In School, Online'
 
   Scenario: Only shows cost for tuition type available in the postcode’s location
     Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
-    When they select 'any' tuition type
-    And they select the tuition partner 'Action Tutoring'
+    When they select the tuition partner 'Action Tutoring'
     Then they see the cost for tuition type 'Online'
 
   Scenario: Show all cost for tuition type when the TP supports them all for the postcode’s location
     Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'S1 2PP'
-    When they select 'any' tuition type
-    And they select the tuition partner 'Action Tutoring'
+    When they select the tuition partner 'Action Tutoring'
     Then they see the cost for tuition type 'In school, Online'

--- a/UI/cypress/e2e/location-aware-results.feature
+++ b/UI/cypress/e2e/location-aware-results.feature
@@ -15,3 +15,15 @@ Feature: Tuition Partner provides online but not in-school tuition in an area
     When they select 'any' tuition type
     And they select the tuition partner 'Action Tutoring'
     Then they see the tuition types 'In School, Online'
+
+  Scenario: Only shows cost for tuition type available in the postcode’s location
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+    When they select 'any' tuition type
+    And they select the tuition partner 'Action Tutoring'
+    Then they see the cost for tuition type 'Online'
+
+  Scenario: Show all cost for tuition type when the TP supports them all for the postcode’s location
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'S1 2PP'
+    When they select 'any' tuition type
+    And they select the tuition partner 'Action Tutoring'
+    Then they see the cost for tuition type 'In school, Online'

--- a/UI/cypress/e2e/tuition-partner-details.feature
+++ b/UI/cypress/e2e/tuition-partner-details.feature
@@ -95,6 +95,6 @@ Feature: User can view full details of a Tuition Parner
     Then the tuition partner full pricing tables are displayed
     And the tuition partner pricing table is not displayed
 
-Scenario: subjects covered by a tuition partner are in alphabetical order in the 'search results' page
+  Scenario: subjects covered by a tuition partner are in alphabetical order in the 'search results' page
     Given a user has arrived on the 'Tuition Partner' page for 'bright-heart-education'
     Then the subjects covered by a tuition partner are in alphabetical order 

--- a/UI/cypress/support/step_definitions/results-page.js
+++ b/UI/cypress/support/step_definitions/results-page.js
@@ -67,3 +67,14 @@ Then("they see the tuition types {string}", tuitionTypes => {
         expect(listedTuitionTypes).to.deep.equal(tuitionArray)
     });
 })
+
+Then("they see the cost for tuition type {string}", tuitionTypes => {
+    const tuitionArray = tuitionTypes.split(',').map(s => s.trim())
+
+    tuitionArray.forEach(element => {
+        cy.get("[data-testid='pricing-table'] thead").contains('th', element);
+    });
+
+    cy.get("[data-testid='pricing-table'] thead th")
+        .should('have.length', tuitionArray.length + 1)
+})


### PR DESCRIPTION
## Changes proposed in this pull request

Before: A search for [KS1 English in SK11EB with any tuition](https://localhost:7036/search-results?Data.Subjects=KeyStage2-English&Data.TuitionType=Any&Data.Postcode=SK1+1EB) shows

![image](https://user-images.githubusercontent.com/201727/183404766-a105f832-76dd-494a-b8f8-9e062aa1c7d0.png)

After:

![image](https://user-images.githubusercontent.com/201727/183404972-ff6f7187-0895-41cf-8618-f364f005e41d.png)

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-451

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [x] Database migrations can be applied to the current codebase in main without causing exceptions
- [x] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code