### PR TITLE
NTP-741: "Back" link is incorrectly inside the <main> element

### DIFF
--- a/UI/Pages/AcademicMentors.cshtml
+++ b/UI/Pages/AcademicMentors.cshtml
@@ -1,11 +1,10 @@
 ﻿@page
 @{
     ViewData["Title"] = "Employ mentors";
+    ViewData["IncludeHomeLink"] = true;
 }
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <a href="/" data-testid="home-link" class="govuk-back-link">Home</a>
         <h1 class="govuk-heading-l" data-testid="academic-mentors-header">Employ an academic mentor</h1>
         <p class="govuk-body">
             You can employ an academic mentor for a year at a time as a salaried member of staff. They’ll work alongside
@@ -34,7 +33,7 @@
         </p>
         <p class="govuk-body">
             Use the Education Development Trust service to <a href="http://nominations.tutortraining.co.uk/registration" target="_blank"
-                                                              class="govuk-link" data-testid="book-training">book training for your academic mentor</a>.
+                                                                class="govuk-link" data-testid="book-training">book training for your academic mentor</a>.
         </p>
 
         <h3 class="govuk-heading-m" data-testid="renewing-contract-header">
@@ -78,7 +77,7 @@
             <li>references</li>
             <li>
                 <a href="https://www.gov.uk/find-out-dbs-check/y/caring-for-or-working-with-children-under-18-or-working-in-a-school/teaching-or-caring-for-children/working-in-a-school-nursery-children-s-centre-or-home-detention-service-young-offender-institution-or-childcare-premises/yes"
-                   target="_blank" data-testid="dbs-check-link" class="govuk-link">DBS enhanced check with barred lists</a>
+                    target="_blank" data-testid="dbs-check-link" class="govuk-link">DBS enhanced check with barred lists</a>
             </li>
         </ul>
     </div>

--- a/UI/Pages/Accessibility.cshtml
+++ b/UI/Pages/Accessibility.cshtml
@@ -1,6 +1,7 @@
 ﻿@page
 @{
     ViewData["Title"] = "Accessibility statement";
+    ViewData["IncludeHomeLink"] = true;
 }
 
 <div class="govuk-grid-row">

--- a/UI/Pages/AllTuitionPartners.cshtml
+++ b/UI/Pages/AllTuitionPartners.cshtml
@@ -2,17 +2,9 @@
 @model AllTuitionPartners
 @{
     ViewData["Title"] = "All Tuition Partners";
+    ViewData["BackLinkHref"] = "/";
+    ViewData["IncludePrintPage"] = true;
 }
-
-<div class="app-print-this-page--container govuk-!-margin-bottom-3">
-    <div class="app-print-this-page--container-left govuk-!-padding-top-3">
-        <a asp-page="@nameof(Index)" class="govuk-link" data-testid="home-link">Home</a>
-    </div>
-
-    <div class="govuk-body app-print-this-page--container-right">
-        <a href="#" class="govuk-link app-print-this-page--link" data-module="print-this-page-link" data-testid="print-this-page-link">Print this page</a>
-    </div>
-</div>
 
 <div class="govuk-grid-row">
     <form method="get">

--- a/UI/Pages/ContactUs.cshtml
+++ b/UI/Pages/ContactUs.cshtml
@@ -2,10 +2,10 @@
 @model ContactUsModel
 @{
     ViewData["Title"] = "Contact us";
+    ViewData["BackLinkHref"] = Model.ReturnPath;
 }
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <a href="@Model.ReturnPath" data-testid="back-link" class="govuk-back-link">Back</a>
         <h1 class="govuk-heading-l" data-testid="contact-us-header">
             Contact us
         </h1>

--- a/UI/Pages/Cookies.cshtml
+++ b/UI/Pages/Cookies.cshtml
@@ -3,6 +3,7 @@
 @{
     ViewData["Title"] = "Cookies";
     ViewData["Hide Banner"] = "true";
+    ViewData["IncludeHomeLink"] = true;
 }
 
 

--- a/UI/Pages/Error.cshtml
+++ b/UI/Pages/Error.cshtml
@@ -11,6 +11,7 @@
     {
         ViewData["Title"] = "Problem with the service";
     }
+    ViewData["IncludeHomeLink"] = true;
 }
 
 <div class="govuk-width-container">

--- a/UI/Pages/FundingAndReporting.cshtml
+++ b/UI/Pages/FundingAndReporting.cshtml
@@ -2,10 +2,10 @@
 @model FundingAndReporting
 @{
     ViewData["Title"] = "Funding";
+    ViewData["BackLinkHref"] = Model.ReturnPath;
 }
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <a href="@Model.ReturnPath" data-testid="back-link" class="govuk-back-link">Back</a>
         <h1 class="govuk-heading-l" data-testid="funding-reporting-header">Funding and Reporting</h1>
 
         <p class="govuk-body">

