### PR TITLE
NTP-647: Add Comparing And Contrasting Make Checkbox Style Like GDS

### DIFF
--- a/Tests/TuitionPartnerShortlistStorage/CookieBasedTuitionPartnerShortlistStorageTests.cs
+++ b/Tests/TuitionPartnerShortlistStorage/CookieBasedTuitionPartnerShortlistStorageTests.cs
@@ -1,6 +1,0 @@
-namespace Tests.TuitionPartnerShortlistStorage;
-
-public class CookieBasedTuitionPartnerShortlistStorageTests
-{
-    
-}

--- a/Tests/TuitionPartnerShortlistStorage/CookieBasedTuitionPartnerShortlistStorageTests.cs
+++ b/Tests/TuitionPartnerShortlistStorage/CookieBasedTuitionPartnerShortlistStorageTests.cs
@@ -1,0 +1,6 @@
+namespace Tests.TuitionPartnerShortlistStorage;
+
+public class CookieBasedTuitionPartnerShortlistStorageTests
+{
+    
+}

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -176,7 +176,7 @@
                                         var shortlist = Model.SelectableTuitionPartners
                                             .First(tp => tp.SeoUrl == item.SeoUrl);
                                     }
-                                    <govuk-summary-list-row-key>
+                                    <govuk-summary-list-row-key class="govuk-summary-list__key-for-checkbox-label">
                                         <label for="shortlist-cb-@shortlist.SeoUrl">
                                             Add to my shortlist
                                         </label>

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -141,7 +141,7 @@
                             <h2 class="govuk-heading-m">
                                 <a href="@tpUrl" class="govuk-link">@item.Name</a>
                             </h2>
-                            <govuk-summary-list>
+                            <govuk-summary-list class="govuk-!-margin-bottom-0">
                                 <govuk-summary-list-row class="govuk-body-s">
                                     <govuk-summary-list-row-key>
                                         Subjects covered
@@ -171,22 +171,17 @@
                                         @item.Description
                                     </govuk-summary-list-row-value>
                                 </govuk-summary-list-row>
-                                <govuk-summary-list-row class="govuk-body-s">
-                                    @{
-                                        var shortlist = Model.SelectableTuitionPartners
-                                            .First(tp => tp.SeoUrl == item.SeoUrl);
-                                    }
-                                    <govuk-summary-list-row-key class="govuk-summary-list__key-for-checkbox-label">
-                                        <label for="shortlist-cb-@shortlist.SeoUrl">
-                                            Add to my shortlist
-                                        </label>
-                                    </govuk-summary-list-row-key>
-                                    <govuk-summary-list-row-value data-testid="results-description">
-                                        <input class="shortlist-tuition-partner-checkbox" id="shortlist-cb-@shortlist.SeoUrl" name="ShortlistedTuitionPartners"
-                                               type="checkbox" value="@shortlist.SeoUrl" checked="@shortlist.IsSelected"/>
-                                    </govuk-summary-list-row-value>
-                                </govuk-summary-list-row>
                             </govuk-summary-list>
+                            @{
+                                var shortlist = Model.SelectableTuitionPartners
+                                    .First(tp => tp.SeoUrl == item.SeoUrl);
+                            }
+                            <govuk-checkboxes class="govuk-checkboxes--small govuk-!-padding-bottom-0 govuk-!-margin-1" name="ShortlistedTuitionPartners">
+                                <govuk-checkboxes-item id="shortlist-cb-@shortlist.SeoUrl" value="@shortlist.SeoUrl" checked="@shortlist.IsSelected">
+                                    <span class="shortlist-partner-checkbox-label--font-style">Add @item.Name to my shortlist</span>
+                                </govuk-checkboxes-item>
+                            </govuk-checkboxes>
+                            <hr class="govuk-section-break--visible govuk-!-padding-bottom-0 govuk-!-margin-top-0 govuk-!-margin-bottom-7">
                         </div>
                     </div>
                 }

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -181,7 +181,7 @@
                                     <span class="shortlist-partner-checkbox-label--font-style">Add @item.Name to my shortlist</span>
                                 </govuk-checkboxes-item>
                             </govuk-checkboxes>
-                            <hr class="govuk-section-break--visible govuk-!-padding-bottom-0 govuk-!-margin-top-0 govuk-!-margin-bottom-7">
+                            <hr class="govuk-section-break govuk-section-break--visible govuk-!-padding-bottom-0 govuk-!-margin-top-0 govuk-!-margin-bottom-7">
                         </div>
                     </div>
                 }

--- a/UI/src/sass/search-result-page-shortlist.scss
+++ b/UI/src/sass/search-result-page-shortlist.scss
@@ -19,21 +19,26 @@
 
 .shortlist-tuition-partner-checkbox {
   cursor: pointer;
-  width: 24px;
+  border-radius: 0;
   height: 24px;
   margin-left: 0;
+  outline: 1px solid govuk-colour("black");
+  width: 24px;
 }
 
 .shortlist-tuition-partner-checkbox:focus {
+  background-color: govuk-colour("white");
+  box-shadow: inset 0 0 0 2px;
   outline: 3px solid #ffdd00;
   outline-offset: 0;
-  box-shadow: inset 0 0 0 2px;
-  background-color: govuk-colour("white");
 }
+
 .shortlist-tuition-partner-checkbox:checked {
   accent-color: govuk-colour("white");
-  cursor: pointer;
-  width: 24px;
-  height: 24px;
-  outline: 1px solid govuk-colour("black");
+  outline: 1.5px solid govuk-colour("black");
+}
+
+//override govuk-summary-list__key
+.govuk-summary-list__key-for-checkbox-label {
+  vertical-align: middle;
 }

--- a/UI/src/sass/search-result-page-shortlist.scss
+++ b/UI/src/sass/search-result-page-shortlist.scss
@@ -17,28 +17,7 @@
   padding: 0.5rem 0.5rem 0.5rem 0.5rem;
 }
 
-.shortlist-tuition-partner-checkbox {
-  cursor: pointer;
-  border-radius: 0;
-  height: 24px;
-  margin-left: 0;
-  outline: 1px solid govuk-colour("black");
-  width: 24px;
-}
-
-.shortlist-tuition-partner-checkbox:focus {
-  background-color: govuk-colour("white");
-  box-shadow: inset 0 0 0 2px;
-  outline: 3px solid #ffdd00;
-  outline-offset: 0;
-}
-
-.shortlist-tuition-partner-checkbox:checked {
-  accent-color: govuk-colour("white");
-  outline: 1.5px solid govuk-colour("black");
-}
-
-//override govuk-summary-list__key
-.govuk-summary-list__key-for-checkbox-label {
-  vertical-align: middle;
+.shortlist-partner-checkbox-label--font-style {
+  font-size: medium;
+  font-weight: 700;
 }


### PR DESCRIPTION
## Context

Change the checkboxes used for adding tuition partners to the shortlist to GDS checkboxes.

## Changes proposed in this pull request
Change how and where the checkboxes are displayed and use GDS checkboxes instead

## Guidance to review

The look and feel of the checkboxes used on the Search Result page should be that of a standard GDS checkbox.

## Link to Jira ticket
[NTP-647](https://dfedigital.atlassian.net/jira/software/projects/NTP/boards/135?selectedIssue=NTP-647)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**