### PR TITLE
NTP-587: Correct a copy paste content error on the AM page

### DIFF
--- a/UI/Pages/AcademicMentors.cshtml
+++ b/UI/Pages/AcademicMentors.cshtml
@@ -36,7 +36,7 @@
 		<p class="govuk-body">
 			Use the Education Development Trust service to <a 
 				href="http://nominations.tutortraining.co.uk/registration" target="_blank"
-				class="govuk-link" data-testid="book-training">book training for tutors you employ directly</a>.
+				class="govuk-link" data-testid="book-training">book training for your academic mentor</a>.
 		</p>
 		
 		<h3 class="govuk-heading-m" data-testid="renewing-contract-header">Training for academic mentors you’ve employed

--- a/UI/Pages/SchoolLedTutoring.cshtml
+++ b/UI/Pages/SchoolLedTutoring.cshtml
@@ -27,7 +27,7 @@
       Training can be tailored to meet the requirements of your pupils.
     </p>
     <p class="govuk-body">
-      Use the Education Development Trust service to <a href="http://nominations.tutortraining.co.uk/registration" target="_blank" class="govuk-link">book training for tutors you employ directly</a>.
+      Use the Education Development Trust service to <a href="http://nominations.tutortraining.co.uk/registration" target="_blank" class="govuk-link" data-testid="book-training">book training for tutors you employ directly</a>.
     </p>
     <h2 class="govuk-heading-l">What it costs
     </h2>

--- a/UI/cypress/e2e/academicmentors.js
+++ b/UI/cypress/e2e/academicmentors.js
@@ -13,7 +13,13 @@ Then("they will see the book training link", () => {
 });
 
 Then("the book training link opens in a new window", () => {
-    cy.get('[data-testid="book-training"]').should('have.attr', 'target', '_blank')
+    cy.get('[data-testid="book-training"]')
+        .should('have.attr', 'target', '_blank')
+        .invoke('attr', 'href')
+        .then(($href) => {
+            cy.request($href).then((resp) => {
+                expect(resp.status).to.eq(200)
+              })});
 });
 
 Then("they will see the funding allocation link", () => {

--- a/UI/cypress/e2e/schoolledtutoring.feature
+++ b/UI/cypress/e2e/schoolledtutoring.feature
@@ -16,6 +16,11 @@
     Given a user has arrived on the school led tutoring page
     Then they will see the school led tutoring header
 
+  Scenario: page has link to book training
+    Given a user has arrived on the school led tutoring page
+     Then they will see the book training link
+     And the book training link opens in a new window
+
   Scenario: page has link to funding allocation link
     Given a user has arrived on the school led tutoring page
     Then they will see the funding allocation link

--- a/UI/cypress/e2e/schoolledtutoring.js
+++ b/UI/cypress/e2e/schoolledtutoring.js
@@ -8,6 +8,20 @@ Then("they will see the school led tutoring header", () => {
     cy.get('[data-testid="school-led-header"]').should('contain.text', "Employ your own tutor")
 });
 
+Then("they will see the book training link", () => {
+    cy.get('[data-testid="book-training"]').should('have.attr', 'href', 'http://nominations.tutortraining.co.uk/registration')
+});
+
+Then("the book training link opens in a new window", () => {
+    cy.get('[data-testid="book-training"]')
+        .should('have.attr', 'target', '_blank')
+        .invoke('attr', 'href')
+        .then(($href) => {
+            cy.request($href).then((resp) => {
+                expect(resp.status).to.eq(200)
+              })});
+});
+
 Then("they will see the dbs check link", () => {
     cy.get('[data-testid="dbs-check-link"]').should('have.attr', 'href', 'https://www.gov.uk/find-out-dbs-check/y/caring-for-or-working-with-children-under-18-or-working-in-a-school/teaching-or-caring-for-children/working-in-a-school-nursery-children-s-centre-or-home-detention-service-young-offender-institution-or-childcare-premises/yes')
 });


### PR DESCRIPTION
## Context

A link on the Academic Mentors page had been copied from the School Led Tuition page. The rest of the ticket had already been completed.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/9396346/188596846-29316dda-c882-4ad9-b5c0-b4e94d4d7b02.png)

![image](https://user-images.githubusercontent.com/9396346/188596905-aa36c9bb-7c05-4bcb-9251-6b9a6e03a6d6.png)

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-587

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [X] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [X] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [X] **PR deployment has been signed off by wider team**