### PR TITLE
NTP-534: fixed the bug related to Security vulnerability on cookies page

### DIFF
--- a/UI/Pages/Cookies.cshtml
+++ b/UI/Pages/Cookies.cshtml
@@ -11,7 +11,8 @@
 
         @if (Model.PreferencesSet)
         {
-            <div data-testid="success-banner" class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div data-testid="success-banner" class="govuk-notification-banner govuk-notification-banner--success"
+            role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
                 <div class="govuk-notification-banner__header">
                     <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
                         Success
@@ -19,14 +20,17 @@
                 </div>
                 <div class="govuk-notification-banner__content">
                     <p class="govuk-notification-banner__heading">
-                        You’ve set your cookie preferences. <a data-testid="view-previous-page-link" class="govuk-notification-banner__link" href="@Model.ReturnUrl">Go back to the page you were looking at</a>.
+                        You’ve set your cookie preferences. <a data-testid="view-previous-page-link"
+                        class="govuk-notification-banner__link" href="@Model.ReturnUrl">Go back to the page you were
+                            looking at</a>.
                     </p>
                 </div>
             </div>
         }
         <h1 class="govuk-heading-l">Cookies</h1>
         <p class="govuk-body">
-            We put small files known as ‘cookies’ onto your computer or mobile device when you use this service so we can:
+            We put small files known as ‘cookies’ onto your computer or mobile device when you use this service so we
+            can:
         </p>
         <ul class="govuk-list govuk-list--bullet">
             <li>measure how you use the service </li>
@@ -39,7 +43,9 @@
         <h1 class="govuk-heading-l">Analytics cookies to help improve this service</h1>
 
         <p class="govuk-body">
-            If you give permission, we use Google Analytics to measure how you use this service. This means we can update and improve it more effectively. We do not allow Google to use or share the data about how you use it.
+            If you give permission, we use Google Analytics to measure how you use this service. This means we can
+            update and improve it more effectively. We do not allow Google to use or share the data about how you use
+            it.
         </p>
 
         <p class="govuk-body">Google Analytics stores information about:</p>
@@ -56,15 +62,18 @@
             <li>what you enter into pages on this site</li>
         </ul>
 
-        <form method="post">
-
+        <form method="post" PostBackUrl="/cookies">
+            <input asp-for="ReturnUrl" value="@Model.ReturnUrl" hidden=true />
             <govuk-radios asp-for="Consent">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend>
-                        Do you agree to the Department for Education using Google Analytics to help improve the Find a tuition partner service?
+                        Do you agree to the Department for Education using Google Analytics to help improve the Find a
+                        tuition partner service?
                     </govuk-radios-fieldset-legend>
-                    <govuk-radios-item value="@true" data-testid="cookie-consent-accept">Yes, opt-in to analytics cookies</govuk-radios-item>
-                    <govuk-radios-item value="@false" data-testid="cookie-consent-deny">No, do not use cookies to track my website usage</govuk-radios-item>
+                    <govuk-radios-item value="@true" data-testid="cookie-consent-accept">Yes, opt-in to analytics
+                        cookies</govuk-radios-item>
+                    <govuk-radios-item value="@false" data-testid="cookie-consent-deny">No, do not use cookies to track
+                        my website usage</govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
             <govuk-button type="submit" data-testid="call-to-action">Save my choice</govuk-button>
@@ -81,26 +90,31 @@
             <tbody class="govuk-table__body">
                 <tr>
                     <td class="govuk-table__cell">_ga</td>
-                    <td class="govuk-table__cell">Checks if you’ve signed in to / accessed the service before. This helps us count how many people use it.</td>
+                    <td class="govuk-table__cell">Checks if you’ve signed in to / accessed the service before. This
+                        helps us count how many people use it.</td>
                     <td class="govuk-table__cell">Up to 2 years</td>
                 </tr>
                 <tr>
                     <td class="govuk-table__cell">_gid</td>
-                    <td class="govuk-table__cell">Checks if you’ve signed in to / accessed the service before. This helps us count how many people use it.</td>
+                    <td class="govuk-table__cell">Checks if you’ve signed in to / accessed the service before. This
+                        helps us count how many people use it.</td>
                     <td class="govuk-table__cell">24 hours</td>
                 </tr>
                 <tr>
                     <td class="govuk-table__cell">_ga_&lt;container&#8209;id&gt;</td>
