### PR TITLE
NTP-717: Ensure checkboxes can be selected on filters with no js

### DIFF
--- a/UI/Pages/Shared/_OptionsSelect.cshtml
+++ b/UI/Pages/Shared/_OptionsSelect.cshtml
@@ -12,7 +12,7 @@
         <div class="app-c-option-select__container-inner">
             <div class="gem-c-checkboxes govuk-form-group govuk-checkboxes--small" data-module="gem-checkboxes">
                 <fieldset class="govuk-fieldset govuk-checkboxes--small govuk-!-margin-left-1">
-                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden">@Model.DisplayName</legend>
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s app-c-option-select__legend">@Model.DisplayName</legend>
 
                     <ul class="govuk-checkboxes gem-c-checkboxes__list" data-module="govuk-checkboxes">
                         @foreach (var subject in Model.Items)

--- a/UI/Pages/Shared/_OptionsSelect.cshtml
+++ b/UI/Pages/Shared/_OptionsSelect.cshtml
@@ -3,10 +3,7 @@
 <div class="app-c-option-select js-collapsible" data-testid="@Model.Name" data-module="option-select" @Model.ClosedData>
 
     <div class="app-c-option-select__heading js-container-heading">
-        <button class="js-container-button app-c-option-select__title app-c-option-select__button" type="button"
-                id="option-select-title-@Model.Name" aria-controls="list-of-@Model.Name">
-            @Model.DisplayName
-        </button>
+        <span class="app-c-option-select__title js-container-button" id="option-select-title-@Model.Name">@Model.DisplayName</span>
         <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"></path></svg>
         <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"></path></svg>
     </div>

--- a/UI/src/sass/option-select.scss
+++ b/UI/src/sass/option-select.scss
@@ -116,10 +116,19 @@ ul.gem-c-checkboxes__list {
   }
 }
 
+.app-c-option-select__heading {
+  display: none;
+}
+
 .js-enabled {
   .app-c-option-select__heading {
     position: relative;
     padding: 10px 8px 0px 35px;
+    display: block;
+  }
+
+  .app-c-option-select__legend {
+    display: none;
   }
 
   [aria-expanded="true"] ~ .app-c-option-select__icon--up {

--- a/UI/src/sass/option-select.scss
+++ b/UI/src/sass/option-select.scss
@@ -128,7 +128,7 @@ ul.gem-c-checkboxes__list {
   }
 
   .app-c-option-select__legend {
-    display: none;
+    @extend .govuk-visually-hidden;
   }
 
   [aria-expanded="true"] ~ .app-c-option-select__icon--up {


### PR DESCRIPTION
## Context

To reproduce:

Disable JS

Carry out a search and get to the results page

Attempt to change the subject checkboxes on the left side

Expected result:

At 3. The checkboxes can be changed and ‘Apply filters’ will update the results

Actual result:

At 3. The checkboxes cannot be clicked with the mouse (although they can be selected with the keyboard).

## Changes proposed in this pull request

The issue is that the "Key Stage" filter headings (that collapse and expand the sections when js is enabled) is set as a an HTML button, which is correct when js is enabled, but by design it should be a span when js is disabled.   This then allows the checkboxes to be selected.  

The following component is used and details about this are on line 131 of the js file:
https://github.com/alphagov/finder-frontend/blob/main/app/assets/javascripts/components/option-select.js 

This work was originally done as part of 
https://dfedigital.atlassian.net/browse/NTP-355

## Guidance to review

Follow the steps above and test without js

## Link to Jira ticket

[<!-- https://dfedigital.atlassian.net/browse/NTP-123 -->](https://dfedigital.atlassian.net/browse/NTP-717)

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**