### PR TITLE
NTP-755: Removing TPs from the TP shortlist page

### DIFF
--- a/UI/Extensions/SearchModelExtensions.cs
+++ b/UI/Extensions/SearchModelExtensions.cs
@@ -26,6 +26,18 @@ namespace UI.Extensions
             return dictionary;
         }
 
+        public static Dictionary<string, string> ToRouteData(this SearchModel model, Dictionary<string, string> itemsToInclude)
+        {
+            var dictionary = model.ToRouteData();
+
+            foreach (var itemToInclude in itemsToInclude)
+            {
+                dictionary.Add(itemToInclude.Key, itemToInclude.Value);
+            }
+
+            return dictionary;
+        }
+
         private static void AddAll<T>(
             this SearchModel model,
             Expression<Func<SearchModel, IEnumerable<T>?>> expression,

--- a/UI/Filters/ExceptionLoggingMiddleware.cs
+++ b/UI/Filters/ExceptionLoggingMiddleware.cs
@@ -14,7 +14,7 @@ public class ExceptionLoggingMiddleware
         {
             await _next(context);
 
-            if(context.Response.StatusCode == 404)
+            if (context.Response.StatusCode == 404)
             {
                 using var _ = _logger.BeginScope("{@Context}", context);
                 var url = $"{context.Request.Scheme}://{context.Request.Host}{context.Request.Path}{context.Request.QueryString}";

--- a/UI/Filters/ExceptionLoggingMiddleware.cs
+++ b/UI/Filters/ExceptionLoggingMiddleware.cs
@@ -13,6 +13,16 @@ public class ExceptionLoggingMiddleware
         try
         {
             await _next(context);
+
+            if(context.Response.StatusCode == 404)
+            {
+                using var _ = _logger.BeginScope("{@Context}", context);
+                var url = $"{context.Request.Scheme}://{context.Request.Host}{context.Request.Path}{context.Request.QueryString}";
+                var referer = context.Request.Headers["Referer"].ToString();
+                var rerererComment = string.IsNullOrWhiteSpace(referer) ? string.Empty : $"  The referer was {referer}";
+                //Log 404 errors so we can review these, if needed
+                _logger.LogInformation("404 Response for {url}.{RerererComment}", url, rerererComment);
+            }
         }
         catch (Exception e)
         {

--- a/UI/Pages/Shortlist.cshtml
+++ b/UI/Pages/Shortlist.cshtml
@@ -31,7 +31,7 @@
                         <th scope="col" class="govuk-table__header">Subjects</th>
                         <th scope="col" class="govuk-table__header">Type of tuition</th>
                         <th scope="col" class="govuk-table__header" aria-sort="@(Model.Data.GetAriaSort(Domain.Enums.TuitionPartnerOrderBy.MinPrice))">
-                            <a class="table-column-sort" data-testid="shortlist-price-sort" asp-page="Shortlist" asp-all-route-data="@(Model.Data.GetSortRouteData(Domain.Enums.TuitionPartnerOrderBy.MinPrice))">Price range</a>
+                            <a class="table-column-sort" data-testid="shortlist-price-sort" asp-page="Shortlist" asp-all-route-data="@(Model.Data.GetSortRouteData(Domain.Enums.TuitionPartnerOrderBy.MinPrice))">Price</a>
                         </th>
                         <th scope="col" class="govuk-table__header app-print-hide">Remove</th>
                     </tr>

--- a/UI/Pages/Shortlist.cshtml
+++ b/UI/Pages/Shortlist.cshtml
@@ -1,6 +1,7 @@
 ﻿@page
 @model UI.Pages.ShortlistModel
 @{
+    var clearShortlistUrl = "/shortlist-clear-confirm?" + Model.Data.ToQueryString();
     ViewData["Title"] = "Compare my shortlisted tuition partners";
     ViewData["BackLinkHref"] = "/search-results?" + Model.Data.ToQueryString();
     ViewData["IncludePrintPage"] = true;
@@ -8,7 +9,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <form method="get">
+        <form method="post">
             @{
                 var count = Model.Data.Results?.Count;
                 var partnersPlural = count > 1 ? "partners" : "partner";
@@ -32,6 +33,7 @@
                         <th scope="col" class="govuk-table__header" aria-sort="@(Model.Data.GetAriaSort(Domain.Enums.TuitionPartnerOrderBy.MinPrice))">
                             <a class="table-column-sort" data-testid="shortlist-price-sort" asp-page="Shortlist" asp-all-route-data="@(Model.Data.GetSortRouteData(Domain.Enums.TuitionPartnerOrderBy.MinPrice))">Price range</a>
                         </th>
+                        <th scope="col" class="govuk-table__header app-print-hide">Remove</th>
                     </tr>
                     </thead>
                     <tbody class="govuk-table__body">
@@ -50,6 +52,9 @@
                             </td>
                             <td class="govuk-table__cell">@string.Join(", ", item.TuitionTypes.Select(e => e.Name))</td>
                             <td class="govuk-table__cell">From @item.Prices?.Min(e => e.HourlyRate).FormatPrice()</td>
+                            <td class="govuk-table__cell app-print-hide">
+                                <button class="govuk-button govuk-button--secondary remove-shortlist-table-button" data-testid="remove-tp" data-module="govuk-button" type="submit" asp-page-handler="remove" asp-all-route-data="@Model.Data.ToRouteData(new Dictionary<string, string>() {{"RemoveTuitionPartnerSeoUrl", item.SeoUrl}})">Remove</button>
+                            </td>
                         </tr>
                     }
                     </tbody>
@@ -73,6 +78,10 @@
                 </ul>
             </div>
             }
+
+            <div show-if="count > 0 || Model.Data.InvalidTPs is not null" class="govuk-body app-print-hide">
+                <a class="govuk-link" data-testid="clear-shortlist-link" href="@clearShortlistUrl">Clear my shortlist</a>
+            </div>            
         </form>
     </div>
 </div>

--- a/UI/Pages/Shortlist.cshtml
+++ b/UI/Pages/Shortlist.cshtml
@@ -63,7 +63,8 @@
             }
             else
             {
-                <p class="govuk-body">There are no tuition partners shortlisted, return to the <a class="govuk-link" data-testid="no-results-return-link" href="/search-results?@Model.Data.ToQueryString()">search page</a> to add tuition partners to the list.</p>
+                <p class="govuk-body">You don’t have any shortlisted tuition partners.</p>
+                <p class="govuk-body">To shortlist tuition partners, go to your <a class="govuk-link" data-testid="no-results-return-link" href="/search-results?@Model.Data.ToQueryString()">search results</a>.</p>
             }
 
             @if (Model.Data.InvalidTPs is not null)

--- a/UI/Pages/Shortlist.cshtml
+++ b/UI/Pages/Shortlist.cshtml
@@ -2,7 +2,7 @@
 @model UI.Pages.ShortlistModel
 @{
     var clearShortlistUrl = "/shortlist-clear-confirm?" + Model.Data.ToQueryString();
-    ViewData["Title"] = "Compare my shortlisted tuition partners";
+    ViewData["Title"] = "My shortlisted tuition partners";
     ViewData["BackLinkHref"] = "/search-results?" + Model.Data.ToQueryString();
     ViewData["IncludePrintPage"] = true;
 }
@@ -15,7 +15,7 @@
                 var partnersPlural = count > 1 ? "partners" : "partner";
             }
             <span show-if="@count > 0 && Model.Data.Results?.LocalAuthorityName != null" class="govuk-caption-l" data-testid="la-name">Tuition @partnersPlural for <strong>@Model.Data.Results?.LocalAuthorityName</strong></span>
-            <h1 class="govuk-heading-l">Compare my shortlisted tuition partners</h1>
+            <h1 class="govuk-heading-l">My shortlisted tuition partners</h1>
 
             @if (count > 0)
             {

--- a/UI/Pages/Shortlist.cshtml.cs
+++ b/UI/Pages/Shortlist.cshtml.cs
@@ -23,9 +23,22 @@ public class ShortlistModel : PageModel
                 ModelState.AddModelError($"Data.{error.PropertyName}", error.ErrorMessage);
     }
 
+    public async Task<IActionResult> OnPostRemoveAsync(Query data)
+    {
+        if (!ModelState.IsValid) return Page();
+
+        if (!string.IsNullOrWhiteSpace(data.RemoveTuitionPartnerSeoUrl))
+        {
+            await _mediator.Send(new RemoveTuitionPartnerCommand(data.RemoveTuitionPartnerSeoUrl));
+        }
+
+        return RedirectToPage(data.ToRouteData());
+    }
+
     public record Query : SearchModel, IRequest<ResultsModel>
     {
         public TuitionPartnerOrderBy? OrderBy { get; set; }
+        public string? RemoveTuitionPartnerSeoUrl { get; set; }
     };
 
     public record ResultsModel : SearchModel

--- a/UI/Pages/ShortlistClearConfirm.cshtml
+++ b/UI/Pages/ShortlistClearConfirm.cshtml
@@ -1,0 +1,26 @@
+﻿@page
+@model UI.Pages.ShortlistClearConfirm
+@{
+    var returnUrl = "/shortlist?" + Model.Data.ToQueryString();
+    ViewData["Title"] = "Clear my shortlisted confirmation";
+    ViewData["BackLinkHref"] = returnUrl;
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <form method="post">
+            <h1 class="govuk-heading-l">Confirm clear my shortlist</h1>
+
+            <div class="govuk-inset-text">
+                Please confirm that you wish to remove all the tuition partners from my shortlist.
+            </div>
+
+            <div class="govuk-button-group">
+              <button class="govuk-button" data-testid="call-to-action" data-module="govuk-button" type="submit" asp-page-handler="remove" asp-all-route-data="@Model.Data.ToRouteData()">
+                Clear my shortlist
+              </button>
+              <a class="govuk-link" data-testid="cancel-link" href="@returnUrl">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>

--- a/UI/Pages/ShortlistClearConfirm.cshtml
+++ b/UI/Pages/ShortlistClearConfirm.cshtml
@@ -11,9 +11,9 @@
         <form method="post">
             <h1 class="govuk-heading-l">You're about to clear your shortlist</h1>
 
-            <div class="govuk-inset-text">
+            <p class="govuk-body">
                 Any tuition partners you’ve shortlisted will be removed.
-            </div>
+            </p>
 
             <div class="govuk-button-group">
               <button class="govuk-button" data-testid="call-to-action" data-module="govuk-button" type="submit" asp-page-handler="remove" asp-all-route-data="@Model.Data.ToRouteData()">

--- a/UI/Pages/ShortlistClearConfirm.cshtml
+++ b/UI/Pages/ShortlistClearConfirm.cshtml
@@ -9,10 +9,10 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <form method="post">
-            <h1 class="govuk-heading-l">Confirm clear my shortlist</h1>
+            <h1 class="govuk-heading-l">You're about to clear your shortlist</h1>
 
             <div class="govuk-inset-text">
-                Please confirm that you wish to remove all the tuition partners from my shortlist.
+                Any tuition partners you’ve shortlisted will be removed.
             </div>
 
             <div class="govuk-button-group">

--- a/UI/Pages/ShortlistClearConfirm.cshtml.cs
+++ b/UI/Pages/ShortlistClearConfirm.cshtml.cs
@@ -1,0 +1,30 @@
+namespace UI.Pages
+{
+    public class ShortlistClearConfirm : PageModel
+    {
+        private readonly IMediator _mediator;
+
+        public ShortlistClearConfirm(IMediator mediator) => _mediator = mediator;
+
+        public Query Data { get; set; } = new();
+
+        public void OnGet(Query data)
+        {
+            Data = data;
+        }
+
+        public async Task<IActionResult> OnPostRemoveAsync(Query data)
+        {
+            if (!ModelState.IsValid) return Page();
+
+            //Remove all TPs
+            await _mediator.Send(new RemoveAllTuitionPartnersCommand());
+
+            return RedirectToPage("shortlist", data.ToRouteData());
+        }
+
+        public record Query : SearchModel
+        {
+        };
+    }
+}

--- a/UI/Pages/ShortlistClearConfirm.cshtml.cs
+++ b/UI/Pages/ShortlistClearConfirm.cshtml.cs
@@ -2,9 +2,14 @@ namespace UI.Pages
 {
     public class ShortlistClearConfirm : PageModel
     {
+        private readonly ILogger<TuitionPartner> _logger;
         private readonly IMediator _mediator;
 
-        public ShortlistClearConfirm(IMediator mediator) => _mediator = mediator;
+        public ShortlistClearConfirm(ILogger<TuitionPartner> logger, IMediator mediator)
+        {
+            _logger = logger;
+            _mediator = mediator;
+        }
 
         public Query Data { get; set; } = new();
 
@@ -19,6 +24,8 @@ namespace UI.Pages
 
             //Remove all TPs
             await _mediator.Send(new RemoveAllTuitionPartnersCommand());
+
+            _logger.LogInformation("Cleared full shortlist");
 
             return RedirectToPage("shortlist", data.ToRouteData());
         }

--- a/UI/Pages/TuitionPartner.cshtml.cs
+++ b/UI/Pages/TuitionPartner.cshtml.cs
@@ -240,8 +240,7 @@ public class TuitionPartner : PageModel
 
             if (id == null)
             {
-                //shouldn't get here, unless manually changed query string
-                _logger.LogWarning("No TP found for the invalid Id '{Id}' provided", request.Id);
+                //shouldn't get here, unless manually changed query string or is an old bookmarked URL that's no longer valid.  Will be logged as 404 error in ExceptionLoggingMiddleware
                 return Result.Error<TuitionPartnerResult>();
             }
 

--- a/UI/cypress/e2e/shortlist.feature
+++ b/UI/cypress/e2e/shortlist.feature
@@ -115,3 +115,54 @@ Feature: Tuition Partner shortlist
         And 'Action Tutoring' is entry 1 on the shortlist page
         And '3D Recruit Ltd' is entry 2 on the shortlist page
         And 'Reeson Education' is entry 3 on the shortlist page
+
+    Scenario: User removes single item from shortlist
+        Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+        And they add 'Reeson Education' to their shortlist on the results page
+        And they add 'Action Tutoring' to their shortlist on the results page
+        And they add '3D Recruit Ltd' to their shortlist on the results page
+        When they choose to view their shortlist from the results page
+        Then there are 3 entries on the shortlist page
+        And 'Reeson Education' is entry 1 on the shortlist page
+        And 'Action Tutoring' is entry 2 on the shortlist page
+        And '3D Recruit Ltd' is entry 3 on the shortlist page
+        Then they choose to remove entry 2 on the shortlist page
+        Then there are 2 entries on the shortlist page
+        And 'Reeson Education' is entry 1 on the shortlist page
+        And '3D Recruit Ltd' is entry 2 on the shortlist page
+        Then they click 'Back'
+        And the search results are displayed
+        Then they choose to view their shortlist from the results page
+        Then there are 2 entries on the shortlist page
+        And 'Reeson Education' is entry 1 on the shortlist page
+        And '3D Recruit Ltd' is entry 2 on the shortlist page
+
+    Scenario: User clears full shortlist then cancel
+        Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+        And they add 'Reeson Education' to their shortlist on the results page
+        And they add 'Action Tutoring' to their shortlist on the results page
+        And they add '3D Recruit Ltd' to their shortlist on the results page
+        When they choose to view their shortlist from the results page
+        Then there are 3 entries on the shortlist page
+        And 'Reeson Education' is entry 1 on the shortlist page
+        And 'Action Tutoring' is entry 2 on the shortlist page
+        And '3D Recruit Ltd' is entry 3 on the shortlist page
+        Then they choose to click on clear shortlist link
+        And they are taken to the clear shortlist confirmation page
+        Then they click the cancel link
+        Then there are 3 entries on the shortlist page
+
+    Scenario: User clears full shortlist
+        Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+        And they add 'Reeson Education' to their shortlist on the results page
+        And they add 'Action Tutoring' to their shortlist on the results page
+        And they add '3D Recruit Ltd' to their shortlist on the results page
+        When they choose to view their shortlist from the results page
+        Then there are 3 entries on the shortlist page
+        And 'Reeson Education' is entry 1 on the shortlist page
+        And 'Action Tutoring' is entry 2 on the shortlist page
+        And '3D Recruit Ltd' is entry 3 on the shortlist page
+        Then they choose to click on clear shortlist link
+        And they are taken to the clear shortlist confirmation page
+        Then they click confirm button
+        Then there are 0 entries on the shortlist page

--- a/UI/cypress/e2e/shortlist.js
+++ b/UI/cypress/e2e/shortlist.js
@@ -106,7 +106,7 @@ Then("they choose to click on clear shortlist link", () => {
 });
 
 Then("they are taken to the clear shortlist confirmation page", () => {
-  cy.get("h1").should("have.text", "Confirm clear my shortlist");
+  cy.get("h1").should("have.text", "You're about to clear your shortlist");
 });
 
 Then("they click the cancel link", () => {

--- a/UI/cypress/e2e/shortlist.js
+++ b/UI/cypress/e2e/shortlist.js
@@ -94,3 +94,25 @@ Then("they choose to sort the shortlist by name", () => {
 Then("they choose to sort the shortlist by price", () => {
   cy.get('[data-testid="shortlist-price-sort"]').click();
 });
+
+Then("they choose to remove entry {int} on the shortlist page", (entry) => {
+  cy.get('tbody td [data-testid="remove-tp"]')
+    .eq(entry - 1)
+    .click();
+});
+
+Then("they choose to click on clear shortlist link", () => {
+  cy.get('[data-testid="clear-shortlist-link"]').click();
+});
+
+Then("they are taken to the clear shortlist confirmation page", () => {
+  cy.get("h1").should("have.text", "Confirm clear my shortlist");
+});
+
+Then("they click the cancel link", () => {
+  cy.get('[data-testid="cancel-link"]').click();
+});
+
+Then("they click confirm button", () => {
+  cy.get('[data-testid="call-to-action"]').click();
+});

--- a/UI/src/sass/shortlist.scss
+++ b/UI/src/sass/shortlist.scss
@@ -1,4 +1,10 @@
-﻿[aria-sort] {
+﻿@media not print {
+  .remove-shortlist-table-button {
+    margin-bottom: 0px;
+  }
+}
+
+[aria-sort] {
   :first-child .table-column-sort {
     right: auto;
   }


### PR DESCRIPTION
## Context

Removing TPs from the TP shortlist page

## Changes proposed in this pull request

Allow each TP row on the shortlist to be removed
Allow the full list to be cleared via the link at the bottom and go via a confirmation page

## Guidance to review

Acceptance Criteria:

AC1: Clear short list link
GIVEN the shortlist TP  page has been displayed
WHEN the user selects ‘Clear my shortlist’ link
THEN display the warning page (according to the mock-up) 

AC2: Clear short list button
GIVEN the warning  page has been displayed
WHEN the user selects ‘Clear my shortlist’ button
THEN remove all shortlisted tuition partners from the shortlist and display the confirmation page (according to the mock-up)

AC3: Cancel link
GIVEN the warning  page has been displayed
WHEN the user selects  the ‘Cancel” link
THEN return user to the shortlist page 

AC4: Search results link
GIVEN the confirmation page has been displayed
WHEN the user selects ‘Search results” link
THEN return the user to the search results page.

AC5: Remove a TP from the shortlist TP page
GIVEN the shortlist TP  page has been displayed
WHEN the user selects the ‘Remove TP from the shortlist” button/icon
THEN remove the selected TP from the shortlist

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-755

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [x] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [x] **PR deployment has been signed off by wider team**