### PR TITLE
NTP-659: pricing info not displaying for t ps when do you offer tuition to all locations nationwide response is empty

### DIFF
--- a/Application/INtpDbContext.cs
+++ b/Application/INtpDbContext.cs
@@ -6,6 +6,7 @@ namespace Application;
 public interface INtpDbContext
 {
     DbSet<LocalAuthorityDistrict> LocalAuthorityDistricts { get; set; }
+    DbSet<LocalAuthorityDistrictCoverage> LocalAuthorityDistrictCoverage { get; set; }
     DbSet<Region> Regions { get; set; }
     DbSet<Subject> Subjects { get; set; }
     DbSet<TuitionPartner> TuitionPartners { get; set; }

--- a/Tests/SearchForResults.cs
+++ b/Tests/SearchForResults.cs
@@ -242,19 +242,6 @@ public class SearchForResults : CleanSliceFixture
         result!.Results!.Count.Should().Be(numberOfTuitionPartners);
     }
 
-    [Fact]
-    public async Task Sets_from_search_results()
-    {
-        var page = await Fixture.GetPage<SearchResults>()
-            .Execute(async page =>
-            {
-                await page.OnGet(new SearchResults.Query { From = ReferrerList.FullList });
-                return page;
-            });
-
-        page.Data.From.Should().Be(ReferrerList.SearchResults);
-    }
-
     [Theory]
     [InlineData(null, false)]
     [InlineData("image-data", true)]

--- a/Tests/ShowAllTuitionPartners.cs
+++ b/Tests/ShowAllTuitionPartners.cs
@@ -71,37 +71,4 @@ public class ShowAllTuitionPartners : CleanSliceFixture
             new { Name = "Alpha" }
         });
     }
-
-    [Fact]
-    public async Task Sets_from_full_list()
-    {
-        var page = await Fixture.GetPage<AllTuitionPartners>(page =>
-        {
-            page.Data.From = ReferrerList.SearchResults;
-            return page.OnGet();
-        });
-
-        page.Data.From.Should().Be(ReferrerList.FullList);
-    }
-
-    [Fact]
-    public async Task Sets_AllSearchData()
-    {
-        var page = await Fixture.GetPage<AllTuitionPartners>(page =>
-        {
-            page.TempData = new TempDataDictionary(new DefaultHttpContext(), Mock.Of<ITempDataProvider>());
-            page.Data.From = ReferrerList.SearchResults;
-            page.Data.Name = "test";
-            return page.OnGet();
-        });
-
-        var data = page.TempData.Peek<SearchModel>("AllSearchData");
-        data.Should().NotBeNull();
-        data!.From.Should().Be(ReferrerList.FullList);
-        data.Name.Should().Be("test");
-        data.Postcode.Should().BeNull();
-        data.Subjects.Should().BeNull();
-        data.TuitionType.Should().BeNull();
-        data.KeyStages.Should().BeNull();
-    }
 }

--- a/Tests/TestData/District.cs
+++ b/Tests/TestData/District.cs
@@ -3,7 +3,7 @@
 public record District(int Id, string Code, string Name, string SamplePostcode)
 {
     public static District Dacorum { get; } = new(254, "E07000096", "Dacorum", "AA00AA");
-    public static District EastRidingOfYorkshire { get; } = new(1, "E06000011", "East Riding of Yorkshire", "");
-    public static District NorthEastLincolnshire { get; } = new(2, "E06000012", "North East Lincolnshire", "");
-    public static District Ryedale { get; } = new(9, "E07000167", "Ryedale", "");
+    public static District EastRidingOfYorkshire { get; } = new(1, "E06000011", "East Riding of Yorkshire", "DN14 0AA");
+    public static District NorthEastLincolnshire { get; } = new(2, "E06000012", "North East Lincolnshire", "DN31 1AB");
+    public static District Ryedale { get; } = new(9, "E07000167", "Ryedale", "DL6 3QE");
 }