-                    <td class="govuk-table__cell">Checks if you’ve signed in to / accessed the service before. This helps us count how many people use it.</td>
+                    <td class="govuk-table__cell">Checks if you’ve signed in to / accessed the service before. This
+                        helps us count how many people use it.</td>
                     <td class="govuk-table__cell">2 years</td>
                 </tr>
             </tbody>
         </table>
         <h2 class="govuk-heading-m">Essential cookies</h2>
         <p class="govuk-body">
-            These cookies need to be on to allow you to use this service. They don’t store your personal data. For more information read our <a asp-page="./Privacy" class="govuk-link" data-testid="privacy-policy-link">privacy policy</a>.
+            These cookies need to be on to allow you to use this service. They don’t store your personal data. For more
+            information read our <a asp-page="./Privacy" class="govuk-link" data-testid="privacy-policy-link">privacy
+                policy</a>.
         </p>
-        <table class="govuk-table" >
+        <table class="govuk-table">
             <thead class="govuk-table__header">
                 <tr>
                     <th class="govuk-table__header">Name</th>
@@ -111,7 +125,8 @@
             <tbody class="govuk-table__body">
                 <tr>
                     <td class="govuk-table__cell">.FindATuitionPartner.Antiforgery</td>
-                    <td class="govuk-table__cell">Stops someone tricking you into changing personal information on this website which they could use to exploit your identity</td>
+                    <td class="govuk-table__cell">Stops someone tricking you into changing personal information on this
+                        website which they could use to exploit your identity</td>
                     <td class="govuk-table__cell">When the browser is closed</td>
                 </tr>
                 <tr>
@@ -119,7 +134,7 @@
                     <td class="govuk-table__cell">Saves your cookie consent settings</td>
                     <td class="govuk-table__cell">1 year</td>
                 </tr>
-                   <tr>
+                <tr>
                     <td class="govuk-table__cell">.FindATuitionPartner.Mvc.CookieTempDataProvider</td>
                     <td class="govuk-table__cell">Stores your search parameters</td>
                     <td class="govuk-table__cell">When the browser is closed</td>

--- a/UI/Pages/Cookies.cshtml
+++ b/UI/Pages/Cookies.cshtml
@@ -62,7 +62,7 @@
             <li>what you enter into pages on this site</li>
         </ul>
 
-        <form method="post" PostBackUrl="/cookies">
+        <form method="post">
             <input asp-for="ReturnUrl" value="@Model.ReturnUrl" hidden=true />
             <govuk-radios asp-for="Consent">
                 <govuk-radios-fieldset>

--- a/UI/Pages/Cookies.cshtml.cs
+++ b/UI/Pages/Cookies.cshtml.cs
@@ -42,6 +42,10 @@ public class Cookies : PageModel
         if (consent.HasValue)
         {
             ApplyCookieConsent(consent);
+            if (!string.IsNullOrEmpty(ReturnUrl))
+            {
+                return Redirect(ReturnUrl);
+            }
         }
 
         return Page();
@@ -50,7 +54,6 @@ public class Cookies : PageModel
     public IActionResult OnPost()
     {
         if (!ModelState.IsValid) return Page();
-        ReturnUrl = ReturnUrl;
 
         if (!string.IsNullOrEmpty(ReturnUrl)) TempData.Set("ReturnUrl", ReturnUrl);
         ApplyCookieConsent(Consent);

--- a/UI/Pages/Cookies.cshtml.cs
+++ b/UI/Pages/Cookies.cshtml.cs
@@ -3,7 +3,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-
+using UI.Extensions;
 
 namespace UI.Pages;
 
@@ -24,9 +24,7 @@ public class Cookies : PageModel
         if (preferencesSet.HasValue)
         {
             PreferencesSet = preferencesSet.Value;
-            if (!string.IsNullOrEmpty(ReturnUrl) && IsBase64String(ReturnUrl))
-                ReturnUrl = Encoding.UTF8.GetString(Convert.FromBase64String(ReturnUrl));
-            if (!string.IsNullOrEmpty(ReturnUrl) && !IsBase64String(ReturnUrl)) ReturnUrl = null;
+            ReturnUrl = TempData.Peek<string>("ReturnUrl");
         }
         else
         {
@@ -52,12 +50,12 @@ public class Cookies : PageModel
     public IActionResult OnPost()
     {
         if (!ModelState.IsValid) return Page();
+        ReturnUrl = ReturnUrl;
 
-        if (!string.IsNullOrEmpty(ReturnUrl)) ReturnUrl = Convert.ToBase64String(Encoding.UTF8.GetBytes(ReturnUrl));
-
+        if (!string.IsNullOrEmpty(ReturnUrl)) TempData.Set("ReturnUrl", ReturnUrl);
         ApplyCookieConsent(Consent);
 
-        return RedirectToPage(new { preferencesSet = true, returnUrl = ReturnUrl, });
+        return RedirectToPage(new { preferencesSet = true });
     }
 
     private void ApplyCookieConsent(bool? consent)
@@ -78,11 +76,5 @@ public class Cookies : PageModel
                 }
             }
         }
