### PR TITLE
NTP-729 : Fix cypress tests after "m2r Education" TP caused issue wit…

### DIFF
--- a/Application.Tests/Extensions/StringExtensionsTests.cs
+++ b/Application.Tests/Extensions/StringExtensionsTests.cs
@@ -70,6 +70,38 @@ public class StringExtensionsTests
         value.ToSeoUrl().Should().Be("search-id");
     }
 
+    [Fact]
+    public void ToSeoUrl_ReturnsKebabCase_WhenHasUnderscore()
+    {
+        const string value = "search_ Id";
+
+        value.ToSeoUrl().Should().Be("search_-id");
+    }
+
+    [Fact]
+    public void ToSeoUrl_ReturnsKebabCase_WhenValueCamelCase_WithNumbers()
+    {
+        const string value = "m2r Education";
+
+        value.ToSeoUrl().Should().Be("m-2r-education");
+    }
+
+    [Fact]
+    public void ToSeoUrl_ReturnsKebabCase_WhenValueCamelCase_WithHypen()
+    {
+        const string value = "PET-Xi Training Limited";
+
+        value.ToSeoUrl().Should().Be("pet-xi-training-limited");
+    }
+
+    [Fact]
+    public void ToSeoUrl_ReturnsKebabCase_WhenValueCamelCase_WithAmpersand()
+    {
+        const string value = "CER, Monarch Education & Sugarman Education (Parent- Affinity Workforce Solutions)";
+
+        value.ToSeoUrl().Should().Be("cer-monarch-education--sugarman-education-(parent--affinity-workforce-solutions)");
+    }
+
     [Theory]
     [InlineData("apostrophe's", "apostrophes")]
     [InlineData("special!\"£$%^&*+=chars", "specialchars")]

--- a/UI/cypress/support/utils.js
+++ b/UI/cypress/support/utils.js
@@ -1,6 +1,6 @@
 export const kebabCase = (string) =>
   string
-    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+)/g, " $1")
     .replace(/[\s_]+/g, "-")
     .replace(/[^a-zA-Z0-9_{}()\-~/]/g, "")
     .toLowerCase();

--- a/UI/cypress/support/utils.js
+++ b/UI/cypress/support/utils.js
@@ -1,6 +1,9 @@
 export const kebabCase = (string) =>
   string
-    .replace(/((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+)/g, " $1")
+    .replace(
+      /((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+)/g,
+      " $1"
+    )
     .replace(/[\s_]+/g, "-")
     .replace(/[^a-zA-Z0-9_{}()\-~/]/g, "")
     .toLowerCase();


### PR DESCRIPTION
## Context

Error when running cypress tests since the end to end tests are out of date with the C# logic that sets the URL for the pages on import.  Spotted when a new "m2r Education" TP was added and the URL is "m-2r-education", but the cypress tests are using  "m2r-education"

## Changes proposed in this pull request

Update cypress test logic so it cater for the new TP

## Guidance to review

Check this works by running the end-to-end tests

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-729

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**