### PR TITLE
NTP-516: Default all GA cookie related consent to denied

### DIFF
--- a/UI/Pages/Cookies.cshtml.cs
+++ b/UI/Pages/Cookies.cshtml.cs
@@ -3,69 +3,71 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 
-namespace UI.Pages
+namespace UI.Pages;
+
+public class Cookies : PageModel
 {
-    public class Cookies : PageModel
+    public const string ConsentCookieName = ".FindATuitionPartner.Consent";
+
+    [BindProperty]
+    [Required(ErrorMessage = "You must select an option")]
+    public bool? Consent { get; set; }
+    [BindProperty(SupportsGet = true)]
+    public string? ReturnUrl { get; set; }
+    public bool PreferencesSet { get; set; }
+
+    public IActionResult OnGet(bool? consent, bool? preferencesSet)
     {
-        private const string ConsentCookieName = ".FindATuitionPartner.Consent";
-
-        [BindProperty]
-        [Required(ErrorMessage = "You must select an option")]
-        public bool? Consent { get; set; }
-        public bool PreferencesSet { get; set; } = false;
-
-        [BindProperty(SupportsGet = true)]
-        public string? ReturnUrl { get; set; }
-
-        public IActionResult OnGet(bool? consent)
+        Consent = consent;
+        if (preferencesSet.HasValue)
         {
-            Consent = consent;
-
-            if (Request.Cookies.ContainsKey(ConsentCookieName))
-            {
-                var value = Request.Cookies[ConsentCookieName];
-                if (value != null)
-                {
-                    Consent = bool.Parse(value);
-                }
-            }
-
-            if (consent.HasValue)
-            {
-                ApplyCookieConsent(consent);
-                if (!string.IsNullOrEmpty(ReturnUrl))
-                {
-                    return Redirect(ReturnUrl);
-                }
-            }
-            return Page();
+            PreferencesSet = preferencesSet.Value;
         }
 
-        public IActionResult OnPost()
+        if (Request.Cookies.ContainsKey(ConsentCookieName))
         {
-            if (!ModelState.IsValid) return Page();
-
-            PreferencesSet = true;
-            ApplyCookieConsent(Consent);
-
-            return Page();
+            var value = Request.Cookies[ConsentCookieName];
+            if (value != null)
+            {
+                Consent = bool.Parse(value);
+            }
         }
 
-        private void ApplyCookieConsent(bool? consent)
+        if (consent.HasValue)
         {
-            if (consent.HasValue)
+            ApplyCookieConsent(consent);
+            if (!string.IsNullOrEmpty(ReturnUrl))
             {
-                var cookieOptions = new CookieOptions { Expires = DateTime.Today.AddMonths(12), Secure = true };
-                Response.Cookies.Append(ConsentCookieName, consent.Value.ToString(), cookieOptions);
+                return Redirect(ReturnUrl);
+            }
+        }
 
-                if (!consent.Value)
+        return Page();
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid) return Page();
+
+        ApplyCookieConsent(Consent);
+
+        return RedirectToPage(new { returnUrl = ReturnUrl, preferencesSet = true });
+    }
+
+    private void ApplyCookieConsent(bool? consent)
+    {
+        if (consent.HasValue)
+        {
+            var cookieOptions = new CookieOptions { Expires = DateTime.Today.AddMonths(12), Secure = true };
+            Response.Cookies.Append(ConsentCookieName, consent.Value.ToString(), cookieOptions);
+
+            if (!consent.Value)
+            {
+                foreach (var cookie in Request.Cookies.Keys)
                 {
-                    foreach (var cookie in Request.Cookies.Keys)
+                    if (cookie.StartsWith("_ga") || cookie.Equals("_gid"))
                     {
-                        if (cookie.StartsWith("_ga") || cookie.Equals("_gid"))
-                        {
-                            Response.Cookies.Delete(cookie);
-                        }
+                        Response.Cookies.Delete(cookie);
                     }
                 }
             }

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -1,6 +1,6 @@
 ﻿@inject IHostEnvironment HostEnvironment
 @inject IConfiguration Configuration
-@inject Microsoft.AspNetCore.Http.IHttpContextAccessor httpcontext
+@inject IHttpContextAccessor HttpContext
 
 @{
 	// Only allow search engines to index pages on the production environment that have explicitly set AllowIndexing to true
@@ -8,9 +8,8 @@
 
 	var measurementId = Configuration["GoogleAnalytics:MeasurementId"];
 	var enableGoogleAnalytics = !string.IsNullOrWhiteSpace(measurementId);
-	var googleAnalyticsConsent = Convert.ToBoolean(httpcontext?.HttpContext?.Request.Cookies[".FindATuitionPartner.Consent"]);
-
-	enableGoogleAnalytics = enableGoogleAnalytics && googleAnalyticsConsent;
+    var requestCookie = HttpContext?.HttpContext?.Request.Cookies[Cookies.ConsentCookieName];
+    var googleAnalyticsConsent = Convert.ToBoolean(requestCookie);
 
 	var supportEmailAddress = "tutoring.support@service.education.gov.uk";
 }
@@ -46,6 +45,24 @@
     
     @if (enableGoogleAnalytics)
     {
+        @if (!googleAnalyticsConsent)
+        {
+            <script>
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+
+                gtag('consent', 'default', {
+                    'ad_storage': 'denied',
+                    'analytics_storage': 'denied',
+                    'functionality_storage': 'denied',
+                    'personalization_storage': 'denied',
+                    'security_storage': 'denied'
+                });
+
+                gtag('set', 'ads_data_redaction', true);
+            </script>
+        }
+
 	    <!-- Global site tag (gtag.js) - Google Analytics -->
 	    <script async src="https://www.googletagmanager.com/gtag/js?id=@measurementId"></script>
 	    <script>


### PR DESCRIPTION
## Context

Services similar to ours have reported that the rates for opting into Google Analytics cookies are low at around 25%. This makes extrapolating usage of the service potentially inaccurate.

GA has supported consent mode since 2020 allowing users to deny consent to the parts of GA that rely on cookies for session and advertising needs. This means it is possible for users to opt out of the _cookies_ used for full GA tracking but for us to still track basic usage of the side e.g. page titles, URLs, user agents etc.

We want to use consent mode during public beta to discover if these reduced metrics still provide the KPIs needed to evaluate the service. 

## Changes proposed in this pull request

No user visible changes. The key code changes are:

- Post -> redirect -> get implemented on the cookies page. The current implementation resulted in GA still being enabled for the post response but not subsequent pages. Now consent applies immediately and the deletion of the GA cookies works properly.
- GA is always enabled but if the user opt out of tracking cookies, all GA cookie related consent will default to denied

## Guidance to review

Run the service with the application tab in dev tools showing. See how opting in and out affects the cookies. Also use the network tab to see that GA calls are still being made regardless.

## Link to Jira ticket

(NTP-516)[https://dfedigital.atlassian.net/browse/NTP-516]

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [X] Test coverage of new code is at least 80%
- [X] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [X] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code