### PR TITLE
Ntp 425 log key events

### DIFF
--- a/Application/Handlers/SearchTuitionPartnerHandler.cs
+++ b/Application/Handlers/SearchTuitionPartnerHandler.cs
@@ -1,6 +1,5 @@
 ﻿using Application.Repositories;
 using Domain;
-using Domain.Constants;
 using Domain.Search;
 using Domain.Validators;
 using MediatR;
@@ -12,12 +11,10 @@ public class SearchTuitionPartnerHandler
 {
     public class CommandValidator : TuitionPartnerSearchRequestValidator<Command>
     {
-
     }
 
     public class Command : TuitionPartnerSearchRequest, IRequest<TuitionPartnerSearchResultsPage>
     {
-
     }
 
     public class Handler : IRequestHandler<Command, TuitionPartnerSearchResultsPage>

--- a/Infrastructure/Extensions/ServiceCollectionDecorationExtensions.cs
+++ b/Infrastructure/Extensions/ServiceCollectionDecorationExtensions.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Infrastructure.Extensions;
+
+public static class ServiceCollectionDecorationExtensions
+{
+    public static void Decorate<TInterface, TDecorator>(this IServiceCollection services)
+      where TInterface : class
+      where TDecorator : class, TInterface
+    {
+        var wrappedDescriptor = services.FirstOrDefault(
+          s => s.ServiceType == typeof(TInterface));
+
+        if (wrappedDescriptor == null)
+            throw new InvalidOperationException($"{typeof(TInterface).Name} is not registered");
+
+        var objectFactory = ActivatorUtilities.CreateFactory(
+          typeof(TDecorator),
+          new[] { typeof(TInterface) });
+
+        services.Replace(ServiceDescriptor.Describe(
+          typeof(TInterface),
+          s => (TInterface)objectFactory(s, new[] { s.CreateInstance(wrappedDescriptor) }),
+          wrappedDescriptor.Lifetime)
+        );
+    }
+
+    private static object CreateInstance(this IServiceProvider services, ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance != null)
+            return descriptor.ImplementationInstance;
+
+        if (descriptor.ImplementationFactory != null)
+            return descriptor.ImplementationFactory(services);
+
+        if (descriptor.ImplementationType != null)
+            return ActivatorUtilities.GetServiceOrCreateInstance(
+                services, descriptor.ImplementationType);
+
+        throw new InvalidOperationException($"{descriptor.ServiceType.Name} has no implementation");
+    }
+}

--- a/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Infrastructure.Configuration.GPaaS;
 using Infrastructure.Constants;
 using Infrastructure.Extraction;
 using Infrastructure.Factories;
+using Infrastructure.MetricLogging;
 using Infrastructure.Repositories;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
@@ -65,7 +66,6 @@ public static class ServiceCollectionExtensions
         {
             client.BaseAddress = new Uri("https://api.postcodes.io");
         });
-        services.Decorate<ILocationFilterService, LoggingLocationFilterService>();
 
         return services;
     }

--- a/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -65,6 +65,7 @@ public static class ServiceCollectionExtensions
         {
             client.BaseAddress = new Uri("https://api.postcodes.io");
         });
+        services.Decorate<ILocationFilterService, LoggingLocationFilterService>();
 
         return services;
     }

--- a/Infrastructure/Extensions/ServiceCollectionLoggingExtensions.cs
+++ b/Infrastructure/Extensions/ServiceCollectionLoggingExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Application;
+using Domain.Search;
+using Infrastructure.MetricLogging;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using static Application.Handlers.SearchTuitionPartnerHandler;
+
+namespace Infrastructure.Extensions;
+
+public static class ServiceCollectionLoggingExtensions
+{
+    public static IServiceCollection LogKeyMetrics(this IServiceCollection services)
+    {
+        services.Decorate<ILocationFilterService, LoggingLocationFilterService>();
+        services.AddScoped(
+            typeof(IPipelineBehavior<Command, TuitionPartnerSearchResultsPage>),
+            typeof(SearchTuitionPartnerHandlerLoggingBehaviour));
+        return services;
+    }
+}

--- a/Infrastructure/LoggingLocationFilterService.cs
+++ b/Infrastructure/LoggingLocationFilterService.cs
@@ -1,0 +1,42 @@
+﻿using System.Diagnostics;
+using Application;
+using Application.Extensions;
+using Domain;
+using Domain.Search;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure;
+
+public class LoggingLocationFilterService : ILocationFilterService
+{
+    private readonly ILocationFilterService _inner;
+    private readonly ILogger _logger;
+
+    public LoggingLocationFilterService(ILocationFilterService inner, ILogger<LoggingLocationFilterService> logger)
+        => (_inner, _logger) = (inner, logger);
+
+    public async Task<LocationFilterParameters?> GetLocationFilterParametersAsync(string postcode)
+    {
+        _logger.LogInformation("Searching for postcode {Postcode}", postcode);
+
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+        var result = await _inner.GetLocationFilterParametersAsync(postcode);
+        stopwatch.Stop();
+
+        switch (result.TryValidate())
+        {
+            case SuccessResult:
+                _logger.LogInformation("Searching for postcode {Postcode} found {LocalAuthorityCode} results in {time}ms",
+                    postcode, result?.LocalAuthorityCode, stopwatch.ElapsedMilliseconds);
+                break;
+
+            case ErrorResult e:
+                _logger.LogWarning("Could not find postcode {Postcode} in {time}ms - {reason}",
+                    postcode, stopwatch.ElapsedMilliseconds, e.GetType().Name);
+                break;
+        }
+
+        return result;
+    }
+}

