### PR TITLE
NTP-381:fixed the header class for funding and reporting page

### DIFF
--- a/UI/Pages/FundingAndReporting.cshtml
+++ b/UI/Pages/FundingAndReporting.cshtml
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
 		<a href="@Model.returnPath" data-testid="back-link" class="govuk-back-link">Back</a>
-		<h1 class="govuk-heading-xl" data-testid="funding-reporting-header">Funding and Reporting</h1>
+		<h1 class="govuk-heading-l" data-testid="funding-reporting-header">Funding and Reporting</h1>
 
 		<p class="govuk-body">Your school will get the following funding for each pupil premium-eligible pupil in a:
 		</p>


### PR DESCRIPTION
## Context

Header Class should be l rather than xl to be consists around the pages

## Changes proposed in this pull request


Before:
![image](https://user-images.githubusercontent.com/44170638/184604378-07ed6556-7912-4b83-8a7d-05690009f1fa.png)

After:
![image](https://user-images.githubusercontent.com/44170638/184604455-e090feb9-c5ee-4089-a37d-4cde1feb038f.png)

## Guidance to review

Header class should be L Not Xl
## Link to Jira ticket
https://dfedigital.atlassian.net/browse/NTP-381

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code