### PR TITLE
NTP-544: back from search results to key stage and continue clears subjects

### DIFF
--- a/UI/Pages/Index.cshtml
+++ b/UI/Pages/Index.cshtml
@@ -34,6 +34,25 @@
 				<govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>
 			</div>
 
+			@if (Model.Data.KeyStages != null)
+			{
+			    foreach (var KeyStage in Model.Data.KeyStages)
+			    {
+					<input type="hidden" id="@KeyStage" name="Data.KeyStages" value="@KeyStage" />
+				}
+			}
+			@if (Model.Data.Subjects != null)
+			{
+			    foreach (var subject in Model.Data.Subjects)
+			    {
+					<input type="hidden" id="@subject" name="Data.Subjects" value="@subject" />
+				}
+			}
+            @if (Model.Data.TuitionType.HasValue)
+            {
+                <input asp-for="Data.TuitionType" hidden/>
+            }
+
 			<h2 class="govuk-heading-m" data-testid="other-tutoring-options">Other tutoring options</h2>
 			<p class="govuk-body">You can use your National Tutoring Programme funding to mix and match tutoring options.</p>
 			<div class="govuk-grid-column-one-half govuk-!-padding-0">

--- a/UI/Pages/WhichKeyStages.cshtml
+++ b/UI/Pages/WhichKeyStages.cshtml
@@ -23,8 +23,22 @@
 			    <govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>
 		    </div>
 
-		    <input asp-for="Data.Postcode" hidden />
-		    <input asp-for="Data.Subjects" hidden />
+		    @if (Model.Data.Postcode != null)
+			{
+			    <input asp-for="Data.Postcode" hidden/>
+			}
+			@if (Model.Data.Subjects != null)
+			{
+			    foreach (var subject in Model.Data.Subjects)
+			    {
+					<input type="hidden" id="@subject" name="Data.Subjects" value="@subject" />
+				}
+			}
+            @if (Model.Data.TuitionType.HasValue)
+            {
+                <input asp-for="Data.TuitionType" hidden/>
+            }
+
 	    </form>
     </div>
 </div>

--- a/UI/cypress/e2e/subjects.js
+++ b/UI/cypress/e2e/subjects.js
@@ -23,24 +23,6 @@ When("they manually navigate to the 'Which subjects' page", () => {
     cy.visit("/which-subjects");
 });
 
