### PR TITLE
NTP-472: Move GPaaS components over to find-a-tuition-partner

### DIFF
--- a/.github/workflows/continuous-deployment-to-qa.yml
+++ b/.github/workflows/continuous-deployment-to-qa.yml
@@ -31,7 +31,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           working-directory: ./UI
-          config: baseUrl=https://national-tutoring-qa.london.cloudapps.digital/
+          config: baseUrl=https://find-a-tuition-partner-qa.london.cloudapps.digital/
         env:
           CYPRESS_username: ${{ secrets.QA_HTTP_AUTH_USERNAME }}
           CYPRESS_password: ${{ secrets.QA_HTTP_AUTH_PASSWORD }}

--- a/.github/workflows/deploy-to-gpaas.yml
+++ b/.github/workflows/deploy-to-gpaas.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run database migrations and import data
         if: ${{ inputs.run_database_migrations_and_import_data == true }}
         run: |
-          cf run-task national-tutoring-${{ inputs.environment }} --command "exec /home/vcap/deps/0/dotnet_publish/UI import --DataEncryption:Key ${{ secrets.DATA_ENCRYPTION_KEY }}" --name national-tutoring-${{ inputs.environment }}-data-import
+          cf run-task find-a-tuition-partner-${{ inputs.environment }} --command "exec /home/vcap/deps/0/dotnet_publish/UI import --DataEncryption:Key ${{ secrets.DATA_ENCRYPTION_KEY }}" --name find-a-tuition-partner-${{ inputs.environment }}-data-import
       
       - name: Logout
         run: cf logout

--- a/.github/workflows/end-to-end-testing.yml
+++ b/.github/workflows/end-to-end-testing.yml
@@ -33,7 +33,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           working-directory: ./UI
-          config: baseUrl=https://national-tutoring-${{ inputs.environment }}.london.cloudapps.digital/
+          config: baseUrl=https://find-a-tuition-partner-${{ inputs.environment }}.london.cloudapps.digital/
         env:
           CYPRESS_username: ${{ inputs.username }}
           CYPRESS_password: ${{ inputs.password }}

--- a/UI/Pages/Index.cshtml
+++ b/UI/Pages/Index.cshtml
@@ -2,7 +2,7 @@
 @model Index
 @{
 	ViewData["Title"] = "Find a tuition partner";
-	ViewData["AllowIndexing"] = true;
+	ViewData["AllowIndexing"] = false;
 }
 
 <div class="govuk-grid-row">

--- a/UI/package-lock.json
+++ b/UI/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "compare-national-tutoring-options",
+  "name": "find-a-tuition-partner",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "compare-national-tutoring-options",
+      "name": "find-a-tuition-partner",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/UI/package.json
+++ b/UI/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "compare-national-tutoring-options",
+  "name": "find-a-tuition-partner",
   "version": "0.1.0",
   "description": "National Tuition Programme Compare National Tutoring Options",
   "main": "index.js",
@@ -13,14 +13,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DFE-Digital/national-tutoring-programme.git"
+    "url": "git+https://github.com/DFE-Digital/find-a-tuition-partner.git"
   },
   "author": "The Department for Education",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/DFE-Digital/national-tutoring-programme/issues"
+    "url": "https://github.com/DFE-Digital/find-a-tuition-partner/issues"
   },
-  "homepage": "https://github.com/DFE-Digital/national-tutoring-programme#readme",
+  "homepage": "https://github.com/DFE-Digital/find-a-tuition-partner#readme",
   "dependencies": {
     "govuk-frontend": "^4.1.0"
   },

--- a/docs/decisions/0001-use-gpaas-hosting-environment.md
+++ b/docs/decisions/0001-use-gpaas-hosting-environment.md
@@ -102,6 +102,6 @@ Tooling is cross platform - Verified that the Cloud Foundry command line interfa
     * The primary search implementation
     * Data protection services
     * Identity tables
-* Application scaling - Scaled the application up to three instances and down through two to one instance with the `cf scale national-tutoring-dev -i 2` command
+* Application scaling - Scaled the application up to three instances and down through two to one instance with the `cf scale find-a-tuition-partner-dev -i 2` command
 
 <!-- markdownlint-disable-file MD013 -->

