### PR TITLE
NTP-630: Ensure logos are matched to their exact tuition partner name

### DIFF
--- a/Infrastructure/DataImport/GoogleDriveFileEnumerable.cs
+++ b/Infrastructure/DataImport/GoogleDriveFileEnumerable.cs
@@ -44,7 +44,7 @@ public sealed class GoogleDriveFileEnumerable : IEnumerable<DataFile>, IEnumerat
 
     private void RetrieveFileList()
     {
-        var parents = _service.FindAllFiles($"name = '{_directory}'");
+        var parents = _service.FindAllDirectories($"name = '{_directory}'");
         var logoDir = parents.First();
         var files = _service.FindAllFiles($"parents in '{logoDir.Id}'");
         _files.AddRange(files);

--- a/Infrastructure/DataImport/GoogleDriveFileService.cs
+++ b/Infrastructure/DataImport/GoogleDriveFileService.cs
@@ -1,4 +1,4 @@
-﻿using Google.Apis.Download;
+using Google.Apis.Download;
 using Google.Apis.Drive.v3;
 using Google.Apis.Drive.v3.Data;
 using Microsoft.Extensions.Logging;
@@ -15,7 +15,13 @@ public class GoogleDriveFileService
     public GoogleDriveFileService(DriveService service, string googleDriveId, ILogger logger)
         => (_service, _driveId, _logger) = (service, googleDriveId, logger);
 
+    public List<File> FindAllDirectories(string search)
+        => FindAllEntities($"{search} and mimeType = 'application/vnd.google-apps.folder'");
+
     public List<File> FindAllFiles(string search)
+        => FindAllEntities($"{search} and mimeType != 'application/vnd.google-apps.folder'");
+
+    private List<File> FindAllEntities(string search)
     {
         var listRequest = _service.Files.List();
 

--- a/Infrastructure/DataImporterService.cs
+++ b/Infrastructure/DataImporterService.cs
@@ -119,18 +119,18 @@ public class DataImporterService : IHostedService
         _logger.LogInformation("Matched {Count} logos to tuition partners:\n{Matches}",
             matching.Count, string.Join("\n", matching.Select(x => $"{x.Partner.SeoUrl} => {x.Logo.Filename}")));
 
-        var partnersWithoutLogos = partners.Except(matching.Select(x => x.Partner));
+        var partnersWithoutLogos = partners.Except(matching.Select(x => x.Partner)).ToList();
         if (partnersWithoutLogos.Any())
         {
             _logger.LogInformation("{Count} tuition partners do not have logos:\n{WithoutLogo}",
-                partnersWithoutLogos.Count(), string.Join("\n", partnersWithoutLogos.Select(x => x.SeoUrl)));
+                partnersWithoutLogos.Count, string.Join("\n", partnersWithoutLogos.Select(x => x.SeoUrl)));
         }
 
-        var logosWithoutPartners = logos.Except(matching.Select(x => x.Logo));
+        var logosWithoutPartners = logos.Except(matching.Select(x => x.Logo)).ToList();
         if (logosWithoutPartners.Any())
         {
             _logger.LogWarning("{Count} logos files do not match a tuition partner:\n{UnmatchedLogos}",
-                logosWithoutPartners.Count(), string.Join("\n", logosWithoutPartners.Select(x => x.Filename)));
+                logosWithoutPartners.Count, string.Join("\n", logosWithoutPartners.Select(x => x.Filename)));
         }
 
         foreach (var import in matching)

--- a/Infrastructure/DataImporterService.cs
+++ b/Infrastructure/DataImporterService.cs
@@ -104,32 +104,52 @@ public class DataImporterService : IHostedService
 
         _logger.LogInformation("Looking for logos for {Count} tuition partners", partners.Count);
 
-        var logos = logoFileEnumerable.ToList();
-        _logger.LogInformation("Available logo files are {LogoFiles}",
-            string.Join("\n", logos.Select(x => x.Filename).OrderBy(x => x)));
+        var logos = logoFileEnumerable.Where(x => x.Filename.EndsWith(".svg")).ToList();
 
