### PR TITLE
NTP-389:Content change for privacy,funding page

### DIFF
--- a/UI/Pages/FundingAndReporting.cshtml
+++ b/UI/Pages/FundingAndReporting.cshtml
@@ -36,11 +36,7 @@
 		</p>
 		<h3 class="govuk-heading-m">Maximum tutoring rate per pupil per hour</h3>
 		<p class="govuk-body">
-			The Department for Education sets maximum rates per pupil per hour (also called pupil-hour). You can use
-			your funding at the full 60% as long as your rate does not exceed either:
-		</p>
-		<p class="govuk-body">
-			The maximum rate per pupil-hour which you can use your funding for at the full 60% is either:
+			The Department for Education sets maximum rates per pupil per hour (also called pupil-hour). The maximum rate per pupil-hour which you can use your funding for at the full 60% is either:
 		</p>
 		<ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
 			<li>£18 in a mainstream school </li>

--- a/UI/Pages/Privacy.cshtml
+++ b/UI/Pages/Privacy.cshtml
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <a href="/" data-testid="home-link" class="govuk-back-link">Home</a>
-        <h1 class="govuk-heading-xl" data-testid="privacy-header">Find a tuition partner Privacy Notice</h1>
+        <h1 class="govuk-heading-xl" data-testid="privacy-header">Find a tuition partner privacy notice</h1>
         <p class="govuk-body">This privacy notice explains how the Department for Education (DfE) uses (processes) any
             personal data you give to us, or any that we may collect about you. This privacy notice should be read
             alongside the <a

--- a/UI/cypress/e2e/privacy.js
+++ b/UI/cypress/e2e/privacy.js
@@ -5,7 +5,7 @@ Given("a user has arrived on the privacy page", () => {
 });
 
 Then("they will see the privacy notice header", () => {
-    cy.get('[data-testid="privacy-header"]').should('contain.text', "Find a tuition partner Privacy Notice")
+    cy.get('[data-testid="privacy-header"]').should('contain.text', "Find a tuition partner privacy notice")
 });
 
 Then("they will see personal information link", () => {


### PR DESCRIPTION
## Context

Change in main header for privacy page and content change in funding page

## Changes proposed in this pull request

Before:
![image](https://user-images.githubusercontent.com/44170638/184640005-a72cb48e-72ce-43da-97a1-c5d51eb4b8c0.png)
![image](https://user-images.githubusercontent.com/44170638/184640330-84b140ed-1780-472f-bf28-b9d4c0349455.png)

After:
![image](https://user-images.githubusercontent.com/44170638/184640447-46ab9607-cff0-4765-ac27-6d8cb73c7c3f.png)
![image](https://user-images.githubusercontent.com/44170638/184640487-91963abc-510d-4fc7-9f01-27f4549f3734.png)

## Guidance to review

Content should match as per comments made in the userstory
## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-381
https://dfedigital.atlassian.net/browse/NTP-389
## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code