### PR TITLE
NTP-537: Added end to end tests for selecting and checking subject fi…

### DIFF
--- a/UI/cypress/e2e/results.feature
+++ b/UI/cypress/e2e/results.feature
@@ -163,3 +163,19 @@ Feature: User is shown search results
   Scenario: Tuition partner details are displayed correctly when arriving on the results page
     Given a user has arrived on the 'Search results' page
     Then all tuition partner parameters are populated correctly
+
+  Scenario: All key stages expanded when selected
+    Given a user has arrived on the 'Search results' page without subjects or postcode
+    When they click on the option heading for 'Key stage 1,Key stage 2,Key stage 3,Key stage 4'
+    Then they will see an expanded subject filter for 'Key stage 1,Key stage 2,Key stage 3,Key stage 4'
+
+ Scenario: User is able to select a tuition type
+    Given a user has arrived on the 'Search results' page without subjects or postcode
+    When the user selects tuition type 'in school'
+    Then they will see the tuition type 'in school' is selected
+
+ Scenario: User is able to select subjects
+   Given a user has arrived on the 'Search results' page without subjects or postcode
+   When a user selects all subject
+   Then all the subjects are shown to be selected
+   And they will see an expanded subject filter for 'Key stage 1,Key stage 2,Key stage 3,Key stage 4'

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -43,6 +43,39 @@ When("'Key stage 1 English' is selected", () => {
   cy.get('[id="key-stage-1-english"]').check();
 });
 
+When("the user selects tuition type {string}", (tutionType) => {
+  cy.get(`input[id="${kebabCase(tutionType)}"]`).click();
+});
+
+When("a user selects all subject", () => {
+  const keystages = "Key stage 1,Key stage 2,Key stage 3,Key stage 4";
+  const stages = keystages.split(",").map((s) => s.trim());
+  stages.forEach((element) => {
+    cy.get(`#option-select-title-${kebabCase(element)}`).click();
+  });
+
+  cy.get('[id="key-stage-1-english"]').check();
+  cy.get('[id="key-stage-2-english"]').check();
+  cy.get('[id="key-stage-3-english"]').check();
+  cy.get('[id="key-stage-4-english"]').check();
+
+  cy.get('[id="key-stage-1-maths"]').check();
+  cy.get('[id="key-stage-2-maths"]').check();
+  cy.get('[id="key-stage-3-maths"]').check();
+  cy.get('[id="key-stage-4-maths"]').check();
+
+  cy.get('[id="key-stage-1-science"]').check();
+  cy.get('[id="key-stage-2-science"]').check();
+  cy.get('[id="key-stage-3-science"]').check();
+  cy.get('[id="key-stage-4-science"]').check();
+
+  cy.get('[id="key-stage-3-modern-foreign-languages"]').check();
+  cy.get('[id="key-stage-3-humanities"]').check();
+
+  cy.get('[id="key-stage-4-modern-foreign-languages"]').check();
+  cy.get('[id="key-stage-4-humanities"]').check();
+});
+
 Then("the ‘clear filters’ button as been selected", () => {
   cy.get('[data-testid="clear-all-filters"]').click();
 });
@@ -183,4 +216,33 @@ Then("results are updated after filters are cleared", () => {
 
 Then("the postcode search parameter remains", () => {
   cy.get('[data-testid="postcode-input-box"]').should("have.value", "sk11eb");
+});
+
+Then("all the subjects are shown to be selected", () => {
+  const keystages = "Key stage 1,Key stage 2,Key stage 3,Key stage 4";
+  const stages = keystages.split(",").map((s) => s.trim());
+  stages.forEach((element) => {
+    cy.get(`#option-select-title-${kebabCase(element)}`).click();
+  });
+
+  cy.get('[id="key-stage-1-english"]').should("be.checked");
+  cy.get('[id="key-stage-2-english"]').should("be.checked");
+  cy.get('[id="key-stage-3-english"]').should("be.checked");
+  cy.get('[id="key-stage-4-english"]').should("be.checked");
+
+  cy.get('[id="key-stage-1-maths"]').should("be.checked");
+  cy.get('[id="key-stage-2-maths"]').should("be.checked");
+  cy.get('[id="key-stage-3-maths"]').should("be.checked");
+  cy.get('[id="key-stage-4-maths"]').should("be.checked");
+
+  cy.get('[id="key-stage-1-science"]').should("be.checked");
+  cy.get('[id="key-stage-2-science"]').should("be.checked");
+  cy.get('[id="key-stage-3-science"]').should("be.checked");
+  cy.get('[id="key-stage-4-science"]').should("be.checked");
+
+  cy.get('[id="key-stage-3-modern-foreign-languages"]').should("be.checked");
+  cy.get('[id="key-stage-3-humanities"]').should("be.checked");
+
+  cy.get('[id="key-stage-4-modern-foreign-languages"]').should("be.checked");
+  cy.get('[id="key-stage-4-humanities"]').should("be.checked");
 });


### PR DESCRIPTION
…lters

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Subject filter in results page are not covered fully by end to end tests

## Changes proposed in this pull request

End to end tests to expand all key stages, select and check all subjects, select and check tuition type. Postcode tests are already present

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-537

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**