### PR TITLE
NTP-528: resolve missing http security headers

### DIFF
--- a/UI/Pages/Cookies.cshtml
+++ b/UI/Pages/Cookies.cshtml
@@ -89,18 +89,13 @@
                     <td class="govuk-table__cell">Checks if you’ve signed in to / accessed the service before. This helps us count how many people use it.</td>
                     <td class="govuk-table__cell">24 hours</td>
                 </tr>
-                <tr>
-                    <td class="govuk-table__cell">_ga_&lt;container&#8209;id&gt;</td>
-                    <td class="govuk-table__cell">Checks if you’ve signed in to / accessed the service before. This helps us count how many people use it.</td>
-                    <td class="govuk-table__cell">2 years</td>
-                </tr>
             </tbody>
         </table>
         <h2 class="govuk-heading-m">Essential cookies</h2>
         <p class="govuk-body">
             These cookies need to be on to allow you to use this service. They don’t store your personal data. For more information read our <a asp-page="./Privacy" class="govuk-link" data-testid="privacy-policy-link">privacy policy</a>.
         </p>
-        <table class="govuk-table" >
+        <table class="govuk-table">
             <thead class="govuk-table__header">
                 <tr>
                     <th class="govuk-table__header">Name</th>
@@ -117,11 +112,6 @@
                 <tr>
                     <td class="govuk-table__cell">.FindATuitionPartner.Consent</td>
                     <td class="govuk-table__cell">Saves your cookie consent settings</td>
-                    <td class="govuk-table__cell">1 year</td>
-                </tr>
-                   <tr>
-                    <td class="govuk-table__cell">.FindATuitionPartner.Mvc.CookieTempDataProvider</td>
-                    <td class="govuk-table__cell">Stores your search parameters</td>
                     <td class="govuk-table__cell">1 year</td>
                 </tr>
             </tbody>

--- a/UI/Pages/Cookies.cshtml
+++ b/UI/Pages/Cookies.cshtml
@@ -89,13 +89,18 @@
                     <td class="govuk-table__cell">Checks if you’ve signed in to / accessed the service before. This helps us count how many people use it.</td>
                     <td class="govuk-table__cell">24 hours</td>
                 </tr>
+                <tr>
+                    <td class="govuk-table__cell">_ga_&lt;container&#8209;id&gt;</td>
+                    <td class="govuk-table__cell">Checks if you’ve signed in to / accessed the service before. This helps us count how many people use it.</td>
+                    <td class="govuk-table__cell">2 years</td>
+                </tr>
             </tbody>
         </table>
         <h2 class="govuk-heading-m">Essential cookies</h2>
         <p class="govuk-body">
             These cookies need to be on to allow you to use this service. They don’t store your personal data. For more information read our <a asp-page="./Privacy" class="govuk-link" data-testid="privacy-policy-link">privacy policy</a>.
         </p>
-        <table class="govuk-table">
+        <table class="govuk-table" >
             <thead class="govuk-table__header">
                 <tr>
                     <th class="govuk-table__header">Name</th>
@@ -112,6 +117,11 @@
                 <tr>
                     <td class="govuk-table__cell">.FindATuitionPartner.Consent</td>
                     <td class="govuk-table__cell">Saves your cookie consent settings</td>
