### PR TITLE
NTP-785: Using Browser Navigation Bug Fix

### DIFF
--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -4,7 +4,7 @@ using Domain.Search;
 using FluentValidationResult = FluentValidation.Results.ValidationResult;
 
 namespace UI.Pages;
-
+[ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
 public class SearchResults : PageModel
 {
     private readonly IMediator _mediator;
@@ -151,7 +151,7 @@ public class SearchResults : PageModel
         return selectableTuitionPartnerModels;
     }
 
-    private bool IsParamValid(string value) => !(string.IsNullOrEmpty(value) || value.ToLower().Equals("undefined"));
+    private bool IsParamValid(string value) => !(string.IsNullOrWhiteSpace(value) || value.ToLower().Equals("undefined"));
 
     private JsonResult GetJsonResult(int totalShortlistedTuitionPartners) =>
         new(new UpdateTuitionPartnerResult(true, totalShortlistedTuitionPartners));

--- a/UI/Pages/SearchResults.cshtml.js
+++ b/UI/Pages/SearchResults.cshtml.js
@@ -101,19 +101,6 @@ const onCheckboxClick = async (event) => {
   }
 };
 
-//Prevents user from going to the previous page using the browser's back button
-const preventBrowserBackButtonFunctionality = () => {
-  history.pushState(null, null, document.URL);
-  window.addEventListener("popstate", function () {
-    history.pushState(null, null, document.URL);
-  });
-};
-
-const reloadOnBackNavigation = () => {
-  const perfEntries = performance.getEntriesByType("navigation");
-  if (perfEntries && perfEntries[0].type === "back_forward") location.reload();
-};
-
 const addClickEventListenerToTuitionPartnerCheckboxes = () => {
   const selectableTuitionPartners = document.getElementsByName(
     "ShortlistedTuitionPartners"
@@ -125,6 +112,4 @@ const addClickEventListenerToTuitionPartnerCheckboxes = () => {
   }
 };
 
-// preventBrowserBackButtonFunctionality();
-reloadOnBackNavigation();
 addClickEventListenerToTuitionPartnerCheckboxes();

--- a/UI/Pages/SearchResults.cshtml.js
+++ b/UI/Pages/SearchResults.cshtml.js
@@ -109,6 +109,11 @@ const preventBrowserBackButtonFunctionality = () => {
   });
 };
 
+const reloadOnBackNavigation = () => {
+  const perfEntries = performance.getEntriesByType("navigation");
+  if (perfEntries && perfEntries[0].type === "back_forward") location.reload();
+};
+
 const addClickEventListenerToTuitionPartnerCheckboxes = () => {
   const selectableTuitionPartners = document.getElementsByName(
     "ShortlistedTuitionPartners"
@@ -120,5 +125,6 @@ const addClickEventListenerToTuitionPartnerCheckboxes = () => {
   }
 };
 
-preventBrowserBackButtonFunctionality();
+// preventBrowserBackButtonFunctionality();
+reloadOnBackNavigation();
 addClickEventListenerToTuitionPartnerCheckboxes();


### PR DESCRIPTION
## Context
Using the browser navigation displays the incorrect counter information for the number of TP's Shortlisted

## Changes proposed in this pull request

Prevent page for caching results.

## Guidance to review

When you use the browser navigation back button from the 'shortlist' page to go back 
to the 'searchresult' page, the counter should display the correct information of the number of shortlisted Tp's. 

## Link to Jira ticket

[NTP-785](https://dfedigital.atlassian.net/jira/software/projects/NTP/boards/135/backlog?selectedIssue=NTP-785&text=785)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**