### PR TITLE
NTP-423: Prevent errors when going back to pages submitted with invalid data

### DIFF
--- a/Tests/SearchForAPostcode.cs
+++ b/Tests/SearchForAPostcode.cs
@@ -90,8 +90,7 @@ public class SearchForAPostcode
 
         var result = await _fixture.GetPage<Index>().Execute(page =>
         {
-            page.Data.Postcode = postcode;
-            return page.OnPost();
+            return page.OnGetSubmit(new() { Postcode = postcode });
         });
 
         var redirect = result.Should().BeOfType<RedirectToPageResult>().Which;

--- a/Tests/SearchForKeyStages.cs
+++ b/Tests/SearchForKeyStages.cs
@@ -65,12 +65,14 @@ public class SearchForKeyStages : IAsyncLifetime
     {
         var result = await fixture.GetPage<WhichKeyStages>().Execute(page =>
         {
-            page.Data.Postcode = "AB00BA";
-            page.Data.Subjects = new[]
+            return page.OnGetSubmit(new WhichKeyStages.Command
             {
-                $"{KeyStage.KeyStage1}-English", $"{KeyStage.KeyStage1}-Humanities",
-            };
-            return page.OnPost();
+                Postcode = "AB00BA",
+                Subjects = new[]
+                {
+                    $"{KeyStage.KeyStage1}-English", $"{KeyStage.KeyStage1}-Humanities",
+                },
+            });
         });
 
         var resultPage = result.Should().BeAssignableTo<RedirectToPageResult>().Which;

--- a/Tests/SearchForSubjects.cs
+++ b/Tests/SearchForSubjects.cs
@@ -124,7 +124,7 @@ public class SearchForSubjects : CleanSliceFixture
                     $"{KeyStage.KeyStage1}-English", $"{KeyStage.KeyStage3}-Humanities",
                 }
             };
-            return page.OnPost(command);
+            return page.OnGetSubmit(command);
         });
 
         var resultPage = result.Should().BeAssignableTo<RedirectToPageResult>().Which;

--- a/UI/Pages/Index.cshtml
+++ b/UI/Pages/Index.cshtml
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <form method="post">
+        <form method="get">
             <h1 class="govuk-heading-l">Find a tuition partner</h1>
             <p class="govuk-body">
                 You can use your National Tutoring Programme funding to get a tuition partner, who will arrange tutoring for your pupils in school or online.
@@ -34,6 +34,7 @@
                 <govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>
             </div>
 
+            <input type="hidden" name="handler" value="Submit" />
             @if (Model.Data.KeyStages != null)
             {
                 foreach (var KeyStage in Model.Data.KeyStages)

--- a/UI/Pages/Index.cshtml.cs
+++ b/UI/Pages/Index.cshtml.cs
@@ -34,20 +34,21 @@ public partial class Index : PageModel
         return Page();
     }
 
-    public async Task<IActionResult> OnPost()
+    public async Task<IActionResult> OnGetSubmit(Command data)
     {
         if (!ModelState.IsValid) return Page();
 
-        var validation = await _mediator.Send(Data);
+        var validation = await _mediator.Send(data);
 
         if (validation.IsSuccess)
         {
-            return RedirectToPage(nameof(WhichKeyStages), Data);
+            return RedirectToPage(nameof(WhichKeyStages), data);
         }
 
         if (validation is ErrorResult error)
             ModelState.AddModelError("Data.Postcode", error.ToString());
 
+        Data = data;
         return Page();
     }
 

