### PR TITLE
NTP-764: Resolve issue with 404 error on 3D Recruit Ltd TP details page

### DIFF
--- a/UI/Pages/TuitionPartner.cshtml.cs
+++ b/UI/Pages/TuitionPartner.cshtml.cs
@@ -34,19 +34,21 @@ public class TuitionPartner : PageModel
             return NotFound();
         }
 
-        var seoUrl = query.Id.ToSeoUrl();
-        if (query.Id != seoUrl)
-        {
-            _logger.LogInformation("Non SEO id '{Id}' provided. Redirecting to {SeoUrl}", query.Id, seoUrl);
-            return RedirectToPage((query with { Id = seoUrl }).ToRouteData());
-        }
-
         Data = await _mediator.Send(query);
 
         if (Data == null)
         {
-            _logger.LogInformation("No Tuition Partner found for id '{Id}'", query.Id);
-            return NotFound();
+            var seoUrl = query.Id.ToSeoUrl();
+            if (query.Id != seoUrl)
+            {
+                _logger.LogInformation("Non SEO id '{Id}' provided. Redirecting to {SeoUrl}", query.Id, seoUrl);
+                return RedirectToPage((query with { Id = seoUrl }).ToRouteData());
+            }
+            else
+            {
+                _logger.LogInformation("No Tuition Partner found for id '{Id}'", query.Id);
+                return NotFound();
+            }
         }
 
         _logger.LogInformation("Tuition Partner {Name} found for id '{Id}'", Data.Name, query.Id);

--- a/UI/cypress/e2e/full-list.feature
+++ b/UI/cypress/e2e/full-list.feature
@@ -91,3 +91,8 @@ Scenario: Logos are not displayed for tution partners
     Given a user is using a 'phone'
     Given a user has arrived on the all quality-assured tuition partners page
     Then logos are not shown for tuition partners
+
+  Scenario: From the full list we can visit each TP details page and see the Type of Tuition details
+    Given a user has started the 'Find a tuition partner' journey
+    When they click the 'All quality-assured tuition partners' link
+    Then they we can visit each TP details page and see the Type of Tuition details

--- a/UI/cypress/e2e/full-list.js
+++ b/UI/cypress/e2e/full-list.js
@@ -193,3 +193,14 @@ Then("logos are not shown for tuition partners", () => {
     "not.be.visible"
   );
 });
+
+Then(
+  "they we can visit each TP details page and see the Type of Tuition details",
+  () => {
+    cy.get('[data-testid="tuition-partner-name-link"]').each(($element) => {
+      cy.visit($element.attr("href"));
+      cy.get('[data-testid="type-of-tuition"]').first().should("not.be.empty");
+      cy.get(".govuk-back-link").click();
+    });
+  }
+);


### PR DESCRIPTION
## Context

Issue with navigating to 3D Recruit TP details page.

Issue navigating to the 3D Recruit Ltd TP details page, getting a 404 error page.  Can be reproduced by clicking the “3D Recruit Ltd“ link from the following page [All Tuition Partners](https://www.find-tuition-partner.service.gov.uk/all-tuition-partners)

This is because there is a check on the TP details page to ensure that the URL format is correct when it loads this page.  The link is using “3d-recruit-ltd”, which is correct, since this is the correct SEO URL for the TP name of “3D Recruit Ltd“.  But the check on the TP details page is not formatting the TP name (e.g. “3D Recruit Ltd“) to compare against the passed in URL.  It is formatting the URL (so “3d-recruit-ltd” in this case) to ensure it is as excepted, but since it may be lower case already the format is meaning the outcome is different.  So it’s expecting “3-d-recruit-ltd“ and then it redirects to that, which is invalid, hence the 404 error page.

This is caused as a knock on impact from [NTP-731: Dev - Tidy up TP URL formatDONE](https://dfedigital.atlassian.net/browse/NTP-731)

The end-to-end tests did not catch this, so these should be updated to ensure that every TP details page can be accessed as expected.

## Changes proposed in this pull request

Ensure that the SEO URL check is only done if it doesn't match
Add in end-to-end tests to make sure that all TP details pages can be reached

## Guidance to review

Manually go to 3D Recruit Ltd TP details page and can also run new end-to-end test called "From the full list we can visit each TP details page and see the Type of Tuition details"

## Link to Jira ticket

[<!-- https://dfedigital.atlassian.net/browse/NTP-123 -->](https://dfedigital.atlassian.net/browse/NTP-764)

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [x] **PR deployment has been signed off by wider team**