### PR TITLE
NTP-567: type of tuition is blank when no postcode is specified

### DIFF
--- a/Infrastructure/Repositories/TuitionPartnerRepository.cs
+++ b/Infrastructure/Repositories/TuitionPartnerRepository.cs
@@ -38,7 +38,7 @@ public class TuitionPartnerRepository : ITuitionPartnerRepository
             {
                 result.TuitionTypes = entity.LocalAuthorityDistrictCoverage.Select(e => e.TuitionType).OrderByDescending(e => e.Id).Distinct().ToArray();
             }
-            else 
+            else
             {
                 result.TuitionTypes = _dbContext.LocalAuthorityDistrictCoverage.Select(e => e.TuitionType).OrderByDescending(e => e.Id).Distinct().ToArray();
             }

--- a/Infrastructure/Repositories/TuitionPartnerRepository.cs
+++ b/Infrastructure/Repositories/TuitionPartnerRepository.cs
@@ -2,6 +2,7 @@
 using Domain.Search;
 using Mapster;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
 
 namespace Infrastructure.Repositories;
 
@@ -21,11 +22,12 @@ public class TuitionPartnerRepository : ITuitionPartnerRepository
         CancellationToken cancellationToken = default)
     {
         var entities = await _dbContext.TuitionPartners.AsNoTracking()
-            .Include(e => e.LocalAuthorityDistrictCoverage.Where(lad => lad.LocalAuthorityDistrictId == localAuthorityDistrictId))
+            .IncludeTuitionForLocalDistrict(localAuthorityDistrictId)
             .ThenInclude(e => e.TuitionType)
             .Include(e => e.SubjectCoverage)
             .ThenInclude(e => e.Subject)
             .Where(e => ids.Distinct().Contains(e.Id))
+            .AsSplitQuery()
             .ToListAsync(cancellationToken);
 
         var results = new List<TuitionPartnerSearchResult>(entities.Count);
@@ -34,17 +36,21 @@ public class TuitionPartnerRepository : ITuitionPartnerRepository
             var result = entity.Adapt<TuitionPartnerSearchResult>();
             result.Subjects = entity.SubjectCoverage.OrderBy(e => e.Id).Select(e => e.Subject).Distinct().ToArray();
 
-            if (entity.LocalAuthorityDistrictCoverage.Count != 0)
-            {
-                result.TuitionTypes = entity.LocalAuthorityDistrictCoverage.Select(e => e.TuitionType).OrderByDescending(e => e.Id).Distinct().ToArray();
-            }
-            else
-            {
-                result.TuitionTypes = _dbContext.LocalAuthorityDistrictCoverage.Select(e => e.TuitionType).OrderByDescending(e => e.Id).Distinct().ToArray();
-            }
+            result.TuitionTypes = entity.LocalAuthorityDistrictCoverage.Select(e => e.TuitionType).OrderByDescending(e => e.Id).Distinct().ToArray();
 
             results.Add(result);
         }
         return ordering.Order(results);
+    }
+}
+
+public static class LocalAuthorityDistrictCoverageQueryExtension
+{
+    public static IIncludableQueryable<Domain.TuitionPartner, IEnumerable<Domain.LocalAuthorityDistrictCoverage>>
+    IncludeTuitionForLocalDistrict(this IQueryable<Domain.TuitionPartner> tuitionPartners, int? localAuthorityDistrictId)
+    {
+        return localAuthorityDistrictId == null
+            ? tuitionPartners.Include(e => e.LocalAuthorityDistrictCoverage)
+            : tuitionPartners.Include(e => e.LocalAuthorityDistrictCoverage.Where(lad => lad.LocalAuthorityDistrictId == localAuthorityDistrictId));
     }
 }

