### PR TITLE
NTP-527: Move into public beta

### DIFF
--- a/UI/Pages/Index.cshtml
+++ b/UI/Pages/Index.cshtml
@@ -2,7 +2,7 @@
 @model Index
 @{
 	ViewData["Title"] = "Find a tuition partner";
-	ViewData["AllowIndexing"] = false;
+	ViewData["AllowIndexing"] = true;
 }
 
 <div class="govuk-grid-row">

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -116,7 +116,7 @@
 	<div class="govuk-phase-banner">
 		<p class="govuk-phase-banner__content" data-testid="phase-banner">
 			<strong class="govuk-tag govuk-phase-banner__content__tag">
-				private beta
+				beta
 			</strong>
 			<span class="govuk-phase-banner__text">
 				This is a new service – your <a href="https://forms.gle/44KfQyg1YUidrDCi7" target="_blank" class="govuk-link" data-testid="phase-banner-feedback-link">feedback</a> will help us to improve it.

--- a/UI/cypress/e2e/phase-banner.feature
+++ b/UI/cypress/e2e/phase-banner.feature
@@ -1,8 +1,8 @@
 Feature: Phase banner shows users service is still being worked on and feedback can help improve it
-  Scenario: phase banner state is 'private beta'
+  Scenario: phase banner state is 'beta'
     Given a user has started the 'Find a tuition partner' journey
     Then they will see the phase banner
-    And the current phase is 'private beta'
+    And the current phase is 'beta'
 
   Scenario: phase banner contains link to feedback form
     Given a user has started the 'Find a tuition partner' journey


### PR DESCRIPTION
## Context

We're scheduled to move into public beta on the 17th of August along with soft launching the service.

## Changes proposed in this pull request

* Re-enable indexing of the production start page
* Change the phase banner to beta

![image](https://user-images.githubusercontent.com/9396346/184597278-8798fd81-bf22-47b1-b0ef-afcfb9ca25ac.png)

![image](https://user-images.githubusercontent.com/9396346/184597328-69cc0ae4-bef2-4154-82e9-79e3c5075d62.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

(NTP-527)[https://dfedigital.atlassian.net/browse/NTP-527]

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80% - N/A
- [X] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [X] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code