--- a/Tests/TuitionPartnerDetailsPage.cs
+++ b/Tests/TuitionPartnerDetailsPage.cs
@@ -129,8 +129,8 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
 
         var result = await Fixture.SendAsync(
             new TuitionPartner.Query(
-                "a-tuition-partner",
-                District.EastRidingOfYorkshire.Code));
+                "a-tuition-partner")
+            { Postcode = District.EastRidingOfYorkshire.SamplePostcode });
 
         result!.TuitionTypes.Should().BeEquivalentTo("Online", "In School");
     }
@@ -144,8 +144,8 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
 
         var result = await Fixture.SendAsync(
             new TuitionPartner.Query(
-                "a-tuition-partner",
-                District.Ryedale.Code));
+                "a-tuition-partner")
+            { Postcode = District.Ryedale.SamplePostcode });
 
         result!.TuitionTypes.Should().BeEquivalentTo("Online");
     }
@@ -165,8 +165,8 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
 
         var result = await Fixture.SendAsync(
             new TuitionPartner.Query(
-                "a-tuition-partner",
-                District.NorthEastLincolnshire.Code));
+                "a-tuition-partner")
+            { Postcode = District.NorthEastLincolnshire.SamplePostcode });
 
         result!.Prices.Should().BeEquivalentTo(new Dictionary<int, TuitionPartner.GroupPrice>
         {
@@ -189,8 +189,8 @@ public class TuitionPartnerDetailsPage : CleanSliceFixture
 
         var result = await Fixture.SendAsync(
             new TuitionPartner.Query(
-                "a-tuition-partner",
-                District.Ryedale.Code));
+                "a-tuition-partner")
+            { Postcode = District.Ryedale.SamplePostcode });
 
         result!.Prices.Should().BeEquivalentTo(new Dictionary<int, TuitionPartner.GroupPrice>
         {

--- a/Tests/Utilities/SliceFixture.cs
+++ b/Tests/Utilities/SliceFixture.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NSubstitute;
+using Tests.TestData;
 
 namespace Tests.Utilities;
 
@@ -40,13 +41,32 @@ public class SliceFixture : IAsyncLifetime
         public NtpApplicationFactory()
         {
             LocationFilter = Substitute.For<ILocationFilterService>();
+
+            var locationsToAdd = new Dictionary<string, string>()
+            {
+                { District.EastRidingOfYorkshire.Code, District.EastRidingOfYorkshire.SamplePostcode },
+                { District.NorthEastLincolnshire.Code, District.NorthEastLincolnshire.SamplePostcode },
+                { District.Ryedale.Code, District.Ryedale.SamplePostcode }
+            };
+
+            foreach(var locationToAdd in locationsToAdd)
+            {
+                LocationFilter
+                    .GetLocationFilterParametersAsync(locationToAdd.Value)
+                    .Returns(new LocationFilterParameters
+                    {
+                        Country = "England",
+                        LocalAuthorityDistrictCode = locationToAdd.Key,
+                    });
+            }
+
             LocationFilter
-                .GetLocationFilterParametersAsync(Arg.Any<string>())
+                .GetLocationFilterParametersAsync(Arg.Is<string>(x => !locationsToAdd.ContainsValue(x)))
                 .Returns(new LocationFilterParameters
-                {
-                    Country = "England",
-                    LocalAuthorityDistrictCode = "E07000096",
-                });
+                 {
+                     Country = "England",
+                     LocalAuthorityDistrictCode = District.Dacorum.Code,
+                 });
         }
 
         public ILocationFilterService LocationFilter { get; }

--- a/Tests/Utilities/SliceFixture.cs
+++ b/Tests/Utilities/SliceFixture.cs
@@ -49,7 +49,7 @@ public class SliceFixture : IAsyncLifetime
                 { District.Ryedale.Code, District.Ryedale.SamplePostcode }
             };
 
