### PR TITLE
NTP-742: Absent Fieldset bug-fix for WhichKeyStages & WhichSubjects pages

### DIFF
--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -190,12 +190,9 @@
                                     .First(tp => tp.SeoUrl == item.SeoUrl);
                             }
                             <govuk-checkboxes class="govuk-checkboxes--small govuk-!-padding-bottom-0 govuk-!-margin-1" name="ShortlistedTuitionPartners">
-                                <govuk-checkboxes-fieldset>
-                                    <govuk-checkboxes-fieldset-legend/>
-                                    <govuk-checkboxes-item id="shortlist-cb-@shortlist.SeoUrl" value="@shortlist.SeoUrl" checked="@shortlist.IsSelected">
-                                        <span class="shortlist-partner-checkbox-label--font-style">Add @item.Name to my shortlist</span>
-                                    </govuk-checkboxes-item>
-                                </govuk-checkboxes-fieldset>
+                                <govuk-checkboxes-item id="shortlist-cb-@shortlist.SeoUrl" value="@shortlist.SeoUrl" checked="@shortlist.IsSelected">
+                                    <span class="shortlist-partner-checkbox-label--font-style">Add @item.Name to my shortlist</span>
+                                </govuk-checkboxes-item>
                             </govuk-checkboxes>
                             <hr class="govuk-section-break govuk-section-break--visible govuk-!-padding-bottom-0 govuk-!-margin-top-0 govuk-!-margin-bottom-7">
                         </div>

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -38,7 +38,10 @@
                             <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">Filters</h1>
                         </div>
                         <div class="app-results-filter-overlay--heading-right">
-                            <a href="/search-results?@Model.Data.ToQueryString()" class="govuk-link govuk-link--no-underline" data-module="return-to-results-link" data-testid="return-to-results-link">Return to results</a>
+                            <a href="/search-results?@Model.Data.ToQueryString()" class="govuk-link govuk-link--no-underline"
+                               data-module="return-to-results-link" data-testid="return-to-results-link">
+                                Return to results
+                            </a>
                         </div>
                     </div>
                     <p show-if="Model.Data.Results != null" class="govuk-body" data-testid="overlay-filter-results-count">
@@ -68,7 +71,10 @@
                     </govuk-radios-fieldset>
                 </govuk-radios>
 
-                <a asp-page-handler="ClearAllFilters" data-testid="clear-all-filters" class="govuk-link govuk-link--no-underline" asp-route-postcode=@Model.Data.Postcode>Clear all filters</a>
+                <a asp-page-handler="ClearAllFilters" data-testid="clear-all-filters" class="govuk-link govuk-link--no-underline"
+                   asp-route-postcode=@Model.Data.Postcode>
+                    Clear all filters
+                </a>
 
                 <div class="govuk-!-margin-top-7">
                     <div class="govuk-button-group app-results-filter--apply-filters">
@@ -105,7 +111,8 @@
                     var resultPlural = Model.Data.Results.Count != 1 ? "results" : "result";
                 }
                 <span class="govuk-!-font-size-24">
-                    <strong data-testid="result-count">@count</strong> @(resultPlural) <span show-if="@Model.Data.Results.LocalAuthorityName != null">for <strong>@Model.Data.Results.LocalAuthorityName</strong></span>
+                    <strong data-testid="result-count">@count</strong> @(resultPlural)
+                    <span show-if="@Model.Data.Results.LocalAuthorityName != null">for <strong>@Model.Data.Results.LocalAuthorityName</strong></span>
                 </span><br/>
                 Your results are in a random order.
                 <div class="govuk-grid-row govuk-!-margin-top-2">
@@ -150,7 +157,11 @@
                                     </govuk-summary-list-row-key>
                                     <govuk-summary-list-row-value>
                                         <ul class="govuk-list govuk-body-s govuk-list-bullets-mobile-view" data-testid="results-subjects">