--- a/Infrastructure/Repositories/TuitionPartnerRepository.cs
+++ b/Infrastructure/Repositories/TuitionPartnerRepository.cs
@@ -21,8 +21,6 @@ public class TuitionPartnerRepository : ITuitionPartnerRepository
         CancellationToken cancellationToken = default)
     {
         var entities = await _dbContext.TuitionPartners.AsNoTracking()
-            .Include(e => e.LocalAuthorityDistrictCoverage.Where(lad => lad.LocalAuthorityDistrictId == localAuthorityDistrictId))
-            .ThenInclude(e => e.TuitionType)
             .Include(e => e.SubjectCoverage)
             .ThenInclude(e => e.Subject)
             .Where(e => ids.Distinct().Contains(e.Id))
@@ -32,14 +30,10 @@ public class TuitionPartnerRepository : ITuitionPartnerRepository
         foreach (var entity in entities)
         {
             var result = entity.Adapt<TuitionPartnerSearchResult>();
-
             result.Subjects = entity.SubjectCoverage.OrderBy(e => e.Id).Select(e => e.Subject).Distinct().ToArray();
-
-            result.TuitionTypes = entity.LocalAuthorityDistrictCoverage.Select(e => e.TuitionType).OrderByDescending(e => e.Id).Distinct().ToArray();
-
+            result.TuitionTypes = _dbContext.LocalAuthorityDistrictCoverage.Where(e => e.TuitionPartnerId == entity.Id).Select(e => e.TuitionType).OrderByDescending(e => e.Id).Distinct().ToArray();
             results.Add(result);
         }
-
         return ordering.Order(results);
     }
 }

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -95,7 +95,7 @@
 									Subjects covered
 								</govuk-summary-list-row-key>
 								<govuk-summary-list-row-value>
