### PR TITLE
NTP-452: Highlight when cost information differs by subject

### DIFF
--- a/Tests/TuitionPartnerDetailsPage.cs
+++ b/Tests/TuitionPartnerDetailsPage.cs
@@ -70,6 +70,20 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
                 PhoneNumber = "0123456789",
                 Email = "ntp@bravo.learning.testdata",
                 HasSenProvision = true,
+                LocalAuthorityDistrictCoverage = new List<LocalAuthorityDistrictCoverage>
+                {
+                    new() { LocalAuthorityDistrictId = 1, TuitionTypeId = (int)TuitionTypes.InSchool },
+                },
+                SubjectCoverage = new List<SubjectCoverage>
+                {
+                    new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3English },
+                    new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3Maths },
+                },
+                Prices = new List<Price>
+                {
+                    new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3English, GroupSize = 2, HourlyRate = 12m },
+                    new() { TuitionTypeId = (int)TuitionTypes.InSchool, SubjectId = Subjects.Id.KeyStage3Maths, GroupSize = 2, HourlyRate = 12m },
+                },
             });
 
             await db.SaveChangesAsync();
@@ -244,7 +258,19 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
     [InlineData("bravo-learning", true)]
     public async Task Shows_send_status(string tuitionPartner, bool supportsSend)
     {
-        var result = await Fixture.SendAsync(new TuitionPartner.Query(tuitionPartner, ShowFullPricing: true));
+        var result = await Fixture.SendAsync(new TuitionPartner.Query(tuitionPartner));
         result!.HasSenProvision.Should().Be(supportsSend);
+    }
+
+    [Theory]
+    [InlineData("a-tuition-partner", 2, true)]
+    [InlineData("a-tuition-partner", 3, true)]
+    [InlineData("bravo-learning", 2, false)]
+    public async Task Shows_price_variant_text(string tuitionPartner, int groupSize, bool hasVariation)
+    {
+        var result = await Fixture.SendAsync(new TuitionPartner.Query(tuitionPartner));
+
+        result.Should().NotBeNull();
+        result!.Prices.Should().ContainKey(groupSize).WhoseValue.HasVariation.Should().Be(hasVariation);
     }
 }

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -117,7 +117,12 @@
         <h2 class="govuk-heading-m">Tuition cost information</h2>
         <p class="govuk-body">
             The costs shown are per pupil per hour.<br/>
-            All subjects are the same price but depend on tuition group size.
+			<span show-if="!@Model.Data.HasPricingVariation" data-testid="pricing-same-for-subjects">
+				All subjects are the same price but depend on tuition group size.
+			</span>
+			<span show-if="@Model.Data.HasPricingVariation" data-testid="pricing-differences-for-subjects">
+				Some prices are different depending on key stage or subject.  Please contact @Model.Data.Name for more information.
+			</span>
             <span show-if="@Model.Data.IsVatCharged" data-testid="price-includes-vat"><br/>Prices shown include VAT.</span>
         </p>
 

--- a/UI/Pages/TuitionPartner.cshtml.cs
+++ b/UI/Pages/TuitionPartner.cshtml.cs
@@ -91,12 +91,18 @@ public class TuitionPartner : PageModel
         string[] TuitionTypes, string[] Ratios, Dictionary<int, GroupPrice> Prices,
         string Website, string PhoneNumber, string EmailAddress, string Address, bool HasSenProvision, bool IsVatCharged,
         LocalAuthorityDistrictCoverage[] LocalAuthorityDistricts,
-        Dictionary<TuitionType, Dictionary<KeyStage, Dictionary<string, Dictionary<int, decimal>>>> AllPrices);
+        Dictionary<TuitionType, Dictionary<KeyStage, Dictionary<string, Dictionary<int, decimal>>>> AllPrices)
+    {
+        public bool HasPricingVariation => Prices.Any(x => x.Value.HasVariation);
+    }
 
     public record struct GroupPrice(decimal? SchoolMin, decimal? SchoolMax, decimal? OnlineMin, decimal? OnlineMax)
     {
         public bool HasAtLeastOnePrice =>
             OnlineMin != null || OnlineMax != null || SchoolMin != null || SchoolMax != null;
+
+        public bool HasVariation =>
+            (OnlineMin != OnlineMax) || (SchoolMin != SchoolMax);
     }
 
     public record struct LocalAuthorityDistrictCoverage(string Region, string Code, string Name, bool InSchool, bool Online);

--- a/UI/cypress/e2e/tuition-partner-details.feature
+++ b/UI/cypress/e2e/tuition-partner-details.feature
@@ -84,6 +84,14 @@ Feature: User can view full details of a Tuition Parner
     | FFT Education | In school |
     | career-tree | In school, Online |
 
+  Scenario: tuition cost blurb states pricing uniformity
+    Given a user has arrived on the 'Tuition Partner' page for 'Fledge Tuition Ltd'
+    Then the tuition cost information states declares no differences
+
+  Scenario: tuition cost blurb states pricing differences
+    Given a user has arrived on the 'Tuition Partner' page for 'Reed Tutors'
+    Then the tuition cost information states declares differences
+
   Scenario: full pricing tables are not displayed as default
     Given a user has arrived on the 'Tuition Partner' page for 'Fledge Tuition Ltd'
     Then the tuition partner full pricing tables are not displayed

--- a/UI/cypress/e2e/tuition-partner-details.js
+++ b/UI/cypress/e2e/tuition-partner-details.js
@@ -121,3 +121,12 @@ Then("the subjects covered by a tuition partner are in alphabetical order", () =
     });
 });
 
+Then("the tuition cost information states declares no differences", () => {
+    cy.get('[data-testid="pricing-same-for-subjects').should('exist');
+    cy.get('[data-testid="pricing-differences-for-subjects').should('not.exist');
+})
+
+Then("the tuition cost information states declares differences", () => {
+    cy.get('[data-testid="pricing-differences-for-subjects').should('exist');
+    cy.get('[data-testid="pricing-same-for-subjects').should('not.exist');
+})


### PR DESCRIPTION
## Changes proposed in this pull request

When prices do not vary, the text says "all subjects are the same price"
![image](https://user-images.githubusercontent.com/201727/183908808-15d761d6-3a70-4ad2-bdaf-eb23c821e1c0.png)

When prices do vary, the text says "some prices are different depending on key stage or subject."
![image](https://user-images.githubusercontent.com/201727/183909255-c6dd457d-39e6-43be-9da3-7d08d148fe23.png)

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-453

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [x] Database migrations can be applied to the current codebase in main without causing exceptions
- [x] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code