### PR TITLE
NTP-623: Add nightly run of the data import job to each environment

### DIFF
--- a/.github/workflows/import-data.yml
+++ b/.github/workflows/import-data.yml
@@ -1,6 +1,11 @@
 name: Run Database Migrations and Import Data
 
 on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/nightly-import-data.yml
+++ b/.github/workflows/nightly-import-data.yml
@@ -1,0 +1,16 @@
+name: Run Database Migrations and Import Data Nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '1 1 * * *'
+
+jobs:
+  nightly_migrate_import_data:
+    name: Nightly Migrate Database and Import Data
+    strategy:
+      matrix:
+        environment: [qa, research, staging, production]
+    uses: ./.github/workflows/import-data.yml
+    with:
+      environment: ${{ matrix.environment }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -70,7 +70,7 @@ jobs:
       uses: cygnetdigital/wait_for_response@v2.0.0
       with:
         url: "${{ env.BASE_URL }}/tuition-partner/action-tutoring"
-        timeout: 180000
+        timeout: 600000
         interval: 15000
 
     - name: End to End Testing


### PR DESCRIPTION
## Context

The team would like to move to automatically running the data import process nightly removing the need for a developer to manually run the process and ensure that the TP data is up to date.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

This cannot be fully proven until it's merged into main. Any issues will need to be fixed in subsequent PRs.

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-623

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md) - N/A
- [ ] `dotnet format` has been run in the repository root - N/A
- [ ] Test coverage of new code is at least 80% - N/A
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/) - N/A
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off - N/A
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions - N/A
- [ ] Debug logging has been added after all logic decision points - N/A
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code - N/A
- [ ] **PR deployment has been signed off by wider team** - N/A