### PR TITLE
NTP-537: Added end to end test for selecting subjects

### DIFF
--- a/UI/cypress/e2e/results.feature
+++ b/UI/cypress/e2e/results.feature
@@ -174,8 +174,7 @@ Feature: User is shown search results
     When the user selects tuition type 'in school'
     Then they will see the tuition type 'in school' is selected
 
- Scenario: User is able to select subjects
+Scenario: User is able to select subjects
    Given a user has arrived on the 'Search results' page without subjects or postcode
    When a user selects all subject
    Then all the subjects are shown to be selected
-   And they will see an expanded subject filter for 'Key stage 1,Key stage 2,Key stage 3,Key stage 4'


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Added end to end test for selecting subjects, which was failing before

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-537

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**