### PR TITLE
NTP-794: Set service to use non-JS code if running in IE

### DIFF
--- a/UI/Pages/SearchResults.cshtml.js
+++ b/UI/Pages/SearchResults.cshtml.js
@@ -102,6 +102,10 @@ const onCheckboxClick = async (event) => {
 };
 
 const addClickEventListenerToTuitionPartnerCheckboxes = () => {
+  // The if statement is to prevent using javascript for the checkboxes,
+  // mainly in the case of if the client is using an IE browsers
+  // as it doesn’t seem to support newer javascript keywords. e.g. 'let'.
+  if (!document.body.className.includes("js-enabled")) return;
   const selectableTuitionPartners = document.getElementsByName(
     "ShortlistedTuitionPartners"
   );

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -107,7 +107,7 @@ height="0" width="0" class="govuk-!-display-none"></iframe></noscript>
     }
     <script asp-add-nonce>
        var isIE= /MSIE|Trident/.test(navigator.userAgent);
-        document.body.className = ((document.body.className) && !isIE ? document.body.className + ' js-enabled' : 'js-enabled');
+        document.body.className = (((document.body.className) && !isIE) ? document.body.className + ' js-enabled' : '');
     </script>
 
     <div>

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -106,7 +106,8 @@ height="0" width="0" class="govuk-!-display-none"></iframe></noscript>
         <!-- End Google Tag Manager (noscript) -->
     }
     <script asp-add-nonce>
-        document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+       var isIE= /MSIE|Trident/.test(navigator.userAgent);
+        document.body.className = ((document.body.className) && !isIE ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 
     <div>


### PR DESCRIPTION
## Context

Service doesn't work correctly in IE11 because the code uses newer javascript code e.g. 'let'

## Changes proposed in this pull request

Make it so that on IE11 the service shown to the user is the non-javascript version.

## Guidance to review

on IE11 the non-javascript version of the service should be shown. For example on the Search Result page
a button should be present to shortlist a tuition partner.

## Link to Jira ticket

 [NTP-794](https://dfedigital.atlassian.net/browse/NTP-794)

## Things to check

- [X] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [X] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [X] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**

[NTP-794]: https://dfedigital.atlassian.net/browse/NTP-794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