-        foreach (var partner in partners)
+        var matching = (from p in partners
+                        from l in logos
+                        where IsFileLogoForTuitionPartner(p.SeoUrl, l.Filename)
+                        select new
+                        {
+                            Partner = p,
+                            Logo = l,
+                        })
+                       .ToList();
+
+        _logger.LogInformation("Matched {Count} logos to tuition partners:\n{Matches}",
+            matching.Count, string.Join("\n", matching.Select(x => $"{x.Partner.SeoUrl} => {x.Logo.Filename}")));
+
+        var partnersWithoutLogos = partners.Except(matching.Select(x => x.Partner));
+        if (partnersWithoutLogos.Any())
         {
-            var dataFile = logos
-                .Where(logo => logo.Filename.Contains(partner.SeoUrl))
-                .FirstOrDefault();
+            _logger.LogInformation("{Count} tuition partners do not have logos:\n{WithoutLogo}",
+                partnersWithoutLogos.Count(), string.Join("\n", partnersWithoutLogos.Select(x => x.SeoUrl)));
+        }
 
-            if (dataFile == null)
-            {
-                _logger.LogInformation("No logo file for Tution Partner {Name}", partner.SeoUrl);
-                continue;
-            }
+        var logosWithoutPartners = logos.Except(matching.Select(x => x.Logo));
+        if (logosWithoutPartners.Any())
+        {
+            _logger.LogWarning("{Count} logos files do not match a tuition partner:\n{UnmatchedLogos}",
+                logosWithoutPartners.Count(), string.Join("\n", logosWithoutPartners.Select(x => x.Filename)));
+        }
 
-            _logger.LogInformation("Retrieving logo file for Tution Partner {Name}", partner.SeoUrl);
-            var b64 = Convert.ToBase64String(dataFile.Stream.Value.ReadAllBytes());
+        foreach (var import in matching)
+        {
+            _logger.LogInformation("Retrieving logo file for Tution Partner {Name}", import.Partner.SeoUrl);
+            var b64 = Convert.ToBase64String(import.Logo.Stream.Value.ReadAllBytes());
 
-            var tp = dbContext.TuitionPartners.Find(partner.Id);
+            var tp = dbContext.TuitionPartners.Find(import.Partner.Id);
             tp!.Logo = new TuitionPartnerLogo { Logo = b64 };
         }
 
         await dbContext.SaveChangesAsync();
 
         await Task.CompletedTask;
+    }
+
+    public static bool IsFileLogoForTuitionPartner(string tuitionPartnerName, string logoFilename)
+    {
+        return logoFilename.Equals($"Logo_{tuitionPartnerName}.svg", StringComparison.InvariantCultureIgnoreCase);
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/Tests/Importing/ImportLogoFiles.cs
+++ b/Tests/Importing/ImportLogoFiles.cs
@@ -1,0 +1,23 @@
+﻿using Infrastructure;
+
+namespace Tests.Importing;
+
+public class ImportLogoFiles
+{
+    [Theory]
+    [InlineData("seo-name", "Logo_seo-name.svg")]
+    public void Logo_file_matches_seo_name_exactly(string name, string logoFile)
+    {
+        DataImporterService.IsFileLogoForTuitionPartner(name, logoFile).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("seo-name", "Logo_banana.svg")]
+    [InlineData("seo-name", "Logo_other-seo-name.svg")]
+    [InlineData("seo-name", "Logo_seo-name_logo.svg")]
+    [InlineData("seo-name", "seo-name.svg")]
+    public void Logo_file_does_not_match_seo_name_exactly(string name, string logoFile)
+    {
+        DataImporterService.IsFileLogoForTuitionPartner(name, logoFile).Should().BeFalse();
+    }
+}

--- a/UI/Properties/launchSettings.json
+++ b/UI/Properties/launchSettings.json
@@ -10,6 +10,13 @@
       "applicationUrl": "https://localhost:7036;http://localhost:5036",
       "dotnetRunMessages": true
     },
+    "DataImport": {
+      "commandName": "Project",
+      "commandLineArgs": "import",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    },
     "Docker": {
       "commandName": "Docker",
       "launchBrowser": true,


### PR DESCRIPTION
## Changes proposed in this pull request

Logos were imported for a tuition partner if the logo filename contained the tuition partner's canonicalised name regardless of what else the filename contained.  Some tuition partners have similar names and logos were occasionally imported for the wrong partner.

This change ensures logo files must exactly match the canonicalised name plus a `Logo_` prefix.

The Equal Education Partners logo was showing for both Equal Education Partners but also Equal Education.  Now it only shows for the correct tuition partner

![image](https://user-images.githubusercontent.com/201727/194326232-51c4178a-e6a8-4acf-9116-e1877e38b9ff.png)

![image](https://user-images.githubusercontent.com/201727/194326201-53433cf6-a4c2-4070-bc22-d2522b38d55e.png)


## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-630

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**