-                                            @foreach (var keyStageSubjects in item.SubjectsCoverage.Select(e => e.Subject).Distinct().OrderBy(e => e.KeyStageId).OrderBy(e => e.Name).GroupBy(e => e.KeyStageId))
+                                            @foreach (var keyStageSubjects in item.SubjectsCoverage
+                                                .Select(e => e.Subject)
+                                                .Distinct()
+                                                .OrderBy(e => e.KeyStageId)
+                                                .ThenBy(e => e.Name).GroupBy(e => e.KeyStageId))
                                             {
                                                 <li>@(((KeyStage) keyStageSubjects.Key).DisplayName()) - @keyStageSubjects.DisplayList()</li>
                                             }
@@ -179,9 +190,12 @@
                                     .First(tp => tp.SeoUrl == item.SeoUrl);
                             }
                             <govuk-checkboxes class="govuk-checkboxes--small govuk-!-padding-bottom-0 govuk-!-margin-1" name="ShortlistedTuitionPartners">
-                                <govuk-checkboxes-item id="shortlist-cb-@shortlist.SeoUrl" value="@shortlist.SeoUrl" checked="@shortlist.IsSelected">
-                                    <span class="shortlist-partner-checkbox-label--font-style">Add @item.Name to my shortlist</span>
-                                </govuk-checkboxes-item>
+                                <govuk-checkboxes-fieldset>
+                                    <govuk-checkboxes-fieldset-legend/>
+                                    <govuk-checkboxes-item id="shortlist-cb-@shortlist.SeoUrl" value="@shortlist.SeoUrl" checked="@shortlist.IsSelected">
+                                        <span class="shortlist-partner-checkbox-label--font-style">Add @item.Name to my shortlist</span>
+                                    </govuk-checkboxes-item>
+                                </govuk-checkboxes-fieldset>
                             </govuk-checkboxes>
                             <hr class="govuk-section-break govuk-section-break--visible govuk-!-padding-bottom-0 govuk-!-margin-top-0 govuk-!-margin-bottom-7">
                         </div>

--- a/UI/Pages/WhichKeyStages.cshtml
+++ b/UI/Pages/WhichKeyStages.cshtml
@@ -8,35 +8,40 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form method="get">
-            <h1 class="govuk-heading-l">Which key stages do you need tutoring support for?</h1>
-            <p class="govuk-body">Select all of the key stages that apply</p>
-
             <govuk-checkboxes asp-for="Data.KeyStages">
-                @foreach (var item in Model.Data.AllKeyStages)
-                {
-                    <govuk-checkboxes-item id="@item.Name.ToString().ToSeoUrl()" value="@item.Name" checked="@item.Selected" data-testid="key-stage-name">@item.Name.DisplayName()</govuk-checkboxes-item>
-                }
+                <govuk-checkboxes-fieldset>
+                    <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+                        Which key stages do you need tutoring support for?
+                    </govuk-checkboxes-fieldset-legend>
+                    <govuk-checkboxes-hint>
+                        Select all of the key stages that apply
+                    </govuk-checkboxes-hint>
+                    @foreach (var item in Model.Data.AllKeyStages)
+                    {
+                        <govuk-checkboxes-item id="@item.Name.ToString().ToSeoUrl()" value="@item.Name" checked="@item.Selected" data-testid="key-stage-name">@item.Name.DisplayName()</govuk-checkboxes-item>
+                    }
+                </govuk-checkboxes-fieldset>
             </govuk-checkboxes>
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>
             </div>
 
-            <input type="hidden" name="handler" value="Submit" />
+            <input type="hidden" name="handler" value="Submit"/>
             @if (Model.Data.Postcode != null)
             {
-                <input asp-for="Data.Postcode" hidden />
+                <input asp-for="Data.Postcode" hidden/>
             }
             @if (Model.Data.Subjects != null)
             {
                 foreach (var subject in Model.Data.Subjects)
                 {
-                    <input type="hidden" id="@subject" name="Data.Subjects" value="@subject" />
+                    <input type="hidden" id="@subject" name="Data.Subjects" value="@subject"/>
                 }
             }
             @if (Model.Data.TuitionType.HasValue)
             {
-                <input asp-for="Data.TuitionType" hidden />
+                <input asp-for="Data.TuitionType" hidden/>
             }
 
         </form>

