### PR TITLE
NTP-594: Add automatic configuration for GTM when in development env

### DIFF
--- a/Infrastructure/Extensions/ServiceCollectionDevelopmentExtensions.cs
+++ b/Infrastructure/Extensions/ServiceCollectionDevelopmentExtensions.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Infrastructure.Extensions;
+
+public static class ServiceCollectionEnvironmentExtensions
+{
+    public static WebApplicationBuilder AddEnvironmentConfiguration(this WebApplicationBuilder builder)
+    {
+        if (builder.Environment.IsDevelopment())
+        {
+            builder.Host.ConfigureAppConfiguration((context, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    {"GoogleAnalytics:MeasurementId", "testing"},
+                });
+            });
+        }
+
+        return builder;
+    }
+}

--- a/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -7,7 +7,6 @@ using Infrastructure.Configuration.GPaaS;
 using Infrastructure.Constants;
 using Infrastructure.Extraction;
 using Infrastructure.Factories;
-using Infrastructure.MetricLogging;
 using Infrastructure.Repositories;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -35,6 +35,7 @@ if (args.Any(x => x == "import"))
 }
 
 var builder = WebApplication.CreateBuilder(args);
+builder.AddEnvironmentConfiguration();
 
 // Rename add and rename cookies for application
 builder.Services.AddAntiforgery(options =>


### PR DESCRIPTION
## Context

A fresh clone without any previous local configuration fails the e2e tests for GTM cookies as the GTM cookie is only present once configuration has been added.

## Changes proposed in this pull request

This PR adds the GTM configuration `GoogleAnalytics:MeasurementId` automatically when the project is run in development environment.

The `MeasurementId` value does not link to any real Google analytics project.

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-594

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [x] Database migrations can be applied to the current codebase in main without causing exceptions
- [x] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**