### PR TITLE
NTP-513: Added html titles for error pages

### DIFF
--- a/UI/Pages/Error.cshtml
+++ b/UI/Pages/Error.cshtml
@@ -3,7 +3,14 @@
 
 @model ErrorModel
 @{
-    ViewData["Title"] = "Find a tuition partner";
+    @if (Model.Status == HttpStatusCode.NotFound)
+    {
+         ViewData["Title"] = "Page not found";
+    }
+    else
+    {
+         ViewData["Title"] = "Problem with the service";
+    }
 }
 
 <div class="govuk-width-container">

--- a/UI/cypress/e2e/error-handling.js
+++ b/UI/cypress/e2e/error-handling.js
@@ -8,4 +8,5 @@ When("a service page has not been found", () => {
 
 Then("the 'page not found' error page is displayed", () => {
     cy.get('[data-testid="error-page"').should('exist');
+    cy.get('head title').should('contain', 'Page not found')
 });


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Titles are needed for pages

## Changes proposed in this pull request

Added html titles for error page and added end to end test check for title for 'page not found'. No end to end test for 'problem with service' as the error cannot be created at this point to test

<!-- If there are UI changes, please include Before and After screenshots. -->

No

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-513


## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code