+                    <td class="govuk-table__cell">1 year</td>
+                </tr>
+                   <tr>
+                    <td class="govuk-table__cell">.FindATuitionPartner.Mvc.CookieTempDataProvider</td>
+                    <td class="govuk-table__cell">Stores your search parameters</td>
                     <td class="govuk-table__cell">1 year</td>
                 </tr>
             </tbody>

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -126,7 +126,7 @@ app.Use(async (context, next) =>
 
     if (!context.Response.Headers.ContainsKey("Content-Security-Policy"))
     {
-        context.Response.Headers.Add("Content-Security-Policy", "base-uri 'self'; block - all - mixed - content; default - src 'self'; img - src data: https:; object-src 'none'; script - src 'self'; style - src 'self'; upgrade - insecure - requests; ");
+        context.Response.Headers.Add("Content-Security-Policy", "base-uri 'self'; block-all-mixed-content; default-src 'self'; img-src data: https:; object-src 'none'; script-src 'self'; style-src 'self'; upgrade-insecure-requests; ");
     }
 
     if (!context.Response.Headers.ContainsKey("X-XSS-Protection"))

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -117,6 +117,30 @@ app.MapControllers();
 
 app.MapRazorPages();
 
+app.Use(async (context, next) =>
+{
+    if (!context.Response.Headers.ContainsKey("X-Frame-Options"))
+    {
+        context.Response.Headers.Add("X-Frame-Options", "DENY");
+    }
+
+    if (!context.Response.Headers.ContainsKey("Content-Security-Policy"))
+    {
+        context.Response.Headers.Add("Content-Security-Policy", "base-uri 'self'; block - all - mixed - content; default - src 'self'; img - src data: https:; object-src 'none'; script - src 'self'; style - src 'self'; upgrade - insecure - requests; ");
+    }
+
+    if (!context.Response.Headers.ContainsKey("X-XSS-Protection"))
+    {
+        context.Response.Headers.Add("X-XSS-Protection", "0");
+    }
+    
+    if (!context.Response.Headers.ContainsKey("X-Content-Type-Options"))
+    {
+        context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
+    }
+    await next();
+});
+
 // Ensure all date and currency formatting is set to UK/GB
 var cultureInfo = new CultureInfo("en-GB");
 CultureInfo.DefaultThreadCurrentCulture = cultureInfo;

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -133,7 +133,7 @@ app.Use(async (context, next) =>
     {
         context.Response.Headers.Add("X-XSS-Protection", "0");
     }
-    
+
     if (!context.Response.Headers.ContainsKey("X-Content-Type-Options"))
     {
         context.Response.Headers.Add("X-Content-Type-Options", "nosniff");

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -7,6 +7,7 @@ using Infrastructure;
 using Infrastructure.Configuration;
 using Infrastructure.Extensions;
 using MediatR;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Serilog.Events;
 using UI.Filters;
@@ -76,6 +77,14 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Host.AddLogging();
+
+builder.Services.AddAntiforgery(options =>
+{
+    options.Cookie.Name = ".FindATuitionPartner.Antiforgery";
+});
+
+builder.Services.Configure<CookieTempDataProviderOptions>(options => options.Cookie.Name = ".FindATuitionPartner.Mvc.CookieTempDataProvider");
+
 
 var app = builder.Build();
 

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -7,7 +7,6 @@ using Infrastructure;
 using Infrastructure.Configuration;
 using Infrastructure.Extensions;
 using MediatR;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Serilog.Events;
 using UI.Filters;
@@ -77,14 +76,6 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Host.AddLogging();
-
-builder.Services.AddAntiforgery(options =>
-{
-    options.Cookie.Name = ".FindATuitionPartner.Antiforgery";
-});
-
-builder.Services.Configure<CookieTempDataProviderOptions>(options => options.Cookie.Name = ".FindATuitionPartner.Mvc.CookieTempDataProvider");
-
 
 var app = builder.Build();
 

--- a/UI/cypress/e2e/security-headers.feature
+++ b/UI/cypress/e2e/security-headers.feature
@@ -1,0 +1,16 @@
+Feature: Security headers
+    Scenario: Security header X-Frame-Options added to page
+        Given a user has started the 'Find a tuition partner' journey
+        Then header 'X-Frame-Options' is added to the displayed page
+
+    Scenario: Security header Content-Security-Policy added to page
+        Given a user has started the 'Find a tuition partner' journey
+        Then header 'Content-Security-Policy' is added to the displayed page
+
+    Scenario: Security header X-Xss-Protection added to page
+        Given a user has started the 'Find a tuition partner' journey
+        Then header 'X-XSS-Protection' is added to the displayed page
+
+    Scenario: Security header X-Content-Type-Options added to page
+        Given a user has started the 'Find a tuition partner' journey
+        Then header 'X-Content-Type-Options' is added to the displayed page

--- a/UI/cypress/e2e/security-headers.feature
+++ b/UI/cypress/e2e/security-headers.feature
@@ -7,7 +7,7 @@ Feature: Security headers
         Given a user has started the 'Find a tuition partner' journey
         Then header 'Content-Security-Policy' is added to the displayed page
 
-    Scenario: Security header X-Xss-Protection added to page
+    Scenario: Security header X-X-Protection added to page
         Given a user has started the 'Find a tuition partner' journey
         Then header 'X-XSS-Protection' is added to the displayed page
 

--- a/UI/cypress/e2e/security-headers.js
+++ b/UI/cypress/e2e/security-headers.js
@@ -1,0 +1,9 @@
+import {Then} from "@badeball/cypress-cucumber-preprocessor";
+
+Then("header {string} is added to the displayed page", (header) => {
+    cy.intercept('/which-subjects?Postcode=sk11eb&KeyStages=KeyStage1&KeyStages=KeyStage2&KeyStages=KeyStage3&KeyStages=KeyStage4', (req) => {
+      req.on('response', (res) => {
+              expect(res.headers).to.have.property(header) //assert Request header
+      })
+    })
+});


### PR DESCRIPTION
## Context

Security risks have been highlighted by the absence of security headers in the Assessment.

## Changes proposed in this pull request

Adding following security headers:
X-Frame-Options
Content-Security-Policy
X-XSS-Protection
X-Content-Type-Options

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-528

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code