-    }
-
-    private bool IsBase64String(string base64)
-    {
-        base64 = base64.Trim();
-        return (base64.Length % 4 == 0) && Regex.IsMatch(base64, @"^[a-zA-Z0-9\+/]*={0,3}$", RegexOptions.None);
     }
 }

--- a/UI/Pages/Cookies.cshtml.cs
+++ b/UI/Pages/Cookies.cshtml.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -23,7 +24,7 @@ public class Cookies : PageModel
         if (preferencesSet.HasValue)
         {
             PreferencesSet = preferencesSet.Value;
-            if (!string.IsNullOrEmpty(ReturnUrl)) ReturnUrl = Encoding.UTF8.GetString(Convert.FromBase64String(ReturnUrl));
+            if (!string.IsNullOrEmpty(ReturnUrl) && IsBase64String(ReturnUrl)) ReturnUrl = Encoding.UTF8.GetString(Convert.FromBase64String(ReturnUrl));
         }
         else
         {
@@ -75,5 +76,11 @@ public class Cookies : PageModel
                 }
             }
         }
+    }
+
+    private bool IsBase64String(string base64)
+    {
+        base64 = base64.Trim();
+        return (base64.Length % 4 == 0) && Regex.IsMatch(base64, @"^[a-zA-Z0-9\+/]*={0,3}$", RegexOptions.None);
     }
 }

--- a/UI/Pages/Cookies.cshtml.cs
+++ b/UI/Pages/Cookies.cshtml.cs
@@ -24,7 +24,9 @@ public class Cookies : PageModel
         if (preferencesSet.HasValue)
         {
             PreferencesSet = preferencesSet.Value;
-            if (!string.IsNullOrEmpty(ReturnUrl) && IsBase64String(ReturnUrl)) ReturnUrl = Encoding.UTF8.GetString(Convert.FromBase64String(ReturnUrl));
+            if (!string.IsNullOrEmpty(ReturnUrl) && IsBase64String(ReturnUrl))
+                ReturnUrl = Encoding.UTF8.GetString(Convert.FromBase64String(ReturnUrl));
+            if (!string.IsNullOrEmpty(ReturnUrl) && !IsBase64String(ReturnUrl)) ReturnUrl = null;
         }
         else
         {

--- a/UI/Pages/FundingAndReporting.cshtml
+++ b/UI/Pages/FundingAndReporting.cshtml
@@ -5,7 +5,7 @@
 }
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
-		<a href="@Model.returnPath" data-testid="back-link" class="govuk-back-link">Back</a>
+		<a href="@Model.ReturnPath" data-testid="back-link" class="govuk-back-link">Back</a>
 		<h1 class="govuk-heading-l" data-testid="funding-reporting-header">Funding and Reporting</h1>
 
 		<p class="govuk-body">Your school will get the following funding for each pupil premium-eligible pupil in a:

