### PR TITLE
NTP-532: mobile views bullet points

### DIFF
--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -95,7 +95,7 @@
 									Subjects covered
 								</govuk-summary-list-row-key>
 								<govuk-summary-list-row-value>
-									<ul class="govuk-list govuk-body-s">
+									<ul class="govuk-list govuk-body-s govuk-list-bullets-mobile-view">
 									@foreach (var keyStageSubjects in item.Subjects.GroupBy(e => e.KeyStageId))
 									{
 										<li>@(((KeyStage)keyStageSubjects.Key).DisplayName()) - @keyStageSubjects.DisplayList()</li>

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -32,7 +32,7 @@
 					    Subjects covered
 				    </govuk-summary-list-row-key>
 				    <govuk-summary-list-row-value>
-					    <ul class="govuk-list">
+					    <ul class="govuk-list govuk-list-bullets-mobile-view">
 						    @foreach (var item in Model.Data.Subjects)
 						    {
 							    <li>@item</li>

--- a/UI/cypress/e2e/mobile.feature
+++ b/UI/cypress/e2e/mobile.feature
@@ -1,23 +1,21 @@
 Feature: Mobile view page tests
   
-    Scenario: Subject list is bullet pointed on search reaults page in mobile view
-        Given a user has started the 'Find a tuition partner' journey
+    Scenario: Subject list is bullet pointed on search reaults page in mobile phone view
+        Given a user has arrived on the 'Search results' page
             And a user is using a 'phone' 
-        When the search result page is displayed
         Then the subject list is bullet pointed
 
-    Scenario: Subject list is bullet pointed on tuition partner page in mobile view
-       Given a user has started the 'Find a tuition partner' journey
+    Scenario: Subject list is bullet pointed on tuition partner page in mobile phone view
+       Given a user has arrived on the 'Tuition Partner' page for 'bright-heart-education'
             And a user is using a 'phone' 
-        When a user has arrived on the 'Tuition Partner' page for 'bright-heart-education'
         Then the subject list is bullet pointed
 
-    Scenario: Subject list is not bullet pointed on search reaults page in non mobile view
-        Given a user has started the 'Find a tuition partner' journey 
-        When the search result page is displayed
+    Scenario: Subject list is not bullet pointed on search reaults page in tablet and above view
+         Given a user has arrived on the 'Search results' page
+            And a user is using a 'tablet' 
         Then the subject list is not bullet pointed
 
-    Scenario: Subject list is not bullet pointed on tuition partner page in non mobile view
-       Given a user has started the 'Find a tuition partner' journey
-        When a user has arrived on the 'Tuition Partner' page for 'bright-heart-education'
+    Scenario: Subject list is not bullet pointed on tuition partner page in tablet and above view
+       Given a user has arrived on the 'Tuition Partner' page for 'bright-heart-education'
+            And a user is using a 'tablet'
         Then the subject list is not bullet pointed

--- a/UI/cypress/e2e/mobile.feature
+++ b/UI/cypress/e2e/mobile.feature
@@ -1,0 +1,23 @@
+Feature: Mobile view page tests
+  
+    Scenario: Subject list is bullet pointed on search reaults page in mobile view
+        Given a user has started the 'Find a tuition partner' journey
+            And a user is using a 'phone' 
+        When the search result page is displayed
+        Then the subject list is bullet pointed
+
+    Scenario: Subject list is bullet pointed on tuition partner page in mobile view
+       Given a user has started the 'Find a tuition partner' journey
+            And a user is using a 'phone' 
+        When a user has arrived on the 'Tuition Partner' page for 'bright-heart-education'
+        Then the subject list is bullet pointed
+
+    Scenario: Subject list is not bullet pointed on search reaults page in non mobile view
+        Given a user has started the 'Find a tuition partner' journey 
+        When the search result page is displayed
+        Then the subject list is not bullet pointed
+
+    Scenario: Subject list is not bullet pointed on tuition partner page in non mobile view
+       Given a user has started the 'Find a tuition partner' journey
+        When a user has arrived on the 'Tuition Partner' page for 'bright-heart-education'
+        Then the subject list is not bullet pointed

--- a/UI/cypress/e2e/mobile.js
+++ b/UI/cypress/e2e/mobile.js
@@ -1,0 +1,39 @@
+import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
+
+Then("a user is using a {string}", (device) => {
+    cy.viewport(428, 926);
+});
+
+When("the search result page is displayed", () => {
+     cy.visit('/search-results?Postcode=sk11eb&Subjects=KeyStage1-English&Subjects=KeyStage1-Maths&Subjects=KeyStage1-Science&Subjects=KeyStage2-English&Subjects=KeyStage2-Maths&Subjects=KeyStage2-Science&Subjects=KeyStage3-English&Subjects=KeyStage3-Humanities&Subjects=KeyStage3-Maths&Subjects=KeyStage3-Modern%20foreign%20languages&Subjects=KeyStage3-Science&Subjects=KeyStage4-English&Subjects=KeyStage4-Humanities&Subjects=KeyStage4-Maths&Subjects=KeyStage4-Modern%20foreign%20languages&Subjects=KeyStage4-Science&KeyStages=KeyStage1&KeyStages=KeyStage2&KeyStages=KeyStage3&KeyStages=KeyStage4');
+});
+
+When("a tuition partner page is displayed", () => {
+    cy.visit("/tuition-partner/bright-heart-education");
+});
+
+Then("the subject list is bullet pointed", () => {
+    cy.get('.govuk-list-bullets-mobile-view').first()
+    .within(() => { 
+        cy.window().then((win) => {
+            cy.contains('li').then(($el) => {
+                const marker = win.getComputedStyle($el[0], '::marker')
+                const markerProperty = marker.getPropertyValue('list-style-type')
+                expect(markerProperty).to.equal('disc')
+            })
+        })
+    })
+}); 
+
+Then("the subject list is not bullet pointed", () => {
+    cy.get('.govuk-list-bullets-mobile-view').first()
+    .within(() => { 
+        cy.window().then((win) => {
+            cy.contains('li').then(($el) => {
+                const marker = win.getComputedStyle($el[0], '::marker')
+                const markerProperty = marker.getPropertyValue('list-style-type')
+                expect(markerProperty).to.equal('none')
+            })
+        })
+    })
+}); 

--- a/UI/cypress/e2e/mobile.js
+++ b/UI/cypress/e2e/mobile.js
@@ -1,15 +1,18 @@
 import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
 
 Then("a user is using a {string}", (device) => {
-    cy.viewport(428, 926);
-});
-
-When("the search result page is displayed", () => {
-     cy.visit('/search-results?Postcode=sk11eb&Subjects=KeyStage1-English&Subjects=KeyStage1-Maths&Subjects=KeyStage1-Science&Subjects=KeyStage2-English&Subjects=KeyStage2-Maths&Subjects=KeyStage2-Science&Subjects=KeyStage3-English&Subjects=KeyStage3-Humanities&Subjects=KeyStage3-Maths&Subjects=KeyStage3-Modern%20foreign%20languages&Subjects=KeyStage3-Science&Subjects=KeyStage4-English&Subjects=KeyStage4-Humanities&Subjects=KeyStage4-Maths&Subjects=KeyStage4-Modern%20foreign%20languages&Subjects=KeyStage4-Science&KeyStages=KeyStage1&KeyStages=KeyStage2&KeyStages=KeyStage3&KeyStages=KeyStage4');
-});
-
-When("a tuition partner page is displayed", () => {
-    cy.visit("/tuition-partner/bright-heart-education");
+   
+    if (device == 'phone'){
+        cy.viewport(321, 640);
+    }
+    else if (device == 'tablet')
+    {
+        cy.viewport(642, 1024);
+    }
+    else if (device == 'desktop')
+    {
+        cy.viewport(770, 1024);
+    }
 });
 
 Then("the subject list is bullet pointed", () => {

--- a/UI/src/index.scss
+++ b/UI/src/index.scss
@@ -33,3 +33,4 @@ $govuk-page-width: 1180px;
 @import "src/sass/options-card";
 @import "src/sass/option-select";
 @import "src/sass/results-filter";
+@import "src/sass/mobile-views";

--- a/UI/src/sass/mobile-views.scss
+++ b/UI/src/sass/mobile-views.scss
@@ -1,0 +1,7 @@
+﻿@media(max-width: 40.0625em) {
+
+    .govuk-list-bullets-mobile-view {
+        list-style-type: disc;
+        padding-left: 25px
+    }
+}

--- a/UI/src/sass/mobile-views.scss
+++ b/UI/src/sass/mobile-views.scss
@@ -1,7 +1,7 @@
-﻿@media(max-width: 40.0625em) {
+﻿@include govuk-media-query($until: tablet) {
 
     .govuk-list-bullets-mobile-view {
         list-style-type: disc;
-        padding-left: 25px
+        padding-left: govuk-spacing(5)
     }
 }


### PR DESCRIPTION
## Context

When viewing the application via a phone subjects need to be listed with bullet pointed

## Changes proposed in this pull request

Pages SearchResults and TuitionPartner have the subject list bullet pointed when viewing application via phone

## Guidance to review

**In desk top view**
![subjects with bullets bef](https://user-images.githubusercontent.com/33860585/186403123-22978215-0039-4fc2-9be7-00a4b7e2a8d0.png)

**In Mobile view**
![subjects with bullets aft](https://user-images.githubusercontent.com/33860585/186403296-a5c0b99a-d031-4f60-a33c-0a719bcea5f1.png)

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

Use tool on browser to emulate viewing via mobile views. 

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-532

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**