### PR TITLE
NTP-381: Funding details content correction

### DIFF
--- a/UI/Pages/FundingAndReporting.cshtml
+++ b/UI/Pages/FundingAndReporting.cshtml
@@ -129,20 +129,20 @@
 			<section class="moj-ticket-panel__content moj-ticket-panel__content--blue" aria-label="Example 3 section 1">
                 <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Example 3</h4>
                 <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-                    <li>Your mainstream school has 67 pupil premium-eligible pupils which means your allocation is £9,514.</li>
-                    <li>You provide 1,340 pupil-hours of tutoring using your own staff at a cost of £20,100.</li>
+                    <li>Your mainstream school has 67 pupil premium-eligible pupils which means your allocation is £10,854.</li>
+                    <li>You provide 1,340 pupil-hours of tutoring using your own staff at a cost of £19,100.</li>
                     <li>You also use a tuition partner to provide 100 pupil-hours at a cost of £4,500</li>
                 </ul>
                 <ul class="govuk-list">
-                    <li><b>Total cost: </b>£24,600</li>
+                    <li><b>Total cost: </b>£23,600</li>
                     <li><b>Total pupil-hours: </b> 1,440</li>
-                    <li><b>Tutoring rate: </b> £17 per pupil per hour</li>
+                    <li><b>Tutoring rate: </b> £16.38 per pupil per hour</li>
                 </ul>
                 <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Funding result</h4>
                 <p class="govuk-body">
-                    Your hourly rate is below the £18 maximum, but 60% of the cost - £14,760 - is greater
-                    than your allocation so you’ll need to pay the shortfall (£5,246) as well as the remaining £9,840 (40%)
-                    from other funding. You’ll pay £15,086 in total.
+                    Your hourly rate is below the £18 maximum, but 60% of the cost - £14,610 - is greater
+                    than your allocation so you’ll need to pay the shortfall (£3,306) as well as the remaining £9,440 (40%)
+                    from other funding. You’ll pay £12,746 in total.
                 </p>
             </section>
 

--- a/UI/Pages/FundingAndReporting.cshtml
+++ b/UI/Pages/FundingAndReporting.cshtml
@@ -140,7 +140,7 @@
                 </ul>
                 <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Funding result</h4>
                 <p class="govuk-body">
-                    Your hourly rate is below the £18 maximum, but 60% of the cost - £14,610 - is greater
+                    Your hourly rate is below the £18 maximum, but 60% of the cost - £14,160 - is greater
                     than your allocation so you’ll need to pay the shortfall (£3,306) as well as the remaining £9,440 (40%)
                     from other funding. You’ll pay £12,746 in total.
                 </p>


### PR DESCRIPTION
## Changes proposed in this pull request

Fix the maths in the funding details example.

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-381?focusedCommentId=47595

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code