### PR TITLE
NTP-593: Use NuGet package to add security headers and make compatible with GTM and local development

### DIFF
--- a/UI/Pages/Cookies.cshtml.cs
+++ b/UI/Pages/Cookies.cshtml.cs
@@ -65,7 +65,7 @@ public class Cookies : PageModel
     {
         if (consent.HasValue)
         {
-            var cookieOptions = new CookieOptions { Expires = DateTime.Today.AddMonths(12), Secure = true };
+            var cookieOptions = new CookieOptions { Expires = DateTime.Today.AddMonths(12), HttpOnly = true, Secure = true, SameSite = SameSiteMode.Strict };
             Response.Cookies.Append(ConsentCookieName, consent.Value.ToString(), cookieOptions);
 
             if (!consent.Value)

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -49,7 +49,7 @@
     {
         @if (!googleAnalyticsConsent)
         {
-            <script>
+            <script asp-add-nonce>
                 window.dataLayer = window.dataLayer || [];
                 function gtag() { dataLayer.push(arguments); }
 
@@ -67,7 +67,7 @@
 
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=@measurementId"></script>
-        <script>
+        <script asp-add-nonce>
             window.dataLayer = window.dataLayer || [];
             function gtag() { dataLayer.push(arguments); }
             gtag('js', new Date());
@@ -78,7 +78,7 @@
 </head>
 
 <body class="govuk-template__body ">
-    <script>
+    <script asp-add-nonce>
         document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 

--- a/UI/Pages/_ViewImports.cshtml
+++ b/UI/Pages/_ViewImports.cshtml
@@ -4,5 +4,6 @@
 @using UI.Extensions
 @namespace UI.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, NetEscapades.AspNetCore.SecurityHeaders.TagHelpers
 @addTagHelper *, GovUk.Frontend.AspNetCore
 @addTagHelper *, UI

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -177,6 +177,10 @@ var policyCollection = new HeaderPolicyCollection()
                 .StrictDynamic()
                 .WithHashTagHelper(); // Allow whitelisted elements based on their SHA256 hash value
 
+            var connectBuilder = cspBuilder.AddConnectSrc() // connect-src 'self' https://*.google-analytics.com
+                .Self()
+                .From("https://*.google-analytics.com");
+
             if (app.Environment.IsDevelopment())
             {
                 // Support webpack development mode used in npm run build:dev and nom run watch
@@ -187,18 +191,11 @@ var policyCollection = new HeaderPolicyCollection()
                 styleBuilder.WithHash256("tVFibyLEbUGj+pO/ZSi96c01jJCvzWilvI5Th+wLeGE=");
 
                 // For hot reload and similar developer tooling
-                cspBuilder.AddConnectSrc() // connect-src 'self' wss://localhost
-                    .Self()
+                connectBuilder
                     .From("http://localhost:*")
                     .From("https://localhost:*")
                     .From("ws://localhost:*")
                     .From("wss://localhost:*");
-            }
-            else
-            {
-                // service makes no connections when deployed
-                cspBuilder.AddConnectSrc()
-                    .None();
             }
 
             cspBuilder.AddUpgradeInsecureRequests(); // upgrade-insecure-requests

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -40,10 +40,18 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddAntiforgery(options =>
 {
     options.Cookie.Name = ".FindATuitionPartner.Antiforgery";
+    options.Cookie.HttpOnly = true;
+    options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+    options.Cookie.SameSite = SameSiteMode.Strict;
 });
 
-builder.Services.Configure<CookieTempDataProviderOptions>(options => options.Cookie.Name = ".FindATuitionPartner.Mvc.CookieTempDataProvider");
-
+builder.Services.Configure<CookieTempDataProviderOptions>(options =>
+{
+    options.Cookie.Name = ".FindATuitionPartner.Mvc.CookieTempDataProvider";
+    options.Cookie.HttpOnly = true;
+    options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+    options.Cookie.SameSite = SameSiteMode.Strict;
+});
 
 // Add services to the container.
 builder.Services.AddNtpDbContext(builder.Configuration);

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -16,6 +16,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
+		<PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.17.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Context

The fixed `Content-Security-Policy` header added to resolve a warning raised during the IT health check cause the following non critical issues:

- Web assets built in developer mode (build:dev and watch) were blocked slowing down development
- Hot reload was similarly blocked and no longer worked
- Google Tag Manager injects scripts into the pages and these dynamic scripts were also blocked

## Changes proposed in this pull request

No user facing changes.

## Guidance to review

Confirm that the local development experience is fully functional

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-593

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80% - N/A
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/) - N/A
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off - N/A
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team** - N/A