--- a/UI/Pages/FundingAndReporting.cshtml.cs
+++ b/UI/Pages/FundingAndReporting.cshtml.cs
@@ -5,19 +5,19 @@ namespace UI.Pages
 {
     public class FundingAndReporting : PageModel
     {
-        public string? returnPath { get; set; }
+        public string? ReturnPath { get; set; }
 
 
         public IActionResult OnGet()
         {
-            returnPath = Request.Headers["Referer"].ToString();
+            ReturnPath = Request.Headers["Referer"].ToString();
 
             return Page();
         }
 
         public IActionResult OnPost(string returnUrl)
         {
-            returnPath = Request.Headers["Referer"].ToString();
+            ReturnPath = Request.Headers["Referer"].ToString();
 
             return Page();
         }

--- a/UI/Pages/Shared/_CookiesOptionBanner.cshtml
+++ b/UI/Pages/Shared/_CookiesOptionBanner.cshtml
@@ -26,14 +26,14 @@
             </div>
 
             <div class="govuk-button-group">
-                <a data-testid="accept-cookies" value="accept" type="button" name="cookies" class="govuk-button" data-module="govuk-button" asp-page="@nameof(Cookies)" asp-route-consent="true" asp-route-returnUrl="@(Context.Request.Path + Context.Request.QueryString)">
+                <a data-testid="accept-cookies" value="accept" type="button" name="cookies" class="govuk-button" data-module="govuk-button" asp-page="@nameof(Cookies)" asp-route-consent="true">
                     Accept analytics cookies
 
                 </a>
-                <a button value="reject" data-testid="reject-cookies" type="button" name="cookies" class="govuk-button" data-module="govuk-button" asp-page="@nameof(Cookies)" asp-route-consent="false" asp-route-returnUrl="@(Context.Request.Path + Context.Request.QueryString)">           
+                <a button value="reject" data-testid="reject-cookies" type="button" name="cookies" class="govuk-button" data-module="govuk-button" asp-page="@nameof(Cookies)" asp-route-consent="false">           
                     Reject analytics cookies
                 </a>
-                <a class="govuk-link" data-testid="view-cookies" a asp-page="@nameof(Cookies)" asp-route-returnUrl="@(Context.Request.Path + Context.Request.QueryString)">View cookies</a>
+                <a class="govuk-link" data-testid="view-cookies" a asp-page="@nameof(Cookies)">View cookies</a>
             </div>
         </div>
     </div>

--- a/UI/Pages/Shared/_CookiesOptionBanner.cshtml
+++ b/UI/Pages/Shared/_CookiesOptionBanner.cshtml
@@ -3,7 +3,7 @@
     var hideBannner = ViewData["Hide Banner"]?.ToString();
     var cookiesPageDisplayed = false;
 
-    if(hideBannner != null)
+    if (hideBannner != null)
     {
         cookiesPageDisplayed = bool.Parse(hideBannner);
     }
@@ -11,7 +11,8 @@
 
 @if (showBanner && !cookiesPageDisplayed)
 {
-    <div data-testid="cookie-banner" class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on Find a tuition partner">
+    <div data-testid="cookie-banner" class="govuk-cookie-banner " data-nosnippet role="region"
+    aria-label="Cookies on Find a tuition partner">
         <div class="govuk-cookie-banner__message govuk-width-container">
 
             <div class="govuk-grid-row">
@@ -20,21 +21,24 @@
 
                     <div class="govuk-cookie-banner__content">
                         <p class="govuk-body">We use some essential cookies to make this service work.</p>
-                        <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements to it.</p>
+                        <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the
+                            service and make improvements to it.</p>
                     </div>
                 </div>
             </div>
 
             <div class="govuk-button-group">
-                <a data-testid="accept-cookies" value="accept" type="button" name="cookies" class="govuk-button" data-module="govuk-button" asp-page="@nameof(Cookies)" asp-route-consent="true">
+                <a data-testid="accept-cookies" value="accept" type="button" name="cookies" class="govuk-button"
+                data-module="govuk-button" asp-page="@nameof(Cookies)" asp-route-consent="true">
                     Accept analytics cookies
 
                 </a>
-                <a button value="reject" data-testid="reject-cookies" type="button" name="cookies" class="govuk-button" data-module="govuk-button" asp-page="@nameof(Cookies)" asp-route-consent="false">           
+                <a button value="reject" data-testid="reject-cookies" type="button" name="cookies" class="govuk-button"
+                data-module="govuk-button" asp-page="@nameof(Cookies)" asp-route-consent="false">
                     Reject analytics cookies
                 </a>
                 <a class="govuk-link" data-testid="view-cookies" a asp-page="@nameof(Cookies)">View cookies</a>
             </div>
         </div>
     </div>
-} 
+}

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -144,7 +144,7 @@
 				        <a asp-page="/Accessibility" class="govuk-footer__link" data-testid="accessibility-link">Accessibility</a>
 			        </li>
 			        <li class="govuk-footer__inline-list-item">
-						<a asp-page="@nameof(Cookies)" asp-route-consent="" asp-route-returnUrl="@(Context.Request.Path + Context.Request.QueryString)" class="govuk-footer__link" data-testid="view-footer-cookies">Cookies</a>
+						<a asp-page="@nameof(Cookies)" asp-route-consent=""  class="govuk-footer__link" data-testid="view-footer-cookies">Cookies</a>
 			        </li>
 			        <li class="govuk-footer__inline-list-item">
 				        <a asp-page="/Privacy" class="govuk-footer__link" data-testid="privacy-link">Privacy</a>

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -79,6 +79,17 @@ builder.Services.AddRazorPages(options =>
     {
         options.HtmlHelperOptions.ClientValidationEnabled = false;
     })
+    .AddMvcOptions(options =>
+    {
+        options.ModelBindingMessageProvider.SetAttemptedValueIsInvalidAccessor((x, y) => $"The value is invalid.");
+        options.ModelBindingMessageProvider.SetNonPropertyAttemptedValueIsInvalidAccessor(s => "The value is invalid.");
+        options.ModelBindingMessageProvider.SetValueIsInvalidAccessor(x => "The value is invalid.");
+        options.ModelBindingMessageProvider.SetValueMustNotBeNullAccessor(x => "The value is invalid.");
+        options.ModelBindingMessageProvider.SetMissingBindRequiredValueAccessor(x => "The value is invalid.");
+        options.ModelBindingMessageProvider.SetUnknownValueIsInvalidAccessor(x => "The value is invalid.");
+        options.ModelBindingMessageProvider.SetValueMustBeANumberAccessor(x => "The value is invalid.");
+        
+    })
     // Supports both data annotation based validation as well as more complex cross property validation using the fluent validation library
     .AddFluentValidation(options => options.RegisterValidatorsFromAssembly(typeof(AssemblyReference).Assembly));
 

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -88,7 +88,7 @@ builder.Services.AddRazorPages(options =>
         options.ModelBindingMessageProvider.SetMissingBindRequiredValueAccessor(x => "The value is invalid.");
         options.ModelBindingMessageProvider.SetUnknownValueIsInvalidAccessor(x => "The value is invalid.");
         options.ModelBindingMessageProvider.SetValueMustBeANumberAccessor(x => "The value is invalid.");
-        
+
     })
     // Supports both data annotation based validation as well as more complex cross property validation using the fluent validation library
     .AddFluentValidation(options => options.RegisterValidatorsFromAssembly(typeof(AssemblyReference).Assembly));