-									<ul class="govuk-list govuk-body-s govuk-list-bullets-mobile-view">
+									<ul class="govuk-list govuk-body-s govuk-list-bullets-mobile-view" data-testid="results-subjects">
 									@foreach (var keyStageSubjects in item.Subjects.GroupBy(e => e.KeyStageId))
 									{
 										<li>@(((KeyStage)keyStageSubjects.Key).DisplayName()) - @keyStageSubjects.DisplayList()</li>
@@ -107,7 +107,7 @@
 								<govuk-summary-list-row-key>
 									Type of tuition
 								</govuk-summary-list-row-key>
-								<govuk-summary-list-row-value>
+								<govuk-summary-list-row-value data-testid="type-of-tuition">
 									@string.Join(", ", item.TuitionTypes.Select(e => e.Name))
 								</govuk-summary-list-row-value>
 							</govuk-summary-list-row>
@@ -115,7 +115,7 @@
 								<govuk-summary-list-row-key>
 									Tuition partner information
 								</govuk-summary-list-row-key>
-								<govuk-summary-list-row-value>
+								<govuk-summary-list-row-value data-testid="results-description">
 									@item.Description
 								</govuk-summary-list-row-value>
 							</govuk-summary-list-row>

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -13,7 +13,7 @@
     <div class="govuk-grid-column-two-thirds">
 
         <h1 class="govuk-heading-l">@Model.Data.Name</h1>
-        <p class="govuk-body">@Model.Data.Description</p>
+        <p class="govuk-body" data-testid="results-description">@Model.Data.Description</p>
 
 		<govuk-details data-testid="qatp-details">
 			<govuk-details-summary>
@@ -32,7 +32,7 @@
 					    Subjects covered
 				    </govuk-summary-list-row-key>
 				    <govuk-summary-list-row-value>
-					    <ul class="govuk-list govuk-list-bullets-mobile-view">
+					    <ul class="govuk-list govuk-list-bullets-mobile-view" data-testid="results-subjects">
 						    @foreach (var item in Model.Data.Subjects)
 						    {
 							    <li>@item</li>

--- a/UI/cypress/e2e/results.feature
+++ b/UI/cypress/e2e/results.feature
@@ -133,8 +133,33 @@ Feature: User is shown search results
     When the ‘clear filters’ button as been selected
     Then the postcode search parameter remains
 
- Scenario: Results page  contact us back link redirects to right page
+  Scenario: Results page  contact us back link redirects to right page
     Given a user has arrived on the 'Search results' page for 'Key stage 2 Maths' for postcode 'HP4 3LG'
     Then they will click the contact us link
     When they click 'Back'
     Then they will see the results summary for 'Hertfordshire'
+
+  Scenario: Tuition partner details are displayed correctly when no postcode entered or filters selected on results page
+    Given a user has arrived on the 'Search results' page without subjects or postcode
+    When they enter '' as the school's postcode
+    Then all tuition partner parameters are populated correctly
+
+  Scenario: Tuition partner details are displayed correctly when postcode entered and no filters are selected on results page
+    Given a user has arrived on the 'Search results' page without subjects or postcode
+    When they enter 'SK1 1EB' as the school's postcode
+    Then all tuition partner parameters are populated correctly
+
+  Scenario: Tuition partner details are displayed correctly when postcode entered and filters are selected on results page
+    Given a user has arrived on the 'Search results' page without subjects or postcode
+    When they enter 'SK1 1EB' as the school's postcode
+      And 'Key stage 1 English' is selected
+    Then all tuition partner parameters are populated correctly
+
+  Scenario: Tuition partner details are displayed correctly after clear filters is selected on results page
+    Given a user has arrived on the 'Search results' page without subjects or postcode
+    When the ‘clear filters’ button as been selected
+    Then all tuition partner parameters are populated correctly
+
+  Scenario: Tuition partner details are displayed correctly when arriving on the results page
+    Given a user has arrived on the 'Search results' page
+    Then all tuition partner parameters are populated correctly

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -21,6 +21,11 @@ When("they clear all the filters", () => {
     cy.get('[type="checkbox"]').uncheck()
 })
 
+When("'Key stage 1 English' is selected", () => {
+    cy.get('[id="option-select-title-key-stage-1"]').click()
+    cy.get('[id="key-stage-1-english"]').check()
+})
+
 Then("the ‘clear filters’ button as been selected", () => {
     cy.get('[data-testid="clear-all-filters"]').click();
 });

--- a/UI/cypress/e2e/tuition-partner-details.feature
+++ b/UI/cypress/e2e/tuition-partner-details.feature
@@ -109,3 +109,7 @@ Feature: User can view full details of a Tuition Parner
   Scenario: subjects covered by a tuition partner are in alphabetical order in the 'search results' page
     Given a user has arrived on the 'Tuition Partner' page for 'bright-heart-education'
     Then the subjects covered by a tuition partner are in alphabetical order 
+
+  Scenario: Tuition partner details are displayed correctly when arriving on the results page
+     Given a user has arrived on the 'Tuition Partner' page for 'bright-heart-education'
+     Then all tuition partner parameters are populated correctly

--- a/UI/cypress/support/step_definitions/results-page.js
+++ b/UI/cypress/support/step_definitions/results-page.js
@@ -78,3 +78,9 @@ Then("they see the cost for tuition type {string}", tuitionTypes => {
     cy.get("[data-testid='pricing-table'] thead th")
         .should('have.length', tuitionArray.length + 1)
 })
+
+Then("all tuition partner parameters are populated correctly", () => {
+    cy.get('[data-testid="results-subjects"] > li:first').first().should('contain.text', 'Key');
+    cy.get('[data-testid="type-of-tuition"]').first().should('not.be.empty');
+    cy.get('[data-testid="results-description"]').first().should('not.be.empty');
+});


### PR DESCRIPTION
## Context

Tuition types are missing when searches are made without postcodes

## Changes proposed in this pull request

**Before:**

![Missing tuition type before](https://user-images.githubusercontent.com/33860585/187940723-b0e613dc-3ac6-49b6-81ec-d7c6b46f0fc6.png)

**After:**

![Missing tuition type after](https://user-images.githubusercontent.com/33860585/187940767-94766ed3-e1bd-474c-9dfc-9355e24a2936.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Query has been changed so testing of searches should be done with and without postcodes. 

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-567


## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**