### PR TITLE
NTP-731: Tidy up TP URL format

### DIFF
--- a/Application.Tests/Extensions/StringExtensionsTests.cs
+++ b/Application.Tests/Extensions/StringExtensionsTests.cs
@@ -75,15 +75,19 @@ public class StringExtensionsTests
     {
         const string value = "search_ Id";
 
-        value.ToSeoUrl().Should().Be("search_-id");
+        value.ToSeoUrl().Should().Be("search-id");
     }
 
-    [Fact]
-    public void ToSeoUrl_ReturnsKebabCase_WhenValueCamelCase_WithNumbers()
+    [Theory]
+    [InlineData("m2r Education", "m-2-r-education")]
+    [InlineData("KeyStage1-Science", "key-stage-1-science")]
+    [InlineData("KeyStage1Science", "key-stage-1-science")]
+    [InlineData("Keystage1science", "keystage-1-science")]
+    [InlineData("KeyStage123Science", "key-stage-123-science")]
+    [InlineData("m123r Education", "m-123-r-education")]
+    public void ToSeoUrl_ReturnsKebabCase_WhenValueCamelCase_WithNumbers(string camel, string kebab)
     {
-        const string value = "m2r Education";
-
-        value.ToSeoUrl().Should().Be("m-2r-education");
+        camel.ToSeoUrl().Should().Be(kebab);
     }
 
     [Fact]
@@ -99,7 +103,7 @@ public class StringExtensionsTests
     {
         const string value = "CER, Monarch Education & Sugarman Education (Parent- Affinity Workforce Solutions)";
 
-        value.ToSeoUrl().Should().Be("cer-monarch-education--sugarman-education-(parent--affinity-workforce-solutions)");
+        value.ToSeoUrl().Should().Be("cer-monarch-education-sugarman-education-(parent-affinity-workforce-solutions)");
     }
 
     [Theory]

--- a/Application/Extensions/StringExtensions.cs
+++ b/Application/Extensions/StringExtensions.cs
@@ -5,8 +5,10 @@ namespace Application.Extensions;
 
 public static class StringExtensions
 {
-    private const string CamelCaseBoundaries = @"((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+)";
+    private const string CamelCaseBoundaries = @"((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+|(?<=\d+)[a-z])";
+    private const string SpacesAndUnderscore = @"[\s_]+";
     private const string UrlUnsafeCharacters = "[^a-zA-Z0-9_{}()\\-~/]";
+    private const string MultipleUnderscores = @"[-]{2,}";
 
     [return: NotNullIfNotNull("value")]
     public static string? ToSeoUrl(this string? value)
@@ -14,8 +16,9 @@ public static class StringExtensions
         var seo = value?
             .RegexReplace(CamelCaseBoundaries, " $1")
             .Trim()
-            .Replace(' ', '-')
+            .RegexReplace(SpacesAndUnderscore, "-")
             .RegexReplace(UrlUnsafeCharacters, "")
+            .RegexReplace(MultipleUnderscores, "-")
             .ToLower();
 
         return seo;

--- a/UI/cypress/e2e/tuition-partner-details.feature
+++ b/UI/cypress/e2e/tuition-partner-details.feature
@@ -23,7 +23,7 @@ Feature: User can view full details of a Tuition Parner
     Then TP has not provided the information in the 'Email address' section
 
   Scenario: don’t show phone number where TP has not provided information
-    Given a user has arrived on the 'Tuition Partner' page for 'lancashire-county-council'
+    Given a user has arrived on the 'Tuition Partner' page for 'pearson'
     Then TP has not provided the information in the 'Phone Number' section
 
   Scenario: show Contact Details where TP has provided information

--- a/UI/cypress/support/utils.js
+++ b/UI/cypress/support/utils.js
@@ -1,11 +1,13 @@
 export const kebabCase = (string) =>
   string
     .replace(
-      /((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+)/g,
+      /((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+|(?<=\d+)[a-z])/g,
       " $1"
     )
+    .trim()
     .replace(/[\s_]+/g, "-")
     .replace(/[^a-zA-Z0-9_{}()\-~/]/g, "")
+    .replace(/[-]{2,}/g, "-")
     .toLowerCase();
 
 export const removeWhitespace = (string) => string.trim().replace(/\s/, "");


### PR DESCRIPTION
## Context

A couple of the TP URLs (which is generated by their name) were not in the best format and could be tidied up…

CER, Monarch Education & Sugarman Education (Parent- Affinity Workforce Solutions): https://www.find-tuition-partner.service.gov.uk/tuition-partner/cer-monarch-education--sugarman-education-(parent--affinity-workforce-solutions) has a URL with double hyphens rather than single: cer-monarch-education--sugarman-education-(parent--affinity-workforce-solutions)

m2r Education: https://www.find-tuition-partner.service.gov.uk/tuition-partner/m-2r-education is shown as m-2r-education, but would be better as m-2-r-education

## Changes proposed in this pull request

Update the SEO URL C# logic and the corresponding cypress js test logic to ensure that all of the exsiting TP URLs stay the same but the following work as specified: 

m2r Education = m-2-r-education
KeyStage1-Science = key-stage-1-science
KeyStage1Science = key-stage-1-science
Keystage1science = keystage-1-science
KeyStage123Science = key-stage-123-science
m123r Education = m-123-r-education
CER, Monarch Education & Sugarman Education (Parent- Affinity Workforce Solutions): cer-monarch-education-sugarman-education-(parent-affinity-workforce-solutions

## Guidance to review

Check this works by running the unit and end-to-end tests

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-731

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [x] **PR deployment has been signed off by wider team**