### PR TITLE
NTP-389: footer privacy link text change

### DIFF
--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -147,7 +147,7 @@
 						<a asp-page="@nameof(Cookies)" asp-route-consent="" asp-route-returnUrl="@(Context.Request.Path + Context.Request.QueryString)" class="govuk-footer__link" data-testid="view-footer-cookies">Cookies</a>
 			        </li>
 			        <li class="govuk-footer__inline-list-item">
-				        <a asp-page="/Privacy" class="govuk-footer__link" data-testid="privacy-link">Privacy policy</a>
+				        <a asp-page="/Privacy" class="govuk-footer__link" data-testid="privacy-link">Privacy</a>
 			        </li>
 		        </ul>
 


### PR DESCRIPTION
## Context

Changed the text of privacy link in the footer to privacy

## Changes proposed in this pull request

Before:
![image](https://user-images.githubusercontent.com/44170638/184920801-68b9e0f1-c881-4a20-ab9e-dcdd94c0ca45.png)

After:
![image](https://user-images.githubusercontent.com/44170638/184921059-ff9cac0f-fbda-4e09-985b-bd926bcad137.png)


## Guidance to review

Name of the link is changed to Privacy

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-389

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code