--- a/Infrastructure/MetricLogging/LoggingLocationFilterService.cs
+++ b/Infrastructure/MetricLogging/LoggingLocationFilterService.cs
@@ -5,7 +5,7 @@ using Domain;
 using Domain.Search;
 using Microsoft.Extensions.Logging;
 
-namespace Infrastructure;
+namespace Infrastructure.MetricLogging;
 
 public class LoggingLocationFilterService : ILocationFilterService
 {

--- a/Infrastructure/MetricLogging/LoggingLocationFilterService.cs
+++ b/Infrastructure/MetricLogging/LoggingLocationFilterService.cs
@@ -27,12 +27,12 @@ public class LoggingLocationFilterService : ILocationFilterService
         switch (result.TryValidate())
         {
             case SuccessResult:
-                _logger.LogInformation("Searching for postcode {Postcode} found {LocalAuthorityCode} results in {time}ms",
-                    postcode, result?.LocalAuthorityCode, stopwatch.ElapsedMilliseconds);
+                _logger.LogInformation("Searching for postcode {Postcode} found {LocalAuthorityDistrictCode} results in {Elapsed}ms",
+                    postcode, result?.LocalAuthorityDistrictCode, stopwatch.ElapsedMilliseconds);
                 break;
 
             case ErrorResult e:
-                _logger.LogWarning("Could not find postcode {Postcode} in {time}ms - {reason}",
+                _logger.LogWarning("Could not find postcode {Postcode} in {Elapsed}ms - {Reason}",
                     postcode, stopwatch.ElapsedMilliseconds, e.GetType().Name);
                 break;
         }

--- a/Infrastructure/MetricLogging/SearchTuitionPartnerHandlerLoggingBehaviour.cs
+++ b/Infrastructure/MetricLogging/SearchTuitionPartnerHandlerLoggingBehaviour.cs
@@ -1,0 +1,41 @@
+﻿using System.Diagnostics;
+using Domain.Search;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using static Application.Handlers.SearchTuitionPartnerHandler;
+
+namespace Infrastructure.MetricLogging;
+
+public class SearchTuitionPartnerHandlerLoggingBehaviour
+    : IPipelineBehavior<Command, TuitionPartnerSearchResultsPage>
+{
+    private readonly ILogger _logger;
+
+    public SearchTuitionPartnerHandlerLoggingBehaviour(
+        ILogger<SearchTuitionPartnerHandlerLoggingBehaviour> logger)
+        => _logger = logger;
+
+    public async Task<TuitionPartnerSearchResultsPage> Handle(
+        Command request,
+        CancellationToken cancellationToken,
+        RequestHandlerDelegate<TuitionPartnerSearchResultsPage> next)
+    {
+        using var scope = _logger.BeginScope("SearchRequest", request);
+        _logger.LogInformation("Searching for tuition partners");
+
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+        var response = await next();
+        stopwatch.Stop();
+
+        var names = response.Results.Select(x => x.Name).ToList();
+        var logLevel = response.Count == 0 ? LogLevel.Warning : LogLevel.Information;
+        using (_logger.BeginScope("TuitionPartners", names))
+        {
+            _logger.Log(logLevel, "Found {Count} results in {time}ms",
+                response.Count, stopwatch.ElapsedMilliseconds);
+        }
+
+        return response;
+    }
+}

--- a/Infrastructure/MetricLogging/SearchTuitionPartnerHandlerLoggingBehaviour.cs
+++ b/Infrastructure/MetricLogging/SearchTuitionPartnerHandlerLoggingBehaviour.cs
@@ -20,7 +20,7 @@ public class SearchTuitionPartnerHandlerLoggingBehaviour
         CancellationToken cancellationToken,
         RequestHandlerDelegate<TuitionPartnerSearchResultsPage> next)
     {
-        using var scope = _logger.BeginScope("SearchRequest", request);
+        using var _ = _logger.BeginScope("{@Search}", request);
         _logger.LogInformation("Searching for tuition partners");
 
         var stopwatch = new Stopwatch();
@@ -30,10 +30,11 @@ public class SearchTuitionPartnerHandlerLoggingBehaviour
 
         var names = response.Results.Select(x => x.Name).ToList();
         var logLevel = response.Count == 0 ? LogLevel.Warning : LogLevel.Information;
-        using (_logger.BeginScope("TuitionPartners", names))
+
+        using (_logger.BeginScope("{@TuitionPartners}", names))
         {
             _logger.Log(logLevel, "Found {Count} results in {time}ms",
-                response.Count, stopwatch.ElapsedMilliseconds);
+                    response.Count, stopwatch.ElapsedMilliseconds);
         }
 
         return response;

--- a/Infrastructure/MetricLogging/SearchTuitionPartnerHandlerLoggingBehaviour.cs
+++ b/Infrastructure/MetricLogging/SearchTuitionPartnerHandlerLoggingBehaviour.cs
@@ -33,7 +33,7 @@ public class SearchTuitionPartnerHandlerLoggingBehaviour
 
         using (_logger.BeginScope("{@TuitionPartners}", names))
         {
-            _logger.Log(logLevel, "Found {Count} results in {time}ms",
+            _logger.Log(logLevel, "Found {Count} results in {Elapsed}ms",
                     response.Count, stopwatch.ElapsedMilliseconds);
         }
 

--- a/Tests/Utilities/SliceFixture.cs
+++ b/Tests/Utilities/SliceFixture.cs
@@ -4,7 +4,9 @@ using Infrastructure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NSubstitute;
 
 namespace Tests.Utilities;
@@ -49,6 +51,16 @@ public class SliceFixture : IAsyncLifetime
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
+            builder.UseEnvironment("Testing");
+
+            builder.ConfigureAppConfiguration(configure =>
+            {
+                configure.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                   {"AppLogging:TcpSinkUri", ""},
+                });
+            });
+
             builder.ConfigureTestServices(services =>
             {
                 services.Remove<DbContextOptions<NtpDbContext>>();

--- a/UI/Filters/ExceptionLoggingMiddleware.cs
+++ b/UI/Filters/ExceptionLoggingMiddleware.cs
@@ -1,0 +1,23 @@
+﻿namespace UI.Filters;
+
+public class ExceptionLoggingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger _logger;
+
+    public ExceptionLoggingMiddleware(RequestDelegate next, ILogger<ExceptionLoggingMiddleware> logger)
+        => (_next, _logger) = (next, logger);
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Unhandled exception in HTTP pipeline");
+            throw;
+        }
+    }
+}

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -40,6 +40,7 @@ builder.Services.AddNtpDbContext(builder.Configuration);
 builder.Services.AddLocationFilterService();
 builder.Services.AddRepositories();
 builder.Services.AddCqrs();
