### PR TITLE
NTP-583: Added link for cognition registration and ends to end test f…

### DIFF
--- a/UI/Pages/AcademicMentors.cshtml
+++ b/UI/Pages/AcademicMentors.cshtml
@@ -16,9 +16,8 @@
 			There are 2 ways to find an academic mentor.
 		</p>
 		<ol class="govuk-list govuk-list--number govuk-!-margin-left-4">
-			<li>Register with a central provider to be matched with a suitable academic mentor (the registration site
-				will be available soon). They’re likely to be a recent graduate, a school leaver taking a gap year, or
-				someone considering a career in teaching or education.
+			<li><a href="https://www.ntpacademicmentors.co.uk/schools/register-your-school" target="_blank" class="govuk-link" data-testid="cognition-registration-link">Register with Cognition</a>, the central provider, to be matched with a suitable academic mentor. 
+				They’re likely to be a recent graduate, a school leaver taking a gap year, or someone considering a career in teaching or education.
 			</li>
 			<li>Select and appoint someone directly.</li>
 		</ol>

--- a/UI/cypress/e2e/academicmentors.feature
+++ b/UI/cypress/e2e/academicmentors.feature
@@ -44,3 +44,8 @@
     Then they will see the funding reporting header
     And  they will click the back link
     Then they redirects to academic mentors page
+
+  Scenario: page has link register with cognition
+    Given a user has arrived on the academic mentors page
+    Then they will see the ‘register with cognition’ link
+    And the ‘register with cognition’ link opens in a new window

--- a/UI/cypress/e2e/academicmentors.js
+++ b/UI/cypress/e2e/academicmentors.js
@@ -4,6 +4,10 @@ Given("a user has arrived on the academic mentors page", () => {
     cy.visit(`/academic-mentors`);
 });
 
+When("they click funding and reporting link", () => {
+    cy.get('[data-testid="funding-reporting-link"]').click();
+});
+
 Then("they will see the academic mentor header", () => {
     cy.get('[data-testid="academic-mentors-header"]').should('contain.text', "Employ an academic mentor")
 });
@@ -37,10 +41,6 @@ Then("they will see the funding and reporting link", () => {
     cy.get('[data-testid="funding-reporting-link"]').should('have.attr', 'href', '/funding-and-reporting')
 });
 
-When("they click funding and reporting link", () => {
-    cy.get('[data-testid="funding-reporting-link"]').click();
-});
-
 Then("they will see the funding reporting header", () => {
     cy.get('[data-testid="funding-reporting-header"]').should('contain.text', "Funding and Reporting")
 });
@@ -51,4 +51,15 @@ Then("they will click the back link", () => {
 
 Then("they redirects to academic mentors page", () => {
     cy.location('pathname').should('eq', '/academic-mentors');
+});
+
+Then("they will see the ‘register with cognition’ link", () => {
+    cy.get('[data-testid="cognition-registration-link"]').should('exist');
+});
+
+Then("the ‘register with cognition’ link opens in a new window", () => {
+    cy.get('[data-testid="cognition-registration-link"]').should('have.attr', 'target', '_blank')
+    cy.get('[data-testid="cognition-registration-link"]').then(function ($a) {
+        const href = $a.prop('href');
+        cy.request(href).its('body').should('include', '</html>')});
 });


### PR DESCRIPTION
New link added to academic mentor page to register with cognition

Link and end to end test added 

**Before:**
![Cognition link Before](https://user-images.githubusercontent.com/33860585/188593695-112aa7cc-ffc3-443c-a00d-3e83b6a4c15f.png)

**After:**
![Cognition link After](https://user-images.githubusercontent.com/33860585/188593777-8de6dfaa-7a78-4633-9c8f-fa67490d6db8.png)

https://dfedigital.atlassian.net/browse/NTP-583


## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**