### PR TITLE
NTP-739: switch no phone number test to use pearson TP

### DIFF
--- a/UI/cypress/e2e/tuition-partner-details.feature
+++ b/UI/cypress/e2e/tuition-partner-details.feature
@@ -23,7 +23,7 @@ Feature: User can view full details of a Tuition Parner
     Then TP has not provided the information in the 'Email address' section
 
   Scenario: don’t show phone number where TP has not provided information
-    Given a user has arrived on the 'Tuition Partner' page for 'lancashire-county-council'
+    Given a user has arrived on the 'Tuition Partner' page for 'pearson'
     Then TP has not provided the information in the 'Phone Number' section
 
   Scenario: show Contact Details where TP has provided information


### PR DESCRIPTION
## Context

Cypress end to end tests broken when Lancashire County Council TP has been removed from the service

## Changes proposed in this pull request

Update to be a different TP - “Pearson”

## Guidance to review

Run end to end tests

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-739

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [x] **PR deployment has been signed off by wider team**