-            foreach(var locationToAdd in locationsToAdd)
+            foreach (var locationToAdd in locationsToAdd)
             {
                 LocationFilter
                     .GetLocationFilterParametersAsync(locationToAdd.Value)
@@ -63,10 +63,10 @@ public class SliceFixture : IAsyncLifetime
             LocationFilter
                 .GetLocationFilterParametersAsync(Arg.Is<string>(x => !locationsToAdd.ContainsValue(x)))
                 .Returns(new LocationFilterParameters
-                 {
-                     Country = "England",
-                     LocalAuthorityDistrictCode = District.Dacorum.Code,
-                 });
+                {
+                    Country = "England",
+                    LocalAuthorityDistrictCode = District.Dacorum.Code,
+                });
         }
 
         public ILocationFilterService LocationFilter { get; }

--- a/UI/Pages/AllTuitionPartners.cshtml
+++ b/UI/Pages/AllTuitionPartners.cshtml
@@ -43,7 +43,7 @@
 
                     <div class="tuition-partner-summary" data-testid="tuition-partner-summary" data-tuitionpartner="@item.SeoUrl">
                         <div>
-                            <h2 class="govuk-heading-m"><a asp-page="TuitionPartner" asp-route-id="@item.SeoUrl" class="govuk-link" data-testid="tuition-partner-name-link">@item.Name</a></h2>
+                            <h2 class="govuk-heading-m"><a asp-page="TuitionPartner" asp-route-id="@item.SeoUrl" asp-route-name="@Model.Data.Name" asp-route-from="@Model.Data.From" class="govuk-link" data-testid="tuition-partner-name-link">@item.Name</a></h2>
                             <govuk-summary-list>
                                 <govuk-summary-list-row class="govuk-summary-list__row--no-border app-print-s">
                                     <govuk-summary-list-row-key>

