### PR TITLE
NTP-587: Update tutor training registration link

### DIFF
--- a/UI/Pages/AcademicMentors.cshtml
+++ b/UI/Pages/AcademicMentors.cshtml
@@ -35,7 +35,7 @@
 		</p>
 		<p class="govuk-body">
 			Use the Education Development Trust service to <a 
-				href="http://nominations.tutortraining.co.uk" target="_blank"
+				href="http://nominations.tutortraining.co.uk/registration" target="_blank"
 				class="govuk-link" data-testid="book-training">book training for tutors you employ directly</a>.
 		</p>
 		

--- a/UI/Pages/SchoolLedTutoring.cshtml
+++ b/UI/Pages/SchoolLedTutoring.cshtml
@@ -27,7 +27,7 @@
       Training can be tailored to meet the requirements of your pupils.
     </p>
     <p class="govuk-body">
-      Use the Education Development Trust service to <a href="http://nominations.tutortraining.co.uk" target="_blank" class="govuk-link">book training for tutors you employ directly</a>.
+      Use the Education Development Trust service to <a href="http://nominations.tutortraining.co.uk/registration" target="_blank" class="govuk-link">book training for tutors you employ directly</a>.
     </p>
     <h2 class="govuk-heading-l">What it costs
     </h2>

--- a/UI/cypress/e2e/academicmentors.js
+++ b/UI/cypress/e2e/academicmentors.js
@@ -9,7 +9,7 @@ Then("they will see the academic mentor header", () => {
 });
 
 Then("they will see the book training link", () => {
-    cy.get('[data-testid="book-training"]').should('have.attr', 'href', 'http://nominations.tutortraining.co.uk')
+    cy.get('[data-testid="book-training"]').should('have.attr', 'href', 'http://nominations.tutortraining.co.uk/registration')
 });
 
 Then("the book training link opens in a new window", () => {


### PR DESCRIPTION
## Changes proposed in this pull request

The Tutor Training link has changed.

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-587

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [x] Database migrations can be applied to the current codebase in main without causing exceptions
- [x] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**