### PR TITLE
NTP-459: Set correct left margin for search results postcode button

### DIFF
--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -60,14 +60,14 @@
 
 		<div class="govuk-grid-column-two-thirds">
 
-			<div class="govuk-form-group">
+			<div class="govuk-form-group app-form-group-inline">
 				<div asp-validation-group-for="Data.Postcode" data-testid="postcode">
 					<label asp-for="Data.Postcode" class="govuk-label govuk-label--s">
 						Enter your school's postcode
 					</label>
 					<span asp-validation-for="Data.Postcode" class="govuk-error-message"></span>
-					<input asp-for="Data.Postcode" class="govuk-input govuk-input--width-10" type="text">
-					<govuk-button type="submit" class="govuk-!-display-inline govuk-!-margin-0" data-testid="call-to-action">Search</govuk-button>
+					<input asp-for="Data.Postcode" class="govuk-input" type="text">
+					<govuk-button type="submit" data-testid="call-to-action">Search</govuk-button>
 				</div>
 			</div>
 

--- a/UI/src/sass/results-filter.scss
+++ b/UI/src/sass/results-filter.scss
@@ -6,3 +6,22 @@
 		background-color: govuk-colour('white');
 	}
 }
+
+.app-form-group-inline {
+	.govuk-button {
+		margin-top: govuk-spacing(3);
+	}
+
+	@include govuk-media-query($from: tablet) {
+		.govuk-input {
+			max-width: 20ex + 3ex;
+		}
+
+		.govuk-button {
+			display: inline !important;
+			margin-top: govuk-spacing(0);
+			margin-bottom: govuk-spacing(0);
+			margin-left: govuk-spacing(1);
+		}
+	}
+}


### PR DESCRIPTION
## Context

The gap between the postcode input box and search button on the search results screen was too narrow. Additionally the mobile view of this inline input element did not expand the input box appropriately.

## Changes proposed in this pull request

Before (desktop):

![image](https://user-images.githubusercontent.com/9396346/184659811-a1ca36f0-11b5-48b5-8f80-4e22f42b2afe.png)

Before (tablet and below):

![image](https://user-images.githubusercontent.com/9396346/184659909-8fb6cf63-58e3-47d1-bf1e-55658ca0de92.png)

After (desktop)

![image](https://user-images.githubusercontent.com/9396346/184660073-f1024fff-a19d-45fd-a61f-b583942b9d07.png)

After (tablet and below):

![image](https://user-images.githubusercontent.com/9396346/184660157-ecb9b029-0ca1-4468-bcd9-f552b5a9b574.png)

## Guidance to review

This is a foundational ticket for the search results mobile view.

## Link to Jira ticket

(NTP-459)[https://dfedigital.atlassian.net/browse/NTP-459]

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80% - N/A
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/) - N/A
- [X] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code