--- a/UI/Pages/WhichKeyStages.cshtml
+++ b/UI/Pages/WhichKeyStages.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model WhichKeyStages
 @{
     ViewData["Title"] = "Which key stages do you need tutoring support for?";
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <form method="post">
+        <form method="get">
             <h1 class="govuk-heading-l">Which key stages do you need tutoring support for?</h1>
             <p class="govuk-body">Select all of the key stages that apply</p>
 
@@ -23,6 +23,7 @@
                 <govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>
             </div>
 
+            <input type="hidden" name="handler" value="Submit" />
             @if (Model.Data.Postcode != null)
             {
                 <input asp-for="Data.Postcode" hidden />

--- a/UI/Pages/WhichKeyStages.cshtml.cs
+++ b/UI/Pages/WhichKeyStages.cshtml.cs
@@ -11,8 +11,22 @@ namespace UI.Pages
 
         public WhichKeyStages(IMediator mediator) => this.mediator = mediator;
 
-        [BindProperty]
         public Command Data { get; set; } = new();
+
+        public async Task OnGet(Query query) => Data = await mediator.Send(query);
+
+        public async Task<IActionResult> OnGetSubmit(Command data)
+        {
+            if (ModelState.IsValid)
+            {
+                return RedirectToPage(nameof(WhichSubjects), new SearchModel(data));
+            }
+            else
+            {
+                Data = await mediator.Send(new Query(data));
+                return Page();
+            }
+        }
 
         public record Query : SearchModel, IRequest<Command>
         {
@@ -20,26 +34,11 @@ namespace UI.Pages
             public Query(SearchModel query) : base(query) { }
         }
 
-        public async Task OnGet(Query query)
-        {
-            Data = await mediator.Send(query);
-        }
-
         public record Command : SearchModel, IRequest<SearchModel>
         {
             public Command() { }
             public Command(SearchModel query) : base(query) { }
             public Selectable<KeyStage>[] AllKeyStages { get; set; } = Array.Empty<Selectable<KeyStage>>();
-        }
-
-        public async Task<IActionResult> OnPost()
-        {
-            if (!ModelState.IsValid)
-            {
-                Data = await mediator.Send(new Query(Data));
-                return Page();
-            }
-            return RedirectToPage(nameof(WhichSubjects), new SearchModel(Data));
         }
 
         public class Validator : AbstractValidator<Command>
@@ -54,7 +53,7 @@ namespace UI.Pages
 
         public class Handler : IRequestHandler<Query, Command>
         {
-            static readonly IEnumerable<KeyStage> AllKeyStages = new KeyStage[]
+            private static readonly IEnumerable<KeyStage> AllKeyStages = new KeyStage[]
             {
                 KeyStage.KeyStage1, KeyStage.KeyStage2, KeyStage.KeyStage3, KeyStage.KeyStage4
             };

--- a/UI/Pages/WhichSubjects.cshtml
+++ b/UI/Pages/WhichSubjects.cshtml
@@ -4,25 +4,25 @@
     ViewData["Title"] = "Which subjects do you need tutoring support for?";
 }
 
-<a href="/which-key-stages?@Model.AllSearchParams.ToQueryString()" class="govuk-back-link">Back</a>
+<a href="/which-key-stages?@Model.Data.ToQueryString()" class="govuk-back-link">Back</a>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <govuk-error-summary>
-            <govuk-error-summary-item asp-for="Subjects" />
+            <govuk-error-summary-item asp-for="Data.Subjects" />
         </govuk-error-summary>
 
-        <form method="post" gfa-prepend-error-summary="false">
+        <form method="get" gfa-prepend-error-summary="false">
             <h1 class="govuk-heading-l">Which subjects do you need tutoring support for?</h1>
             <p class="govuk-body">Select all of the subjects that apply</p>
 
-            @foreach (var item in Model.Subjects.Keys)
+            @foreach (var item in Model.Data.AllSubjects.Keys)
             {
                 <div data-testid="@(item)-subjects">
                     <h2 class="govuk-heading-m">@item.DisplayName() subjects</h2>
 
-                    <govuk-checkboxes asp-for="Subjects">
-                        @foreach (var subject in Model.Subjects[item].OrderBy(x => x.Name))
+                    <govuk-checkboxes asp-for="Data.Subjects">
+                        @foreach (var subject in Model.Data.AllSubjects[item].OrderBy(x => x.Name))
                         {
                             var value = $"{item}-{subject.Name}";
                             <govuk-checkboxes-item id="@value.ToSeoUrl()" value="@value" checked="@subject.Selected" data-testid="subject-name">@subject.Name</govuk-checkboxes-item>
@@ -31,6 +31,22 @@
                 </div>
             }
 
+            <input type="hidden" name="handler" value="Submit" />
+            @if (Model.Data.Postcode != null)
+            {
+                <input asp-for="Data.Postcode" hidden />
+            }
+            @if (Model.Data.KeyStages != null)
+            {
+                foreach (var subject in Model.Data.KeyStages)
+                {
+                    <input type="hidden" id="@subject" name="Data.KeyStages" value="@subject" />
+                }
+            }
+            @if (Model.Data.TuitionType.HasValue)
+            {
+                <input asp-for="Data.TuitionType" hidden />
+            }
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>
             </div>

--- a/UI/Pages/WhichSubjects.cshtml.cs
+++ b/UI/Pages/WhichSubjects.cshtml.cs
@@ -13,21 +13,24 @@ public class WhichSubjects : PageModel
 
     public WhichSubjects(IMediator mediator) => this.mediator = mediator;
 
-    public KeyStageSubjectDictionary Subjects { get; set; } = new();
+    public Command Data { get; set; } = new();
 
     public async Task OnGet(Query query)
     {
-        Subjects = await mediator.Send(query);
+        Data = new Command(query)
+        {
+            AllSubjects = await mediator.Send(query)
+        };
     }
 
-    [BindProperty(SupportsGet = true)]
-    public SearchModel AllSearchParams { get; set; }
-
-    public async Task<IActionResult> OnPost(Command data)
+    public async Task<IActionResult> OnGetSubmit(Command data)
     {
         if (!ModelState.IsValid)
         {
-            Subjects = await mediator.Send(new Query(data));
+            Data = data with
+            {
+                AllSubjects = await mediator.Send(new Query(data))
+            };
             return Page();
         }
         return RedirectToPage("SearchResults", new SearchModel(data));
@@ -41,6 +44,9 @@ public class WhichSubjects : PageModel
 
     public record Command : SearchModel, IRequest<SearchModel>
     {
+        public Command() { }
+        public Command(SearchModel query) : base(query) { }
+
         public KeyStageSubjectDictionary AllSubjects { get; set; } = new();
     }
 

--- a/UI/cypress/e2e/cookies.feature
+++ b/UI/cypress/e2e/cookies.feature
@@ -94,10 +94,6 @@ Feature: User handles cookies
     When Saves Changes
     Then the error banner is displayed
 
-  Scenario: The cookie '.FindATuitionPartner.Antiforgery' is added when a user has started the 'Find a tuition partner' journey
-    Given a user has started the 'Find a tuition partner' journey
-    Then cookie '.FindATuitionPartner.Antiforgery' is added with value 'null'
-
   Scenario: The cookie '.FindATuitionPartner.Mvc.CookieTempDataProvider' is added when a user has reached the search page
     Given the search result page is displayed
     Then cookie '.FindATuitionPartner.Mvc.CookieTempDataProvider' is added with value 'null'


### PR DESCRIPTION
## Changes proposed in this pull request

All search pages now submit their forms by GET so there is no longer a Resubmit Post question by the browser.

Using the browser's back button will simply show the cached version of the previous page.  When this page was originally showing an error due to invalid submission, this error will again be shown.

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-423

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [x] Database migrations can be applied to the current codebase in main without causing exceptions
- [x] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**