--- a/UI/Pages/WhichSubjects.cshtml
+++ b/UI/Pages/WhichSubjects.cshtml
@@ -8,7 +8,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <govuk-error-summary>
-            <govuk-error-summary-item asp-for="Data.Subjects" />
+            <govuk-error-summary-item asp-for="Data.Subjects"/>
         </govuk-error-summary>
 
         <form method="get" gfa-prepend-error-summary="false">
@@ -18,33 +18,36 @@
             @foreach (var item in Model.Data.AllSubjects.Keys)
             {
                 <div data-testid="@(item)-subjects">
-                    <h2 class="govuk-heading-m">@item.DisplayName() subjects</h2>
-
                     <govuk-checkboxes asp-for="Data.Subjects">
-                        @foreach (var subject in Model.Data.AllSubjects[item].OrderBy(x => x.Name))
-                        {
-                            var value = $"{item}-{subject.Name}";
-                            <govuk-checkboxes-item id="@value.ToSeoUrl()" value="@value" checked="@subject.Selected" data-testid="subject-name">@subject.Name</govuk-checkboxes-item>
-                        }
+                        <govuk-checkboxes-fieldset>
+                            <govuk-checkboxes-fieldset-legend is-page-heading="false" class="govuk-fieldset__legend--m">
+                                @item.DisplayName() subjects
+                            </govuk-checkboxes-fieldset-legend>
+                            @foreach (var subject in Model.Data.AllSubjects[item].OrderBy(x => x.Name))
+                            {
+                                var value = $"{item}-{subject.Name}";
+                                <govuk-checkboxes-item id="@value.ToSeoUrl()" value="@value" checked="@subject.Selected" data-testid="subject-name">@subject.Name</govuk-checkboxes-item>
+                            }
+                        </govuk-checkboxes-fieldset>
                     </govuk-checkboxes>
                 </div>
             }
 
-            <input type="hidden" name="handler" value="Submit" />
+            <input type="hidden" name="handler" value="Submit"/>
             @if (Model.Data.Postcode != null)
             {
-                <input asp-for="Data.Postcode" hidden />
+                <input asp-for="Data.Postcode" hidden/>
             }
             @if (Model.Data.KeyStages != null)
             {
                 foreach (var subject in Model.Data.KeyStages)
                 {
-                    <input type="hidden" id="@subject" name="Data.KeyStages" value="@subject" />
+                    <input type="hidden" id="@subject" name="Data.KeyStages" value="@subject"/>
                 }
             }
             @if (Model.Data.TuitionType.HasValue)
             {
-                <input asp-for="Data.TuitionType" hidden />
+                <input asp-for="Data.TuitionType" hidden/>
             }
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="call-to-action">Continue</govuk-button>

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -133,10 +133,11 @@ Then(
 );
 
 Then("they will see the results summary for {string}", (location) => {
-  var expected = new RegExp(`\\d+ results for ${location}`);
+  const expected = new RegExp(`\\d+ results for ${location}`);
   cy.get('[data-testid="results-summary"]')
     .invoke("text")
     .invoke("trim")
+    .then((words) => words.replace(/[\r\n]/gm, "").replace(/  +/g, " "))
     .should("match", expected);
 });
 

--- a/UI/cypress/support/step_definitions/subjects-page.js
+++ b/UI/cypress/support/step_definitions/subjects-page.js
@@ -62,7 +62,7 @@ Then("they are shown the subjects for {string}", (keystage) => {
   stages.forEach((element) => {
     const subjects = allSubjects[element];
 
-    cy.get("h2")
+    cy.get("legend")
       .contains(`${element} subjects`)
       .parent()
       .within(() => {


### PR DESCRIPTION
## Context

The GOV.UK Design System specifies that groups of checkboxes should have a fieldset element around checkboxes.
The checkboxes on the “Which key stages do you need tutoring support for?” and the “Which subjects do you need tutoring support for?” do not have these fieldsets.

## Changes proposed in this pull request

Add Checkboxes Fieldset component around checkboxes

## Guidance to review

Browse to the WhichKeyStages page or/and the WhichSubjects page, 
the checkboxes should be contained in a Fieldset element. 

## Link to Jira ticket

[NTP-742](https://dfedigital.atlassian.net/jira/software/projects/NTP/boards/135?selectedIssue=NTP-742)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**