### PR TITLE
NTP-523: Reduce log level of data import related logging

### DIFF
--- a/Infrastructure/DataEncryptionService.cs
+++ b/Infrastructure/DataEncryptionService.cs
@@ -46,11 +46,11 @@ public class DataEncryptionService : IHostedService
         var destination = GetDestinationDirectoryInfo();
         var keyBytes = Convert.FromBase64String(_config.Key);
 
-        _logger.LogWarning($"Encrypting files from {source} and replacing all existing files in the {destination} directory");
+        _logger.LogInformation($"Encrypting files from {source} and replacing all existing files in the {destination} directory");
 
         foreach (var fileInfo in destination.GetFiles().Where(x => x.Name != "README.md"))
         {
-            _logger.LogWarning($"Deleting existing file {fileInfo}");
+            _logger.LogInformation($"Deleting existing file {fileInfo}");
             fileInfo.Delete();
         }
 

--- a/Infrastructure/DataImporterService.cs
+++ b/Infrastructure/DataImporterService.cs
@@ -45,7 +45,7 @@ public class DataImporterService : IHostedService
         var dbContext = scope.ServiceProvider.GetRequiredService<NtpDbContext>();
         var factory = scope.ServiceProvider.GetRequiredService<ITuitionPartnerFactory>();
 
-        _logger.LogWarning("Migrating database");
+        _logger.LogInformation("Migrating database");
         await dbContext.Database.MigrateAsync(cancellationToken);
 
         var strategy = dbContext.Database.CreateExecutionStrategy();
@@ -55,7 +55,7 @@ public class DataImporterService : IHostedService
             {
                 await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
 
-                _logger.LogWarning("Deleting all existing Tuition Partner data");
+                _logger.LogInformation("Deleting all existing Tuition Partner data");
                 await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM \"LocalAuthorityDistrictCoverage\"", cancellationToken: cancellationToken);
                 await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM \"SubjectCoverage\"", cancellationToken: cancellationToken);
                 await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM \"Prices\"", cancellationToken: cancellationToken);


### PR DESCRIPTION
## Context

We're currently supressing specific warnings from creating alerts in Slack. This PR covers the ones related to the data import process by reducing the log levels from warning to information. The log lines in question were not indicating out of the ordinary actions or behaviour.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-523

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80% - N/A
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/) - N/A
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off - N/A
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [X] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team** - N/A