--- a/UI/Pages/AllTuitionPartners.cshtml.cs
+++ b/UI/Pages/AllTuitionPartners.cshtml.cs
@@ -21,7 +21,6 @@ public class AllTuitionPartners : PageModel
     public async Task OnGet()
     {
         Data.From = ReferrerList.FullList;
-        TempData.Set("AllSearchData", Data);
 
         Results = await _mediator.Send(new SearchTuitionPartnerHandler.Command
         {

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -121,17 +121,21 @@
                 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
             </div>
 
+            @{
+                var dataQueryString = Model.Data.ToQueryString();
+            }
 
             @if (Model.Data.Results != null)
             {
                 foreach (var item in Model.Data.Results.Results)
                 {
                     var logoUrl = item.HasLogo ? $"/tuition-partner-logo/{item.SeoUrl}" : "";
+                    var tpUrl = $"/tuition-partner/{item.SeoUrl}?{dataQueryString}";
 
                     <div data-testid="results-list-item">
                         <div class="search-results-logo" data-testid="results-list-item-@item.SeoUrl" >
                         <img show-if="@item.HasLogo" src="@logoUrl" alt="The company logo for @item.Name" />
-                        <h2 class="govuk-heading-m"><a asp-page="TuitionPartner" asp-route-id="@item.SeoUrl" class="govuk-link">@item.Name</a></h2>
+                        <h2 class="govuk-heading-m"><a href="@tpUrl" class="govuk-link">@item.Name</a></h2>
                         <govuk-summary-list>
                             <govuk-summary-list-row class="govuk-body-s">
                                 <govuk-summary-list-row-key>

--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -8,7 +8,6 @@ using FluentValidation.Results;
 using MediatR;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
-using UI.Extensions;
 using FluentValidationResult = FluentValidation.Results.ValidationResult;
 
 namespace UI.Pages;
@@ -23,13 +22,8 @@ public class SearchResults : PageModel
 
     public async Task OnGet(Query Data)
     {
-        Data.From = ReferrerList.SearchResults;
-        TempData.Set("AllSearchData", Data);
-
         Data.TuitionType ??= TuitionType.Any;
         this.Data = await mediator.Send(Data);
-
-        TempData.Set("LocalAuthorityDistrictCode", this.Data.LocalAuthorityDistrictCode ?? "");
 
         if (!this.Data.Validation.IsValid)
             foreach (var error in this.Data.Validation.Errors)

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -9,15 +9,15 @@
 
 <div class="app-print-this-page--container">
     <div class="app-print-this-page--container-left">
-        @if (Model.AllSearchData?.From == ReferrerList.FullList)
+        @if (Model.SearchModel?.From == ReferrerList.FullList)
         {
-            <a href="/all-tuition-partners?@Model.AllSearchData.ToQueryString()" class="govuk-back-link">
+            <a href="/all-tuition-partners?@Model.SearchModel.ToQueryString()" class="govuk-back-link">
                 Back to tuition partners
             </a>
         }
         else
         {
-            <a href="/search-results?@Model.AllSearchData.ToQueryString()" class="govuk-back-link">
+            <a href="/search-results?@Model.SearchModel.ToQueryString()" class="govuk-back-link">
                 Back to search results
             </a>
         }

--- a/UI/Pages/TuitionPartner.cshtml.cs
+++ b/UI/Pages/TuitionPartner.cshtml.cs
@@ -140,7 +140,7 @@ public class TuitionPartner : PageModel
 
             var subjects = tp.SubjectCoverage.Select(x => x.Subject).Distinct().GroupBy(x => x.KeyStageId).Select(x => $"{((KeyStage)x.Key).DisplayName()} - {x.DisplayList()}");
             string? ladCode = null;
-            if(!string.IsNullOrEmpty(request.Postcode))
+            if (!string.IsNullOrEmpty(request.Postcode))
             {
                 var location = await locationService.GetLocationFilterParametersAsync(request.Postcode!);
                 ladCode = location?.LocalAuthorityDistrictCode;

--- a/UI/Pages/TuitionPartner.cshtml.cs
+++ b/UI/Pages/TuitionPartner.cshtml.cs
@@ -1,13 +1,11 @@
-using System.ComponentModel;
+using Application;
 using Application.Extensions;
 using Domain;
 using Domain.Constants;
-using Infrastructure;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
-using UI.Extensions;
 
 namespace UI.Pages;
 
@@ -24,11 +22,11 @@ public class TuitionPartner : PageModel
 
     public Command? Data { get; set; }
 
-    public SearchModel? AllSearchData { get; set; }
+    public SearchModel? SearchModel { get; set; }
 
     public async Task<IActionResult> OnGetAsync(Query query)
     {
-        AllSearchData = TempData.Peek<SearchModel>("AllSearchData");
+        SearchModel = new SearchModel(query);
 
         if (string.IsNullOrWhiteSpace(query.Id))
         {
@@ -43,10 +41,7 @@ public class TuitionPartner : PageModel
             return RedirectToPage((query with { Id = seoUrl }).ToRouteData());
         }
 
-        Data = await _mediator.Send(query with
-        {
-            LocalAuthorityDistrictCode = TempData.Peek<string>("LocalAuthorityDistrictCode")
-        });
+        Data = await _mediator.Send(query);
 
         if (Data == null)
         {
@@ -60,18 +55,18 @@ public class TuitionPartner : PageModel
 
     public record Query(
             string Id,
-            string? LocalAuthorityDistrictCode = null,
             [FromQuery(Name = "show-locations-covered")]
             bool ShowLocationsCovered = false,
             [FromQuery(Name = "show-full-pricing")]
             bool ShowFullPricing = false)
-        : IRequest<Command?>
+        : SearchModel, IRequest<Command?>
     {
         public Dictionary<string, string> ToRouteData()
         {
-            var dictionary = new Dictionary<string, string>();
-
-            dictionary[nameof(Id)] = Id;
+            var dictionary = new Dictionary<string, string>
+            {
+                [nameof(Id)] = Id
+            };
 
             if (ShowLocationsCovered)
             {
@@ -110,13 +105,18 @@ public class TuitionPartner : PageModel
 
     public class QueryHandler : IRequestHandler<Query, Command?>
     {
-        private readonly NtpDbContext _db;
+        private readonly ILocationFilterService locationService;
+        private readonly INtpDbContext db;
 
-        public QueryHandler(NtpDbContext db) => _db = db;
+        public QueryHandler(ILocationFilterService locationService, INtpDbContext db)
+        {
+            this.locationService = locationService;
+            this.db = db;
+        }
 
         public async Task<Command?> Handle(Query request, CancellationToken cancellationToken)
         {
-            var queryable = _db.TuitionPartners
+            var queryable = this.db.TuitionPartners
                 .Include(e => e.SubjectCoverage)
                 .ThenInclude(e => e.Subject)
                 .Include(x => x.Prices)
@@ -139,9 +139,20 @@ public class TuitionPartner : PageModel
             if (tp == null) return null;
 
             var subjects = tp.SubjectCoverage.Select(x => x.Subject).Distinct().GroupBy(x => x.KeyStageId).Select(x => $"{((KeyStage)x.Key).DisplayName()} - {x.DisplayList()}");
-            var types = await GetTuitionTypesCovered(request.LocalAuthorityDistrictCode, tp, cancellationToken);
+            string? ladCode = null;
+            if(!string.IsNullOrEmpty(request.Postcode))
+            {
+                var location = await locationService.GetLocationFilterParametersAsync(request.Postcode!);
+                ladCode = location?.LocalAuthorityDistrictCode;
+            }
+            var types = await GetTuitionTypesCovered(ladCode, tp, cancellationToken);
+            if (types == null || types.Count() == 0)
+            {
+                //If no data returned then postcode is invalid or issue calling GetLocationFilterParametersAsync, so get all TuitionTypesCovered for TP
+                types = await GetTuitionTypesCovered(null, tp, cancellationToken);
+            }
             var ratios = tp.Prices.Select(x => x.GroupSize).Distinct().Select(x => $"1 to {x}");
-            var prices = GetPricing(types, tp.Prices);
+            var prices = GetPricing(types!, tp.Prices);
             var lads = await GetLocalAuthorityDistricts(request, tp.Id);
             var allPrices = await GetFullPricing(request, tp.Prices);
 
@@ -151,7 +162,7 @@ public class TuitionPartner : PageModel
                 tp.HasLogo,
                 tp.Description,
                 subjects.ToArray(),
-                types.ToArray(),
+                types!.ToArray(),
                 ratios.ToArray(),
                 prices,
                 tp.Website,
@@ -170,7 +181,7 @@ public class TuitionPartner : PageModel
             Domain.TuitionPartner tp,
             CancellationToken cancellationToken)
         {
-            var coverageQuery = _db
+            var coverageQuery = this.db
                 .LocalAuthorityDistrictCoverage
                 .Where(e => e.TuitionPartnerId == tp.Id);
 
@@ -192,14 +203,14 @@ public class TuitionPartner : PageModel
         {
             if (!request.ShowLocationsCovered) return Array.Empty<LocalAuthorityDistrictCoverage>();
 
-            var coverage = await _db.LocalAuthorityDistrictCoverage.Where(e => e.TuitionPartnerId == tpId)
+            var coverage = await this.db.LocalAuthorityDistrictCoverage.Where(e => e.TuitionPartnerId == tpId)
                 .ToArrayAsync();
 
             var coverageDictionary = coverage
                 .GroupBy(e => e.TuitionTypeId)
                 .ToDictionary(e => (TuitionType)e.Key, e => e.ToDictionary(x => x.LocalAuthorityDistrictId, x => x));
 
-            var regions = await _db.Regions
+            var regions = await this.db.Regions
                 .Include(e => e.LocalAuthorityDistricts.OrderBy(x => x.Code))
                 .OrderBy(e => e.Name)
                 .ToDictionaryAsync(e => e, e => e.LocalAuthorityDistricts);
@@ -274,7 +285,7 @@ public class TuitionPartner : PageModel
                 {
                     fullPricing[tuitionType][keyStage] = new Dictionary<string, Dictionary<int, decimal>>();
 
-                    var keyStageSubjects = await _db.Subjects.Where(e => e.KeyStageId == (int)keyStage).OrderBy(e => e.Name).ToArrayAsync();
+                    var keyStageSubjects = await this.db.Subjects.Where(e => e.KeyStageId == (int)keyStage).OrderBy(e => e.Name).ToArrayAsync();
                     foreach (var subject in keyStageSubjects)
                     {
                         fullPricing[tuitionType][keyStage][subject.Name] = new Dictionary<int, decimal>();

--- a/UI/cypress/e2e/cookies.feature
+++ b/UI/cypress/e2e/cookies.feature
@@ -98,10 +98,6 @@ Feature: User handles cookies
     When Saves Changes
     Then the error banner is displayed
 
-  Scenario: The cookie '.FindATuitionPartner.Mvc.CookieTempDataProvider' is added when a user has reached the search page
-    Given the search result page is displayed
-    Then cookie '.FindATuitionPartner.Mvc.CookieTempDataProvider' is added with value 'null'
-
   Scenario: User Select Accept Option from banner Should Stay on Same Page 
     Given a user has arrived on the funding and reporting page
     When cookies are accepted

--- a/UI/cypress/e2e/cookies.js
+++ b/UI/cypress/e2e/cookies.js
@@ -55,12 +55,6 @@ Given("a user accessed the search result page", () => {
     .should("be.checked");
 });
 
-Given("the search result page is displayed", () => {
-  cy.visit(
-    "search-results?Postcode=SK1%201EB&Subjects=KeyStage1-English&KeyStages=KeyStage1"
-  );
-});
-
 When("cookies are accepted", () => {
   cy.get('[data-testid="accept-cookies"]').click();
 });

--- a/UI/cypress/e2e/full-list.js
+++ b/UI/cypress/e2e/full-list.js
@@ -103,7 +103,10 @@ Then("the name of each tuition partner links to their details page", () => {
     cy.wrap($element).should(
       "have.attr",
       "href",
-      `/tuition-partner/${kebabCase($element.text()).replace(/'/g, "")}?from=FullList`
+      `/tuition-partner/${kebabCase($element.text()).replace(
+        /'/g,
+        ""
+      )}?from=FullList`
     );
   });
 });

--- a/UI/cypress/e2e/full-list.js
+++ b/UI/cypress/e2e/full-list.js
@@ -103,7 +103,7 @@ Then("the name of each tuition partner links to their details page", () => {
     cy.wrap($element).should(
       "have.attr",
       "href",
-      `/tuition-partner/${kebabCase($element.text()).replace(/'/g, "")}`
+      `/tuition-partner/${kebabCase($element.text()).replace(/'/g, "")}?from=FullList`
     );
   });
 });

--- a/UI/cypress/e2e/tuition-partner-user-journey.feature
+++ b/UI/cypress/e2e/tuition-partner-user-journey.feature
@@ -25,3 +25,14 @@ Feature: User can travel forwards and backwards
     And the subjects are edited in the subjects page after key stage has been edited
     And the tuition type is changed
     Then the filter selections are correct in the search results page with the edited selections
+
+  Scenario: User can search by postcode SK1 1EB to see Action Tutoring TP with filtered tuition (online only) types then search by new postcode NR1 1BD that excludes Action Tutoring and then find Action Tutoring via find all will show unfiltered tuition types (Online and School)
+    Given a user has started the 'Find a tuition partner' journey
+    And user has entered 'SK1 1EB' and journeyed forward to the 'Action Tutoring' tuition partner page
+    And they see the tuition types 'Online'
+    And they journey back to the search page
+    And they update the postcode on the search page to 'NR1 1BD' and go to a selected tuition partner page
+    And they will be journey back to the page they started from
+    When they click the 'All quality-assured tuition partners' link
+    And they select the 'Action Tutoring' tuition partner page
+    Then they see the tuition types 'In School, Online'

--- a/UI/cypress/e2e/tuition-partner-user-journey.js
+++ b/UI/cypress/e2e/tuition-partner-user-journey.js
@@ -166,7 +166,9 @@ Then(
   }
 );
 
-Then("user has entered {string} and journeyed forward to the {string} tuition partner page", (postcode, tp) => {
+Then(
+  "user has entered {string} and journeyed forward to the {string} tuition partner page",
+  (postcode, tp) => {
     Step(this, "they enter '" + postcode + "' as the school's postcode");
     Step(this, "they click 'Continue'");
     Step(this, "they will be taken to the 'Which key stages' page");
@@ -175,35 +177,36 @@ Then("user has entered {string} and journeyed forward to the {string} tuition pa
     Step(this, "they click 'Continue'");
     Step(this, "they will be taken to the 'Which subjects' page");
     Step(this, "they are shown the subjects for 'Key stage 2'");
-    Step(
-        this,
-        "they select 'Key stage 2 English'"
-    );
+    Step(this, "they select 'Key stage 2 English'");
     Step(this, "they click 'Continue'");
     Step(this, "they will be taken to the 'Search Results' page");
     Step(this, "they select the tuition partner '" + tp + "'");
     Step(this, "the page's title is '" + tp + "'");
-});
+  }
+);
 
 Then("they journey back to the search page", () => {
-    Step(this, "they click 'Back'");
-    Step(this, "they will be taken to the 'Search Results' page");
+  Step(this, "they click 'Back'");
+  Step(this, "they will be taken to the 'Search Results' page");
 });
 
-Then("they update the postcode on the search page to {string} and go to a selected tuition partner page", (postcode) => {
+Then(
+  "they update the postcode on the search page to {string} and go to a selected tuition partner page",
+  (postcode) => {
     Step(this, "they enter '" + postcode + "' as the school's postcode");
     Step(this, "they click 'Search'");
     Step(this, "they select the tuition partner 'Tute Education'");
-});
+  }
+);
 
 Then("they select the {string} tuition partner page", (tp) => {
-    Step(this, "they select the tuition partner '" + tp + "'");
-    Step(this, "the page's title is '" + tp + "'");
+  Step(this, "they select the tuition partner '" + tp + "'");
+  Step(this, "the page's title is '" + tp + "'");
 });
 
 When("they click the 'All quality-assured tuition partners' link", () => {
-    cy.get('[data-testid="full-list-link"]')
-        .should("exist")
-        .should("have.text", "All quality-assured tuition partners")
-        .click();
+  cy.get('[data-testid="full-list-link"]')
+    .should("exist")
+    .should("have.text", "All quality-assured tuition partners")
+    .click();
 });

--- a/UI/cypress/e2e/tuition-partner-user-journey.js
+++ b/UI/cypress/e2e/tuition-partner-user-journey.js
@@ -165,3 +165,45 @@ Then(
     cy.get(`input[id="in-school"]`).should("be.checked");
   }
 );
+
+Then("user has entered {string} and journeyed forward to the {string} tuition partner page", (postcode, tp) => {
+    Step(this, "they enter '" + postcode + "' as the school's postcode");
+    Step(this, "they click 'Continue'");
+    Step(this, "they will be taken to the 'Which key stages' page");
+    Step(this, "they will see all the keys stages as options");
+    Step(this, "they select 'Key stage 2'");
+    Step(this, "they click 'Continue'");
+    Step(this, "they will be taken to the 'Which subjects' page");
+    Step(this, "they are shown the subjects for 'Key stage 2'");
+    Step(
+        this,
+        "they select 'Key stage 2 English'"
+    );
+    Step(this, "they click 'Continue'");
+    Step(this, "they will be taken to the 'Search Results' page");
+    Step(this, "they select the tuition partner '" + tp + "'");
+    Step(this, "the page's title is '" + tp + "'");
+});
+
+Then("they journey back to the search page", () => {
+    Step(this, "they click 'Back'");
+    Step(this, "they will be taken to the 'Search Results' page");
+});
+
+Then("they update the postcode on the search page to {string} and go to a selected tuition partner page", (postcode) => {
+    Step(this, "they enter '" + postcode + "' as the school's postcode");
+    Step(this, "they click 'Search'");
+    Step(this, "they select the tuition partner 'Tute Education'");
+});
+
+Then("they select the {string} tuition partner page", (tp) => {
+    Step(this, "they select the tuition partner '" + tp + "'");
+    Step(this, "the page's title is '" + tp + "'");
+});
+
+When("they click the 'All quality-assured tuition partners' link", () => {
+    cy.get('[data-testid="full-list-link"]')
+        .should("exist")
+        .should("have.text", "All quality-assured tuition partners")
+        .click();
+});

--- a/UI/cypress/support/step_definitions/call-to-action.js
+++ b/UI/cypress/support/step_definitions/call-to-action.js
@@ -18,6 +18,10 @@ When("they click 'Continue'", () => {
   cy.get('[data-testid="call-to-action"]').click();
 });
 
+When("they click 'Search'", () => {
+    cy.get('[data-testid="call-to-action"]').click();
+});
+
 Then("the 'Back' link is not displayed", () => {
   cy.get(".govuk-back-link").should("not.exist");
 });

--- a/UI/cypress/support/step_definitions/call-to-action.js
+++ b/UI/cypress/support/step_definitions/call-to-action.js
@@ -19,7 +19,7 @@ When("they click 'Continue'", () => {
 });
 
 When("they click 'Search'", () => {
-    cy.get('[data-testid="call-to-action"]').click();
+  cy.get('[data-testid="call-to-action"]').click();
 });
 
 Then("the 'Back' link is not displayed", () => {


### PR DESCRIPTION
## Context

When a search is done the postcode (and LADs) are stored in temp data/session and then used to filter the details that are shown on the TP details page.  The same page is also called from the full list of TPs, which should show nationwide data.  The issue is that it's still applying the previously searched postcode/LADs that are in temp data.  

The suggestion is to switch this to using the query string that is similar to the rest of the website.

## Changes proposed in this pull request

To reproduce the issue do the following…

Do a search, with the following details

![image](https://user-images.githubusercontent.com/113545700/201053655-151893af-d5a7-49ad-9b7f-fafdb1ce2bcb.png)

If you then search for “Action Tutoring” on this page it will not be found, since it does not supply tutoring for this postcode.

Return to the full list of tutors and do the following

![image](https://user-images.githubusercontent.com/113545700/201053735-80d98c70-30dd-4441-ade0-36e11dfc988d.png)

Selecting the “Action Tutoring” TP shows the following, with the type of tuition and price details missing (since it applies the previously set postcode filter to the data, but shouldn’t)

![image](https://user-images.githubusercontent.com/113545700/201054928-48ba2c46-f872-46ed-80bf-010a42334e00.png)

The data should be displayed as follows…

![image](https://user-images.githubusercontent.com/113545700/201054971-6f441125-21a2-408c-8787-c1e3596aff4d.png)

## Guidance to review

The end-to-end tests use live data to verify the tuition types are shown / not shown when appropriate. This is the easiest way to write these tests as we currently have no way to manipulate the back-end data from cypress.

## Link to Jira ticket

[<!-- https://dfedigital.atlassian.net/browse/NTP-123 -->](https://dfedigital.atlassian.net/browse/NTP-659)

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**