### PR TITLE
NTP-465: Use postcode for randomiser

### DIFF
--- a/Domain/Search/TuitionPartnerOrdering.cs
+++ b/Domain/Search/TuitionPartnerOrdering.cs
@@ -2,17 +2,17 @@
 
 public class TuitionPartnerOrdering
 {
-    private readonly TuitionPartnerSearchRequest request;
+    private readonly TuitionPartnerSearchRequest _request;
 
     public TuitionPartnerOrdering(TuitionPartnerSearchRequest searchRequest)
-        => request = searchRequest;
+        => _request = searchRequest;
 
     public IEnumerable<TuitionPartnerSearchResult> Order(List<TuitionPartnerSearchResult> results)
     {
-        switch (request.OrderBy)
+        switch (_request.OrderBy)
         {
             case TuitionPartnerOrderBy.Name:
-                return request.Direction == OrderByDirection.Descending
+                return _request.Direction == OrderByDirection.Descending
                     ? results.OrderByDescending(e => e.Name)
                     : results.OrderBy(e => e.Name);
 
@@ -28,8 +28,9 @@ public class TuitionPartnerOrdering
     public int RandomSeed()
     {
         return
-            (request.LocalAuthorityDistrictCode?.Sum(x => x) ?? 0)
-            + (request.SubjectIds?.Sum() ?? 0)
-            + (request.TuitionTypeId ?? 0);
+            (_request.LocalAuthorityDistrictCode?.Sum(x => x) ?? 0)
+            + (_request.Postcode?.Sum(x => x) ?? 0)
+            + (_request.SubjectIds?.Sum() ?? 0)
+            + (_request.TuitionTypeId ?? 0);
     }
 }

--- a/Domain/Search/TuitionPartnerSearchRequest.cs
+++ b/Domain/Search/TuitionPartnerSearchRequest.cs
@@ -5,6 +5,7 @@ namespace Domain.Search;
 public class TuitionPartnerSearchRequest : SearchRequestBase
 {
     public string? LocalAuthorityDistrictCode { get; set; }
+    public string? Postcode { get; set; }
     public IEnumerable<int>? SubjectIds { get; set; }
     public int? TuitionTypeId { get; set; }
     [DefaultValue(TuitionPartnerOrderBy.Random)]

--- a/Tests/RandomiseSearchResults.cs
+++ b/Tests/RandomiseSearchResults.cs
@@ -19,6 +19,13 @@ public class RandomiseSearchResults : IClassFixture<RandomiseSearchResultsFixtur
         new TuitionPartnerOrdering(search).RandomSeed().Should().Be('b' + 'o' + 'b');
     }
 
+    [Fact]
+    public void Postcode_randomness()
+    {
+        var search = new TuitionPartnerSearchRequest { Postcode = "ts1 10n" };
+        new TuitionPartnerOrdering(search).RandomSeed().Should().Be('t' + 's' + '1' + ' ' + '1' + '0' + 'n');
+    }
+
     [Theory]
     [InlineData(0, 0, 1, 1)]
     [InlineData(1, 2, 3, 6)]
@@ -42,11 +49,12 @@ public class RandomiseSearchResults : IClassFixture<RandomiseSearchResultsFixtur
         var search = new TuitionPartnerSearchRequest
         {
             LocalAuthorityDistrictCode = "ab12",
+            Postcode = "ts1 10n",
             SubjectIds = new[] { 5, 9, 22, 65 },
             TuitionTypeId = 5,
         };
         new TuitionPartnerOrdering(search).RandomSeed()
-            .Should().Be('a' + 'b' + '1' + '2' + 5 + 9 + 22 + 65 + 5);
+            .Should().Be('a' + 'b' + '1' + '2' + 't' + 's' + '1' + ' ' + '1' + '0' + 'n' + 5 + 9 + 22 + 65 + 5);
     }
 
     [Fact]

--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -156,6 +156,7 @@ public class SearchResults : PageModel
 
             var results = await FindSubjectsMatchingFilter(
                         location.Data.LocalAuthorityDistrictCode,
+                        location.Data.Postcode,
                         request,
                         cancellationToken);
 
@@ -180,7 +181,8 @@ public class SearchResults : PageModel
         }
 
         private async Task<TuitionPartnerSearchResultsPage> FindSubjectsMatchingFilter(
-            string? localAuthorityDisctict,
+            string? localAuthorityDistrict,
+            string? postcode,
             Query request,
             CancellationToken cancellationToken)
         {
@@ -193,7 +195,8 @@ public class SearchResults : PageModel
             return await mediator.Send(new SearchTuitionPartnerHandler.Command
             {
                 OrderBy = TuitionPartnerOrderBy.Random,
-                LocalAuthorityDistrictCode = localAuthorityDisctict,
+                LocalAuthorityDistrictCode = localAuthorityDistrict,
+                Postcode = postcode,
                 SubjectIds = subjects.Select(x => x.Id),
                 TuitionTypeId = request.TuitionType > 0 ? (int?)request.TuitionType : null,
             }, cancellationToken);


### PR DESCRIPTION
## Context

The current implementation of the search order randomiser uses only the LAD code as part of the random seed. This means that if two schools in the same LAD search with the same subject list, they will see the same ordering of TPs. This is considered a problem by the TPs.

## Changes proposed in this pull request

Add the postcode as part of the random seed generator to make every postcode's results order differently

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

[NTP-465](https://dfedigital.atlassian.net/browse/NTP-465)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [X] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/) - N/A
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off - N/A
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**