+builder.Services.LogKeyMetrics();
 
 builder.Services.AddMediatR(typeof(AssemblyReference));
 

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -80,6 +80,8 @@ builder.Host.AddLogging();
 
 var app = builder.Build();
 
+app.UseMiddleware<ExceptionLoggingMiddleware>();
+
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();


### PR DESCRIPTION
## Context

Log key events that will be used to generate metrics.

## Changes proposed in this pull request

We now log the postcode lookup, the search results and any uncaught exceptions.

Below is an example log when we process the search results ([view in Logit.io](https://kibana.logit.io/s/5a330412-9270-4c5b-ba07-0035bf55fe95/app/discover#/doc/8ac115c0-aac1-11e8-88ea-0383c11b333a/logstash-2022.08.12?id=ALbtk4IBuoNUndCWtFzS)).  Notice that we attach the search request to the log context so that the log line with the results also includes what was searched for.

```json
{
  "_source": {
    "message": "Found 41 results in 409ms",
    "tuitionPartners": [
      "Tuition Partner 1",
      "Tuition Partner 2",
      "Tuition Partner 3\t",
      "Tuition Partner 4\t",
    ],
    "@version": "1",
    "environmentName": "Development",
    "@timestamp": "2022-08-12T21:20:05.124Z",
    "sourceContext": "Infrastructure.MetricLogging.SearchTuitionPartnerHandlerLoggingBehaviour",
    "requestPath": "/search-results",
    "elapsed": 409,
    "actionName": "/SearchResults",
    "proxy_port": "13461",
    "search": {
      "OrderBy": "Random",
      "TuitionTypeId": null,
      "Direction": "Ascending",
      "SubjectIds": [
        1
      ],
      "_typeTag": "Command",
      "PageSize": 50,
      "Page": 0,
      "LocalAuthorityDistrictCode": "E07000220"
    },
    "actionId": "d245a5e2-b4af-483d-a34e-e6309aab7630",
    "timestamp": "2022-08-12T22:20:04.7159356+01:00",
    "requestId": "0HMJSL1KNDH91:00000005",
    "count": 41,
    "level": "Information"
  }
}
```

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

<!-- https://dfedigital.atlassian.net/browse/NTP-123 -->

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [x] Database migrations can be applied to the current codebase in main without causing exceptions
- [x] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code