### PR TITLE
NTP-632: URLs only contain URL safe characters

### DIFF
--- a/Application.Tests/Extensions/StringExtensionsTests.cs
+++ b/Application.Tests/Extensions/StringExtensionsTests.cs
@@ -71,6 +71,17 @@ public class StringExtensionsTests
     }
 
     [Theory]
+    [InlineData("apostrophe's", "apostrophes")]
+    [InlineData("special!\"£$%^&*+=chars", "specialchars")]
+    [InlineData("more[];:@#,.<>?special", "morespecial")]
+    [InlineData("chars-for-aspnet-operation-(){}", "chars-for-aspnet-operation-(){}")]
+    [InlineData("unicode६symbols你好", "unicode-symbols")]
+    public void ToSeoUrl_ReturnsKebabCase_Without_UrlEncoded_Characters(string name, string seoName)
+    {
+        name.ToSeoUrl().Should().Be(seoName);
+    }
+
+    [Theory]
     [InlineData("Find/Location", "find/location")]
     [InlineData("find/location", "find/location")]
     [InlineData("FindPage/LocationSearch", "find-page/location-search")]
@@ -79,6 +90,7 @@ public class StringExtensionsTests
     [InlineData("Find/FindATuitionPartner", "find/find-a-tuition-partner")]
     [InlineData("Find/FindATuitionPartner ", "find/find-a-tuition-partner")]
     [InlineData("Find/findATuitionPartner", "find/find-a-tuition-partner")]
+    [InlineData("tuition-partner/A Tuition Co", "tuition-partner/a-tuition-co")]
     public void ToSeoUrl_ReturnsKebabCase_WhenDirectory(string camel, string kebab)
     {
         camel.ToSeoUrl().Should().Be(kebab);

--- a/Application/Extensions/StringExtensions.cs
+++ b/Application/Extensions/StringExtensions.cs
@@ -5,17 +5,26 @@ namespace Application.Extensions;
 
 public static class StringExtensions
 {
+    private const string CamelCaseBoundaries = @"((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+)";
+    private const string UrlUnsafeCharacters = "[^a-zA-Z0-9_{}()\\-~/]";
+
     [return: NotNullIfNotNull("value")]
     public static string? ToSeoUrl(this string? value)
     {
-        if (value == null) return null;
+        var seo = value?
+            .RegexReplace(CamelCaseBoundaries, " $1")
+            .Trim()
+            .Replace(' ', '-')
+            .RegexReplace(UrlUnsafeCharacters, "")
+            .ToLower();
 
-        var withSpaces = Regex.Replace(value, @"((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+)", " $1", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100)).Trim();
-
-        var spacesToDash = withSpaces.Replace(' ', '-');
-
-        return spacesToDash.ToLower();
+        return seo;
     }
+
+    private static string RegexReplace(this string value, string pattern, string replacement)
+        => Regex.Replace(
+            value, pattern, replacement,
+            RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
 
     public static string ToYesNoString(this bool value)
             => value ? "Yes" : "No";

--- a/UI/cypress/e2e/full-list.js
+++ b/UI/cypress/e2e/full-list.js
@@ -103,7 +103,7 @@ Then("the name of each tuition partner links to their details page", () => {
     cy.wrap($element).should(
       "have.attr",
       "href",
-      `/tuition-partner/${kebabCase($element.text()).replace(/'/g, "%27")}`
+      `/tuition-partner/${kebabCase($element.text()).replace(/'/g, "")}`
     );
   });
 });


### PR DESCRIPTION
## Changes proposed in this pull request

Some tuition partner names have characters that do not safe for URLs. A case in point is `Eric's Tutoring`. This results in the logos not appearing correctly as the browser looks for `eric%23s-tutoring` instead of `eric's-tutoring`.

The resolution is to remove all unsafe characters, resulting in `erics-tutoring`.

The ASPNet core engine does rely on the brace and parenthesis characters remaining untouched as they are used by the routing engine, and our renaming behaviour would break routing if these characters were removed.


## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-632

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [x] Database migrations can be applied to the current codebase in main without causing exceptions
- [x] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**