### PR TITLE
NTP-389:Header Class change from xl to l

### DIFF
--- a/UI/Pages/Privacy.cshtml
+++ b/UI/Pages/Privacy.cshtml
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <a href="/" data-testid="home-link" class="govuk-back-link">Home</a>
-        <h1 class="govuk-heading-xl" data-testid="privacy-header">Find a tuition partner privacy notice</h1>
+        <h1 class="govuk-heading-l" data-testid="privacy-header">Find a tuition partner privacy notice</h1>
         <p class="govuk-body">This privacy notice explains how the Department for Education (DfE) uses (processes) any
             personal data you give to us, or any that we may collect about you. This privacy notice should be read
             alongside the <a


### PR DESCRIPTION
## Context

added the correct header class

## Changes proposed in this pull request

Before:
![image](https://user-images.githubusercontent.com/44170638/184838589-5639cf16-6e6b-43b2-9021-9b6379e640f6.png)

After:
![image](https://user-images.githubusercontent.com/44170638/184838645-f2228695-adf5-4fc9-b95a-49f34f750e26.png)


## Guidance to review
Header class should be l

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-389

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code