--- a/docs/runbooks/manual-environment-setup.md
+++ b/docs/runbooks/manual-environment-setup.md
@@ -18,13 +18,13 @@ You will also need the current LTS version of [NodeJS](https://nodejs.org/en/dow
 
 ### Naming conventions
 
-The service's domain name is `national-tutoring` and that is used as the prefix for all deployed applications and backing services. This is followed by the environment abbreviation on all non production environments e.g. `national-tutoring-qa`, `national-tutoring-research` etc.
+The service's domain name is `find-a-tuition-partner` and that is used as the prefix for all deployed applications and backing services. This is followed by the environment abbreviation on all non production environments e.g. `find-a-tuition-partner-qa`, `find-a-tuition-partner-research` etc.
 
 The guide uses the production names for all applications and backing services. Add the environment abbreviation as appropriate.
 
 ### Scaling
 
-The production environment is scheduled to use a `medium-ha-13` plan for the postgres backing service. Each environment will also have a minimum of three application instances. This guide uses the `small-13` plan to prevent accidentally creating multiple expensive backing services. Replace the plan with the one appropriate for the environment in question.
+The production environment is scheduled to use a `medium-13` plan for the postgres backing service. Each environment will also have a minimum of three application instances. This guide uses the `small-13` plan to prevent accidentally creating multiple expensive backing services. Replace the plan with the one appropriate for the environment in question.
 
 ## Runbook
 
@@ -41,13 +41,13 @@ The service uses [PostgreSQL](https://docs.cloud.service.gov.uk/deploying_servic
 Check if the service has already been created
 
 ```
-cf service national-tutoring-postgres-db
+cf service find-a-tuition-partner-<ENVIRONMENT>-postgres-db
 ```
 
 If not, create the service. This will take around ten minutes
 
 ```
-cf create-service postgres small-13 national-tutoring-<ENVIRONMENT>-postgres-db --wait
+cf create-service postgres small-13 find-a-tuition-partner-<ENVIRONMENT>-postgres-db --wait
 ```
 
 ### Application
@@ -74,7 +74,7 @@ cf push --strategy rolling --vars-file vars-<ENVIRONMENT>.yml
 Run the data import task which will also run the migrations against the database
 
 ```
-cf run-task national-tutoring-<ENVIRONMENT> --command "exec /home/vcap/deps/0/dotnet_publish/UI import --DataEncryption:Key <BASE64_ENCRYPTION_KEY>" --name national-tutoring-<ENVIRONMENT>-data-import
+cf run-task find-a-tuition-partner-<ENVIRONMENT> --command "exec /home/vcap/deps/0/dotnet_publish/UI import --DataEncryption:Key <BASE64_ENCRYPTION_KEY>" --name find-a-tuition-partner-<ENVIRONMENT>-data-import
 ```
 
 ### Basic HTTP Authentication
@@ -86,25 +86,25 @@ Clone and deploy the basic HTTP authentication route application
 ```
 git clone https://github.com/alphagov/paas-cf_basic_auth_route_service
 cd paas-cf_basic_auth_route_service
-cf push national-tutoring-<ENVIRONMENT>-auth-service-app --no-start
+cf push find-a-tuition-partner-<ENVIRONMENT>-auth-service-app --no-start
 ```
 
 Configure chosen username and password for environment and start the service
 
 ```
-cf set-env national-tutoring-<ENVIRONMENT>-auth-service-app AUTH_USERNAME <USERNAME>
-cf set-env national-tutoring-<ENVIRONMENT>-auth-service-app AUTH_PASSWORD <PASSWORD>
-cf start national-tutoring-<ENVIRONMENT>-auth-service-app
+cf set-env find-a-tuition-partner-<ENVIRONMENT>-auth-service-app AUTH_USERNAME <USERNAME>
+cf set-env find-a-tuition-partner-<ENVIRONMENT>-auth-service-app AUTH_PASSWORD <PASSWORD>
+cf start find-a-tuition-partner-<ENVIRONMENT>-auth-service-app
 ```
 
 Create the basic HTTP authentication backing service
 
 ```
-cf create-user-provided-service national-tutoring-<ENVIRONMENT>-auth-service -r https://national-tutoring-<ENVIRONMENT>-auth-service-app.london.cloudapps.digital
+cf create-user-provided-service find-a-tuition-partner-<ENVIRONMENT>-auth-service -r https://find-a-tuition-partner-<ENVIRONMENT>-auth-service-app.london.cloudapps.digital
 ```
 
 Bind the National Tutoring application's route to the basic HTTP authentication application
 
 ```
-cf bind-route-service london.cloudapps.digital national-tutoring-<ENVIRONMENT>-auth-service --hostname national-tutoring-<ENVIRONMENT>
+cf bind-route-service london.cloudapps.digital find-a-tuition-partner-<ENVIRONMENT>-auth-service --hostname find-a-tuition-partner-<ENVIRONMENT>
 ```

--- a/docs/runbooks/manual-environment-teardown.md
+++ b/docs/runbooks/manual-environment-teardown.md
@@ -16,7 +16,7 @@ The service is deployed to [GOV.UK PaaS](https://www.cloud.service.gov.uk/) and 
 
 ### Naming conventions
 
-The service's domain name is `national-tutoring` and that is used as the prefix for all deployed applications and backing services. This is followed by the environment abbreviation on all non production environments e.g. `national-tutoring-qa`, `national-tutoring-research` etc.
+The service's domain name is `find-a-tuition-partner` and that is used as the prefix for all deployed applications and backing services. This is followed by the environment abbreviation on all non production environments e.g. `find-a-tuition-partner-qa`, `find-a-tuition-partner-research` etc.
 
 The guide uses the production names for all applications and backing services. Add the environment abbreviation as appropriate.
 
@@ -33,7 +33,7 @@ cf login -a api.london.cloud.service.gov.uk -u USERNAME
 Remove the application first to prevent any access to it.
 
 ```
-cf delete national-tutoring-<ENVIRONMENT> -r
+cf delete find-a-tuition-partner-<ENVIRONMENT> -r
 ```
 
 ### Database
@@ -41,7 +41,7 @@ cf delete national-tutoring-<ENVIRONMENT> -r
 Remove the backing database service. 
 
 ```
-cf delete-service national-tutoring-<ENVIRONMENT>-postgres-db
+cf delete-service find-a-tuition-partner-<ENVIRONMENT>-postgres-db
 ```
 
 ### Basic HTTP Authentication
@@ -51,11 +51,11 @@ Remove the basic authentication application and backing service if the environme
 Remove the basic HTTP authentication route app
 
 ```
-cf delete national-tutoring-<ENVIRONMENT>-auth-service-app -r
+cf delete find-a-tuition-partner-<ENVIRONMENT>-auth-service-app -r
 ```
 
 Remove the basic HTTP authentication backing service
 
 ```
-cf delete-service national-tutoring-<ENVIRONMENT>-auth-service
+cf delete-service find-a-tuition-partner-<ENVIRONMENT>-auth-service
 ```

--- a/docs/runbooks/performance-testing.md
+++ b/docs/runbooks/performance-testing.md
@@ -25,7 +25,7 @@ All environments use three nodes for resiliance and to confirm that there are no
 Change the number of nodes used to one on the target environment by issuing the following cf command
 
 ```
-cf scale national-tutoring-<ENVIRONMENT> -i 1
+cf scale find-a-tuition-partner-<ENVIRONMENT> -i 1
 ```
 
 ### Performance Testing

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,8 @@
 ---
 applications:
-- name: national-tutoring((environment-postfix))
+- name: find-a-tuition-partner((environment-postfix))
   services:
-    - national-tutoring((environment-postfix))-postgres-db
+    - find-a-tuition-partner((environment-postfix))-postgres-db
   buildpacks:
     - dotnet_core_buildpack
   instances: ((instances))

--- a/terraform/paas/sandbox.env.tfvars
+++ b/terraform/paas/sandbox.env.tfvars
@@ -1,5 +1,5 @@
 paas_space                = "sandbox"
-paas_database_common_name = "national-tutoring-sandbox-postgres-db"
+paas_database_common_name = "find-a-tuition-partner-sandbox-postgres-db"
 paas_application_name  = "find-a-tuition-partner-sandbox"
 application_instances = 1
 logging               = 0

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -35,7 +35,7 @@ variable "paas_space" {
 }
 
 variable "paas_database_common_name" {
-  default = "national-tutoring-sandbox-postgres-db"
+  default = "find-a-tuition-partner-sandbox-postgres-db"
 }
 
 variable "paas_application_name" {

--- a/vars-production.yml
+++ b/vars-production.yml
@@ -1,4 +1,4 @@
-environment-postfix: "-production"
+environment-postfix: -production
 instances: 3
 memory: 1G
 dotnet-environment: Production

--- a/vars-staging.yml
+++ b/vars-staging.yml
@@ -1,6 +1,6 @@
 environment-postfix: -staging
 instances: 3
-memory: 1G
+memory: 256M
 dotnet-environment: Staging
 default-log-event-level: Information
 override-log-event-level: Information


### PR DESCRIPTION
## Context

GDS have agreed to find-tuition-partner.service.gov.uk as the service domain. We want to rename the GPaaS components from national-tuition to find-a-tuition-partner in preparation for this.

## Changes proposed in this pull request

- Create find-a-tuition-partner-<ENVIRONMENT> application and find-a-tuition-partner-<ENVIRONMENT>-postgres-db backing database service GPaaS components
- Remove all national-tutoring-<ENVIRONMENT> GPaaS components
- Remove basic http authentication 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

(NTP-472)[https://dfedigital.atlassian.net/browse/NTP-472]

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md) - N/A
- [ ] `dotnet format` has been run in the repository root - N/A
- [ ] Test coverage of new code is at least 80% - N/A
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/) - N/A
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off - N/A
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code - N/A