### PR TITLE
NTP-731: Tidy up TP URL format (#191)

### DIFF
--- a/Application.Tests/Extensions/StringExtensionsTests.cs
+++ b/Application.Tests/Extensions/StringExtensionsTests.cs
@@ -75,15 +75,19 @@ public class StringExtensionsTests
     {
         const string value = "search_ Id";
 
-        value.ToSeoUrl().Should().Be("search_-id");
+        value.ToSeoUrl().Should().Be("search-id");
     }
 
-    [Fact]
-    public void ToSeoUrl_ReturnsKebabCase_WhenValueCamelCase_WithNumbers()
+    [Theory]
+    [InlineData("m2r Education", "m-2-r-education")]
+    [InlineData("KeyStage1-Science", "key-stage-1-science")]
+    [InlineData("KeyStage1Science", "key-stage-1-science")]
+    [InlineData("Keystage1science", "keystage-1-science")]
+    [InlineData("KeyStage123Science", "key-stage-123-science")]
+    [InlineData("m123r Education", "m-123-r-education")]
+    public void ToSeoUrl_ReturnsKebabCase_WhenValueCamelCase_WithNumbers(string camel, string kebab)
     {
-        const string value = "m2r Education";
-
-        value.ToSeoUrl().Should().Be("m-2r-education");
+        camel.ToSeoUrl().Should().Be(kebab);
     }
 
     [Fact]
@@ -99,7 +103,7 @@ public class StringExtensionsTests
     {
         const string value = "CER, Monarch Education & Sugarman Education (Parent- Affinity Workforce Solutions)";
 
-        value.ToSeoUrl().Should().Be("cer-monarch-education--sugarman-education-(parent--affinity-workforce-solutions)");
+        value.ToSeoUrl().Should().Be("cer-monarch-education-sugarman-education-(parent-affinity-workforce-solutions)");
     }
 
     [Theory]

--- a/Application/Extensions/StringExtensions.cs
+++ b/Application/Extensions/StringExtensions.cs
@@ -5,8 +5,10 @@ namespace Application.Extensions;
 
 public static class StringExtensions
 {
-    private const string CamelCaseBoundaries = @"((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+)";
+    private const string CamelCaseBoundaries = @"((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+|(?<=\d+)[a-z])";
+    private const string SpacesAndUnderscore = @"[\s_]+";
     private const string UrlUnsafeCharacters = "[^a-zA-Z0-9_{}()\\-~/]";
+    private const string MultipleUnderscores = @"[-]{2,}";
 
     [return: NotNullIfNotNull("value")]
     public static string? ToSeoUrl(this string? value)
@@ -14,8 +16,9 @@ public static class StringExtensions
         var seo = value?
             .RegexReplace(CamelCaseBoundaries, " $1")
             .Trim()
-            .Replace(' ', '-')
+            .RegexReplace(SpacesAndUnderscore, "-")
             .RegexReplace(UrlUnsafeCharacters, "")
+            .RegexReplace(MultipleUnderscores, "-")
             .ToLower();
 
         return seo;

--- a/UI/cypress/support/utils.js
+++ b/UI/cypress/support/utils.js
@@ -1,11 +1,13 @@
 export const kebabCase = (string) =>
   string
     .replace(
-      /((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+)/g,
+      /((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+|(?<=\d+)[a-z])/g,
       " $1"
     )
+    .trim()
     .replace(/[\s_]+/g, "-")
     .replace(/[^a-zA-Z0-9_{}()\-~/]/g, "")
+    .replace(/[-]{2,}/g, "-")
     .toLowerCase();
 
 export const removeWhitespace = (string) => string.trim().replace(/\s/, "");


### PR DESCRIPTION
* NTP-731 - Tidy up TP URL format

* NTP-739: switch no phone number test to use pearson TP (#193) (#194)

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

<!-- https://dfedigital.atlassian.net/browse/NTP-123 -->

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**