--- a/UI/Pages/Privacy.cshtml
+++ b/UI/Pages/Privacy.cshtml
@@ -1,10 +1,10 @@
 ﻿@page
 @{
     ViewData["Title"] = "Privacy notice";
+    ViewData["IncludeHomeLink"] = true;
 }
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <a href="/" data-testid="home-link" class="govuk-back-link">Home</a>
         <h1 class="govuk-heading-l" data-testid="privacy-header">Find a tuition partner privacy notice</h1>
         <p class="govuk-body">
             This privacy notice explains how the Department for Education (DfE) uses (processes) any

--- a/UI/Pages/ReportIssues.cshtml
+++ b/UI/Pages/ReportIssues.cshtml
@@ -2,10 +2,10 @@
 @model ReportIssues
 @{
     ViewData["Title"] = "Report issues";
+    ViewData["IncludeHomeLink"] = true;
 }
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <a href="/" data-testid="home-link" class="govuk-link">Home</a><br><br>
         <h1 class="govuk-heading-l" data-testid="report-issues-header">
             If you have an issue with your tuition partner
         </h1>

--- a/UI/Pages/SchoolLedTutoring.cshtml
+++ b/UI/Pages/SchoolLedTutoring.cshtml
@@ -1,10 +1,10 @@
 ﻿@page
 @{
     ViewData["Title"] = "Employ tutors";
+    ViewData["IncludeHomeLink"] = true;
 }
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <a href="/" data-testid="home-link" class="govuk-back-link">Home</a>
         <h1 class="govuk-heading-l" data-testid="school-led-header">Employ your own tutor</h1>
         <p class="govuk-body">
             You can employ someone directly as a tutor for your school, for example a member of teaching

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -2,17 +2,9 @@
 @model SearchResults
 @{
     ViewData["Title"] = "Search results";
+    ViewData["BackLinkHref"] = "/which-subjects?" + Model.Data.ToQueryString();
+    ViewData["IncludePrintPage"] = true;
 }
-
-<div class="app-print-this-page--container">
-    <div class="app-print-this-page--container-left">
-        <a href="/which-subjects?@Model.Data.ToQueryString()" class="govuk-back-link">Back</a>
-    </div>
-
-    <div class="govuk-body app-print-this-page--container-right">
-        <a href="#" class="govuk-link app-print-this-page--link" data-module="print-this-page-link" data-testid="print-this-page-link">Print this page</a>
-    </div>
-</div>
 
 <div class="govuk-grid-row app-print-hide">
     <div class="govuk-grid-column-full">

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -6,6 +6,13 @@
     // Only allow search engines to index pages on the production environment that have explicitly set AllowIndexing to true
     var allowIndexing = HostEnvironment.IsProduction() && ViewData["AllowIndexing"] as bool? == true;
 
+    var includeHomeLink = ViewData["IncludeHomeLink"] as bool? == true; 
+    var backLinkHref = ViewData["BackLinkHref"] as string; 
+    var backLinkText = ViewData["BackLinkText"] as string;
+    backLinkText = backLinkText ?? "Back";
+    var includeBackLink = backLinkHref is not null;
+    var includePrintPage = includeBackLink && ViewData["IncludePrintPage"] as bool? == true; 
+
     var containerId = Configuration["GoogleTagManager:ContainerId"];
     var enableGoogleTagManager = !string.IsNullOrWhiteSpace(containerId);
 
@@ -154,9 +161,38 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </p>
         </div>
 
+        @if (includeHomeLink)
+        {
+        <div class="govuk-breadcrumbs">
+          <ol class="govuk-breadcrumbs__list">
+            <li class="govuk-breadcrumbs__list-item">
+              <a asp-page="@nameof(Index)" class="govuk-breadcrumbs__link" data-testid="home-link" >Home</a>
+            </li>
+          </ol>
+        </div>
+        }
+        
+        @if (includePrintPage)
+        {
+            <div class="app-print-this-page--container">
+                <div class="app-print-this-page--container-left">
+                    <a href="@backLinkHref" data-testid="back-link" class="govuk-back-link">@backLinkText</a>
+                </div>
+
+                <div class="govuk-body app-print-this-page--container-right">
+                    <a href="#" class="govuk-link app-print-this-page--link" data-module="print-this-page-link" data-testid="print-this-page-link">Print this page</a>
+                </div>
+            </div>
+        }
+        else if(includeBackLink)
+        {
+            <a href="@backLinkHref" data-testid="back-link" class="govuk-back-link">@backLinkText</a>
+        }
+
         <main class="govuk-main-wrapper " id="main-content" role="main">
             @RenderBody()
         </main>