-When("they select {string}", keystage => {
-    const stages = keystage.split(',').map(s => s.trim());
-    stages.forEach(element => {
-        cy.get(`input[id=${kebabCase(element)}]`).check();
-    });
-});
-
-Then("they will see all the keys stages as options", () => {
-    const keyStages = Object.keys(allSubjects)
-
-    cy.get('[data-testid="key-stage-name"]')
-        .should('have.length', keyStages.length);
-
-    cy.get('[data-testid="key-stage-name"]').each((item, index) => {
-        cy.wrap(item).should('contain.text', keyStages[index])
-    })
-});
-
 Then("they are shown all the subjects under all the keys stages", () => {
     Step(this, "they are shown the subjects for 'Key stage 1'")
     Step(this, "they are shown the subjects for 'Key stage 2'")

--- a/UI/cypress/e2e/tuition-partner-user-journey.feature
+++ b/UI/cypress/e2e/tuition-partner-user-journey.feature
@@ -2,16 +2,16 @@ Feature: User can travel forwards and backwards
 
 Scenario: User can move forward in the application to the end of the journey
    Given a user has started the 'Find a tuition partner' journey
-    Then they will be able journey forward to a selected tuition partner page
+    Then user has journeyed forward to a selected tuition partner page
 
 Scenario: User can travel back to the begining of journey
     Given a user has started the 'Find a tuition partner' journey
-        And they will be able journey forward to a selected tuition partner page
+        And user has journeyed forward to a selected tuition partner page
     Then they will be journey back to the page they started from
 
 Scenario: User can travel back to the beginning of journey without loss of data
     Given a user has started the 'Find a tuition partner' journey
-        And they will be able journey forward to a selected tuition partner page
+        And user has journeyed forward to a selected tuition partner page
         And they will be journey back to the page they started from
     Then the key stages are correct in the key stages page
         And the subjects are correct in the subjects page
@@ -19,7 +19,7 @@ Scenario: User can travel back to the beginning of journey without loss of data
 
 Scenario: User can travel back to the begining of journey and edit previous selections
     Given a user has started the 'Find a tuition partner' journey
-        And they will be able journey forward to a selected tuition partner page
+        And user has journeyed forward to a selected tuition partner page
         And they will be journey back to the page they started from
     When the postcode is edited in the start page
         And the key stages are edited in the key stages page

--- a/UI/cypress/e2e/tuition-partner-user-journey.feature
+++ b/UI/cypress/e2e/tuition-partner-user-journey.feature
@@ -16,3 +16,11 @@ Scenario: User can travel back to the beginning of journey without loss of data
     Then the key stages are correct in the key stages page
         And the subjects are correct in the subjects page
         And the filter selections are correct in the search results page
+
+Scenario: User can travel back to the begining of journey and edit previous selections
+    Given a user has started the 'Find a tuition partner' journey
+        And they will be able journey forward to a selected tuition partner page
+        And they will be journey back to the page the started from
+    When the key stages are edited in the key stages page
+        And the subjects are edited in the subjects page after key stage has been edited
+    Then the filter selections are correct in the search results page with the edited selections

--- a/UI/cypress/e2e/tuition-partner-user-journey.feature
+++ b/UI/cypress/e2e/tuition-partner-user-journey.feature
@@ -9,4 +9,10 @@ Scenario: User can travel back to the begining of journey
         And they will be able journey forward to a selected tuition partner page
     Then they will be journey back to the page the started from
 
-
+Scenario: User can travel back to the beginning of journey without loss of data
+    Given a user has started the 'Find a tuition partner' journey
+        And they will be able journey forward to a selected tuition partner page
+        And they will be journey back to the page the started from
+    Then the key stages are correct in the key stages page
+        And the subjects are correct in the subjects page
+        And the filter selections are correct in the search results page

--- a/UI/cypress/e2e/tuition-partner-user-journey.feature
+++ b/UI/cypress/e2e/tuition-partner-user-journey.feature
@@ -1,0 +1,12 @@
+Feature: User can travel forwards and backwards
+
+Scenario: User can move forward in the application to the end of the journey
+   Given a user has started the 'Find a tuition partner' journey
+    Then they will be able journey forward to a selected tuition partner page
+
+Scenario: User can travel back to the begining of journey
+    Given a user has started the 'Find a tuition partner' journey
+        And they will be able journey forward to a selected tuition partner page
+    Then they will be journey back to the page the started from
+
+

--- a/UI/cypress/e2e/tuition-partner-user-journey.feature
+++ b/UI/cypress/e2e/tuition-partner-user-journey.feature
@@ -7,12 +7,12 @@ Scenario: User can move forward in the application to the end of the journey
 Scenario: User can travel back to the begining of journey
     Given a user has started the 'Find a tuition partner' journey
         And they will be able journey forward to a selected tuition partner page
-    Then they will be journey back to the page the started from
+    Then they will be journey back to the page they started from
 
 Scenario: User can travel back to the beginning of journey without loss of data
     Given a user has started the 'Find a tuition partner' journey
         And they will be able journey forward to a selected tuition partner page
-        And they will be journey back to the page the started from
+        And they will be journey back to the page they started from
     Then the key stages are correct in the key stages page
         And the subjects are correct in the subjects page
         And the filter selections are correct in the search results page
@@ -20,7 +20,9 @@ Scenario: User can travel back to the beginning of journey without loss of data
 Scenario: User can travel back to the begining of journey and edit previous selections
     Given a user has started the 'Find a tuition partner' journey
         And they will be able journey forward to a selected tuition partner page
-        And they will be journey back to the page the started from
-    When the key stages are edited in the key stages page
+        And they will be journey back to the page they started from
+    When the postcode is edited in the start page
+        And the key stages are edited in the key stages page
         And the subjects are edited in the subjects page after key stage has been edited
+        And the tuition type is changed
     Then the filter selections are correct in the search results page with the edited selections

--- a/UI/cypress/e2e/tuition-partner-user-journey.js
+++ b/UI/cypress/e2e/tuition-partner-user-journey.js
@@ -20,7 +20,7 @@ When("the tuition type is changed", () => {
   cy.get(`input[id="in-school"]`).check();
 });
 
-Then("they will be able journey forward to a selected tuition partner page", () => {
+Then("user has journeyed forward to a selected tuition partner page", () => {
     Step(this, "they enter 'SK1 1EB' as the school's postcode");
     Step(this, "they click 'Continue'");
     Step(this, "they will be taken to the 'Which key stages' page");

--- a/UI/cypress/e2e/tuition-partner-user-journey.js
+++ b/UI/cypress/e2e/tuition-partner-user-journey.js
@@ -1,6 +1,17 @@
 import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
 import { kebabCase, camelCaseKeyStage, KeyStageSubjects } from "../support/utils";
 
+When("the key stages are edited in the key stages page", () => {
+  Step(this, "they click 'Continue'");
+  Step(this, "they select 'Key stage 1, Key stage 2, Key stage 3'");
+  Step(this, "they click 'Continue'");
+});
+
+When("the subjects are edited in the subjects page after key stage has been edited", () => {
+  Step(this, "they select 'Key stage 1 English, Key stage 1 Maths, Key stage 2 English, Key stage 2 Maths, Key stage 3 Science'");
+  Step(this, "they click 'Continue'");
+});
+
 Then("they will be able journey forward to a selected tuition partner page", () => {
     Step(this, "they enter 'SK1 1EB' as the school's postcode");
     Step(this, "they click 'Continue'");
@@ -18,13 +29,11 @@ Then("they will be able journey forward to a selected tuition partner page", () 
     Step(this, "the page's title is 'Tute Education'");
   });
 
-  Then("the filter section will be correctly displayed", () => {
-
+Then("the filter section will be correctly displayed", () => {
     const subjects = ['Key stage 1 English', 'Key stage 1 Maths', 'Key stage 2 English', 'Key stage 2 Maths'];
     subjects.forEach(element => {
         cy.get(`input[id=${kebabCase(element)}]`).check();
     });
-
     cy.get('[data-testid="postcode-input-box"]').should('have.value', 'SK1 1EB');
     cy.get(`input[id="any"]`).should('be.checked');
 });
@@ -69,5 +78,17 @@ Then("the filter selections are correct in the search results page", () => {
   Step(this, "they click 'Back'");
   Step(this, "stages 'Key stage 1, Key stage 2' are selected");
 });
+
+Then("the filter selections are correct in the search results page with the edited selections", () => {
+  const subjects = ['Key stage 1 English', 'Key stage 1 Maths', 'Key stage 2 English', 'Key stage 2 Maths', 'Key stage 3 Science'];
+  subjects.forEach(element => {
+      cy.get(`input[id=${kebabCase(element)}]`).check();
+  });
+  cy.get('[data-testid="postcode-input-box"]').should('have.value', 'SK1 1EB');
+  cy.get(`input[id="any"]`).should('be.checked');
+});
+
+
+
 
 

--- a/UI/cypress/e2e/tuition-partner-user-journey.js
+++ b/UI/cypress/e2e/tuition-partner-user-journey.js
@@ -2,7 +2,6 @@ import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor
 import { kebabCase, camelCaseKeyStage, KeyStageSubjects } from "../support/utils";
 
 When("the key stages are edited in the key stages page", () => {
-  Step(this, "they click 'Continue'");
   Step(this, "they select 'Key stage 1, Key stage 2, Key stage 3'");
   Step(this, "they click 'Continue'");
 });
@@ -10,6 +9,15 @@ When("the key stages are edited in the key stages page", () => {
 When("the subjects are edited in the subjects page after key stage has been edited", () => {
   Step(this, "they select 'Key stage 1 English, Key stage 1 Maths, Key stage 2 English, Key stage 2 Maths, Key stage 3 Science'");
   Step(this, "they click 'Continue'");
+});
+
+When("the postcode is edited in the start page", () => {
+  Step(this, "they enter 'YO11 1AA' as the school's postcode");
+  Step(this, "they click 'Continue'");
+});
+
+When("the tuition type is changed", () => {
+  cy.get(`input[id="in-school"]`).check();
 });
 
 Then("they will be able journey forward to a selected tuition partner page", () => {
@@ -38,7 +46,7 @@ Then("the filter section will be correctly displayed", () => {
     cy.get(`input[id="any"]`).should('be.checked');
 });
 
-Then("they will be journey back to the page the started from", () => {
+Then("they will be journey back to the page they started from", () => {
     Step(this, "they click 'Back'");
     Step(this, "they will be taken to the 'Search Results' page");
     Step(this, "they click 'Back'");
@@ -56,6 +64,7 @@ Then("starting the journey again the postcode is correct in the Find a tuition p
 Then("the key stages are correct in the key stages page", () => {
   Step(this, "they click 'Continue'");
   Step(this, "stages 'Key stage 1, Key stage 2' are selected");
+  Step(this, "stages 'Key stage 3, Key stage 4' are not selected");
   Step(this, "they click 'Continue'");
 });
 
@@ -67,10 +76,28 @@ Then("stages 'Key stage 1, Key stage 2' are selected", () => {
   });
 });
 
+Then("stages 'Key stage 3, Key stage 4' are not selected", () => {
+  
+  const subjects = ['Key stage 3', 'Key stage 4'];
+  subjects.forEach(element => {
+      cy.get(`input[id=${kebabCase(element)}]`).should('not.be.checked');
+  });
+});
+
 Then("the subjects are correct in the subjects page", () => {
-  const subjects = ['Key stage 1 English', 'Key stage 2 Maths','Key stage 2 English', 'Key stage 2 Maths'];
+  const subjects = ['Key stage 1 English', 'Key stage 1 Maths','Key stage 2 English', 'Key stage 2 Maths'];
   subjects.forEach(element => {
       cy.get(`input[id=${kebabCase(element)}]`).check();
+  });
+
+  const subjectsNotSelected = ['Key stage 1 Science', 'Key stage 2 Science'];
+  subjectsNotSelected.forEach(element => {
+      cy.get(`input[id=${kebabCase(element)}]`).should('not.be.checked');
+  });
+
+  const subjectsDoNotExist = ['Key stage 3 English', 'Key stage 3 Maths', 'Key stage 3 Science', 'Key stage 4 English', 'Key stage 4 Maths', 'Key stage 4 Science'];
+  subjectsDoNotExist.forEach(element => {
+      cy.get(`input[id=${kebabCase(element)}]`).should('not.exist');
   });
 });
 
@@ -84,8 +111,8 @@ Then("the filter selections are correct in the search results page with the edit
   subjects.forEach(element => {
       cy.get(`input[id=${kebabCase(element)}]`).check();
   });
-  cy.get('[data-testid="postcode-input-box"]').should('have.value', 'SK1 1EB');
-  cy.get(`input[id="any"]`).should('be.checked');
+  cy.get('[data-testid="postcode-input-box"]').should('have.value', 'YO11 1AA');
+  cy.get(`input[id="in-school"]`).should('be.checked');
 });
 
 

--- a/UI/cypress/e2e/tuition-partner-user-journey.js
+++ b/UI/cypress/e2e/tuition-partner-user-journey.js
@@ -44,11 +44,30 @@ Then("starting the journey again the postcode is correct in the Find a tuition p
   cy.get('[data-testid="postcode-input-box"]').should('have.value', 'SK1 1EB');
 });
 
-Then("And the key stages are correct in the key stages page", () => {
+Then("the key stages are correct in the key stages page", () => {
   Step(this, "they click 'Continue'");
   Step(this, "stages 'Key stage 1, Key stage 2' are selected");
   Step(this, "they click 'Continue'");
 });
 
+Then("stages 'Key stage 1, Key stage 2' are selected", () => {
   
+  const subjects = ['Key stage 1', 'Key stage 2'];
+  subjects.forEach(element => {
+      cy.get(`input[id=${kebabCase(element)}]`).check();
+  });
+});
+
+Then("the subjects are correct in the subjects page", () => {
+  const subjects = ['Key stage 1 English', 'Key stage 2 Maths','Key stage 2 English', 'Key stage 2 Maths'];
+  subjects.forEach(element => {
+      cy.get(`input[id=${kebabCase(element)}]`).check();
+  });
+});
+
+Then("the filter selections are correct in the search results page", () => {
+  Step(this, "they click 'Back'");
+  Step(this, "stages 'Key stage 1, Key stage 2' are selected");
+});
+
 

--- a/UI/cypress/e2e/tuition-partner-user-journey.js
+++ b/UI/cypress/e2e/tuition-partner-user-journey.js
@@ -1,0 +1,54 @@
+import { Given, When, Then, Step } from "@badeball/cypress-cucumber-preprocessor";
+import { kebabCase, camelCaseKeyStage, KeyStageSubjects } from "../support/utils";
+
+Then("they will be able journey forward to a selected tuition partner page", () => {
+    Step(this, "they enter 'SK1 1EB' as the school's postcode");
+    Step(this, "they click 'Continue'");
+    Step(this, "they will be taken to the 'Which key stages' page");
+    Step(this, "they will see all the keys stages as options");
+    Step(this, "they select 'Key stage 1, Key stage 2'");
+    Step(this, "they click 'Continue'");
+    Step(this, "they will be taken to the 'Which subjects' page");
+    Step(this, "they are shown the subjects for 'Key stage 1, Key stage 2'");
+    Step(this, "they select 'Key stage 1 English, Key stage 1 Maths, Key stage 2 English, Key stage 2 Maths'");
+    Step(this, "they click 'Continue'");
+    Step(this, "they will be taken to the 'Search Results' page");
+    Step(this, "the filter section will be correctly displayed");
+    Step(this, "they select the tuition partner 'Tute Education'");
+    Step(this, "the page's title is 'Tute Education'");
+  });
+
+  Then("the filter section will be correctly displayed", () => {
+
+    const subjects = ['Key stage 1 English', 'Key stage 1 Maths', 'Key stage 2 English', 'Key stage 2 Maths'];
+    subjects.forEach(element => {
+        cy.get(`input[id=${kebabCase(element)}]`).check();
+    });
+
+    cy.get('[data-testid="postcode-input-box"]').should('have.value', 'SK1 1EB');
+    cy.get(`input[id="any"]`).should('be.checked');
+});
+
+Then("they will be journey back to the page the started from", () => {
+    Step(this, "they click 'Back'");
+    Step(this, "they will be taken to the 'Search Results' page");
+    Step(this, "they click 'Back'");
+    Step(this, "they will be taken to the 'Which subjects' page");
+    Step(this, "they click 'Back'");
+    Step(this, "they will be taken to the 'Which key stages' page");
+    Step(this, "they click 'Back'");
+    Step(this, "the page's title is 'Find a tuition partner'");
+});
+
+Then("starting the journey again the postcode is correct in the Find a tuition partner page", () => {
+  cy.get('[data-testid="postcode-input-box"]').should('have.value', 'SK1 1EB');
+});
+
+Then("And the key stages are correct in the key stages page", () => {
+  Step(this, "they click 'Continue'");
+  Step(this, "stages 'Key stage 1, Key stage 2' are selected");
+  Step(this, "they click 'Continue'");
+});
+
+  
+

--- a/UI/cypress/support/step_definitions/pages.js
+++ b/UI/cypress/support/step_definitions/pages.js
@@ -24,6 +24,10 @@ Then("they will be taken to the 'Which subjects' page", () => {
     cy.location('pathname').should('eq', '/which-subjects');
 });
 
+Then("they will be taken to the 'Search Results' page", () => {
+    cy.location('pathname').should('eq', '/search-results');
+});
+
 Then("the page URL ends with {string}", url => {
     cy.location('pathname').should('match', new RegExp(`${url}$`));
 });

--- a/UI/cypress/support/step_definitions/subjects-page.js
+++ b/UI/cypress/support/step_definitions/subjects-page.js
@@ -8,6 +8,13 @@ export const allSubjects = {
     "Key stage 4": [ "English", "Humanities", "Maths", "Modern foreign languages", "Science"]
 }
 
+When("they select {string}", keystage => {
+    const stages = keystage.split(',').map(s => s.trim());
+    stages.forEach(element => {
+        cy.get(`input[id=${kebabCase(element)}]`).check();
+    });
+});
+
 Then("they are shown the subjects for {string}", keystage => {
     
     const stages = keystage.split(',').map(s => s.trim());
@@ -34,3 +41,15 @@ Then("they will see {string} selected", keystages => {
         cy.get(`input[id="${kebabCase(element)}"]`).should('be.checked');
     });
 });
+
+Then("they will see all the keys stages as options", () => {
+    const keyStages = Object.keys(allSubjects)
+
+    cy.get('[data-testid="key-stage-name"]')
+        .should('have.length', keyStages.length);
+
+    cy.get('[data-testid="key-stage-name"]').each((item, index) => {
+        cy.wrap(item).should('contain.text', keyStages[index])
+    })
+});
+


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Data selections are lost when navigating back along the application's journey

## Changes proposed in this pull request


## Guidance to review

Go back and forth along the Find a Tutor journey and make sure selections are maintained and edits work. 

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-544

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**