--- a/UI/cypress/e2e/cookies.feature
+++ b/UI/cypress/e2e/cookies.feature
@@ -102,3 +102,8 @@ Scenario: The cookie '.FindATuitionPartner.Mvc.CookieTempDataProvider' is added 
     Given the search result page is displayed
     Then cookie '.FindATuitionPartner.Mvc.CookieTempDataProvider' is added with value 'null'
 
+Scenario: User Select an Option from banner Should Stay on Same Page 
+   Given a user has arrived on the funding and reporting page
+   When cookies are accepted
+   And the user redirected to funding page
+

--- a/UI/cypress/e2e/cookies.feature
+++ b/UI/cypress/e2e/cookies.feature
@@ -102,8 +102,13 @@ Scenario: The cookie '.FindATuitionPartner.Mvc.CookieTempDataProvider' is added 
     Given the search result page is displayed
     Then cookie '.FindATuitionPartner.Mvc.CookieTempDataProvider' is added with value 'null'
 
-Scenario: User Select an Option from banner Should Stay on Same Page 
+Scenario: User Select Accept Option from banner Should Stay on Same Page 
    Given a user has arrived on the funding and reporting page
    When cookies are accepted
+   And the user redirected to funding page
+
+Scenario: User Select Reject Option from banner Should Stay on Same Page 
+   Given a user has arrived on the funding and reporting page
+   When cookies are rejected
    And the user redirected to funding page
 

--- a/UI/cypress/e2e/cookies.js
+++ b/UI/cypress/e2e/cookies.js
@@ -140,3 +140,12 @@ Then("cookie {string} is added with value {string}", (cookie, value) => {
   }
   
 });
+
+Given("a user has arrived on the funding and reporting page", () => {
+    cy.visit(`/funding-and-reporting`);
+});
+
+Then("the user redirected to funding page", () => {
+    cy.location('pathname').should('eq', '/funding-and-reporting');
+});
+


### PR DESCRIPTION
## Context

[OWASP Zed Attack Proxy](https://www.zaproxy.org/) tool has detected a potential vulnerability on the cookies page due to its use of query string parameters this pr should fix the issue 

## Changes proposed in this pull request

After:
![image](https://user-images.githubusercontent.com/44170638/185870752-77506f05-05f3-431b-982b-32312ab3f456.png)



## Guidance to review

when you run the following url https://localhost:7036/ locally with this branch in zap it should not throw the security vulnerability issues

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-534

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code