+
         @if (showContactus)
         {
             <div class="govuk-grid-row">

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -2,32 +2,18 @@
 @model TuitionPartner
 @{
     ViewData["Title"] = Model.Data!.Name;
+    if (Model.SearchModel?.From == ReferrerList.FullList)
+    {
+        ViewData["BackLinkHref"] = "/all-tuition-partners?" + Model.SearchModel.ToQueryString();
+        ViewData["BackLinkText"] = "Back to tuition partners";
+    }
+    else
+    {
+        ViewData["BackLinkHref"] = "/search-results?" + Model.SearchModel.ToQueryString();
+        ViewData["BackLinkText"] = "Back to search results";
+    }
+    ViewData["IncludePrintPage"] = true;
 }
-<div class="app-print-hide">
-    <a asp-page="@nameof(Index)" class="govuk-link" data-testid="home-link">Home</a>
-</div>
-
-<div class="app-print-this-page--container">
-    <div class="app-print-this-page--container-left">
-        @if (Model.SearchModel?.From == ReferrerList.FullList)
-        {
-            <a href="/all-tuition-partners?@Model.SearchModel.ToQueryString()" class="govuk-back-link">
-                Back to tuition partners
-            </a>
-        }
-        else
-        {
-            <a href="/search-results?@Model.SearchModel.ToQueryString()" class="govuk-back-link">
-                Back to search results
-            </a>
-        }
-    </div>
-    
-    <div class="govuk-body app-print-this-page--container-right">
-        <a href="#" class="govuk-link app-print-this-page--link" data-module="print-this-page-link" data-testid="print-this-page-link">Print this page</a>
-    </div>
-</div>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">@Model.Data.Name</h1>

--- a/UI/Pages/WhichKeyStages.cshtml
+++ b/UI/Pages/WhichKeyStages.cshtml
@@ -2,9 +2,8 @@
 @model WhichKeyStages
 @{
     ViewData["Title"] = "Which key stages do you need tutoring support for?";
+    ViewData["BackLinkHref"] = "/?" + Model.Data.ToQueryString();
 }
-
-<a href="/?@Model.Data.ToQueryString()" class="govuk-back-link">Back</a>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/UI/Pages/WhichSubjects.cshtml
+++ b/UI/Pages/WhichSubjects.cshtml
@@ -2,9 +2,8 @@
 @model WhichSubjects
 @{
     ViewData["Title"] = "Which subjects do you need tutoring support for?";
+    ViewData["BackLinkHref"] = "/which-key-stages?" + Model.Data.ToQueryString();
 }
-
-<a href="/which-key-stages?@Model.Data.ToQueryString()" class="govuk-back-link">Back</a>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/UI/cypress/e2e/full-list.feature
+++ b/UI/cypress/e2e/full-list.feature
@@ -17,11 +17,6 @@ Scenario: all quality-assured tuition partners page url is '/all-tuition-partner
     When they click the 'All quality-assured tuition partners' link
     Then they will see the 'All quality-assured tuition partners' page
 
-  Scenario: home link returns to service start page
-    Given a user has arrived on the all quality-assured tuition partners page
-    When they click 'Home'
-    Then they will be taken to the 'Find a tuition partner' journey start page
-
   Scenario: full list of quality-assured tuition partners is in alphabetical order by name
     Given a user has arrived on the all quality-assured tuition partners page
     Then the full list of quality-assured tuition partners is in alphabetical order by name

--- a/UI/cypress/e2e/tuition-partner-details.feature
+++ b/UI/cypress/e2e/tuition-partner-details.feature
@@ -30,11 +30,6 @@ Feature: User can view full details of a Tuition Parner
     Given a user has arrived on the 'Tuition Partner' page for 'bright-heart-education'
     Then TP has provided full contact details
 
-  Scenario: home page is selected 
-    Given a user has arrived on the 'Tuition Partner' page for 'bright-heart-education'
-    When they click 'Home'
-    Then they will be taken to the 'Find a tuition partner' journey start page
-
   Scenario: tuition partner details page linked from search results page has 'Back to search results' back link
     Given a user has arrived on the 'Tuition Partner' page for 'Bright Heart Education' after searching for 'Key stage 1 English'
     Then the back link's text is 'Back to search results'

--- a/UI/src/index.scss
+++ b/UI/src/index.scss
@@ -14,6 +14,7 @@ $govuk-page-width: 1180px;
 
 // GDS components that we use
 @import "node_modules/govuk-frontend/govuk/components/back-link/index";
+@import "node_modules/govuk-frontend/govuk/components/breadcrumbs/index";
 @import "node_modules/govuk-frontend/govuk/components/button/index";
 @import "node_modules/govuk-frontend/govuk/components/checkboxes/index";
 @import "node_modules/govuk-frontend/govuk/components/cookie-banner/index";


### PR DESCRIPTION
## Context

 "Back" link is incorrectly inside the "main" HTML element - change to ensure meets GDS

## Changes proposed in this pull request

Move the back, home and print to outside the main

The “Back” link and “Print this page” links are currently inside the "main" HTML element. The standard GDS layout [GOV.UK - Customised page template](https://design-system.service.gov.uk/styles/page-template/custom/index.html) has the Back link deliberately outside of the "main", sitting between the phase banner and the "main".

## Guidance to review

The “Back” link (and “Print this page” link if applicable) have been moved between the phase banner and main element on all pages.

The “Back” link is sitting in the correct page position, closer to the phase banner, and further from the h1 (as per attached image)

![image](https://user-images.githubusercontent.com/113545700/206219360-c53ff239-df38-43d1-99d8-4382cffb6716.png)

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-741

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**