### PR TITLE
NTP-450: A page that intentionally throws an exception and shows the error page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,3 +410,5 @@ UI/cypress/screenshots
 # NCrunch 
 *.ncrunchsolution
 Tests/Tests.v3.ncrunchproject
+**/appsettings.Development.json
+

--- a/UI/Pages/TriggerError.cshtml
+++ b/UI/Pages/TriggerError.cshtml
@@ -1,0 +1,2 @@
+﻿@page
+@model UI.Pages.TriggerErrorModel

--- a/UI/Pages/TriggerError.cshtml.cs
+++ b/UI/Pages/TriggerError.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace UI.Pages;
+
+public class TriggerErrorModel : PageModel
+{
+    public void OnGet() => throw new InvalidOperationException("This exception is intentionally thrown");
+}


### PR DESCRIPTION
## Changes proposed in this pull request

http://localhost:7036/trigger-exception will throw and log exception and show the error page.

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-450

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code