### PR TITLE
NTP-837: Adding some promise chaining so that shortlisting works when checkboxes are selected rapidly

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -74,10 +74,10 @@ jobs:
         interval: 15000
 
     - name: End to End Testing
-      uses: cypress-io/github-action@v4
+      uses: cypress-io/github-action@v5
       with:
         working-directory: ./UI
-        config: baseUrl="${{ env.BASE_URL }}/"
+        config: baseUrl="${{ env.BASE_URL }}/",video=false
 
     - name: Store screenshots on test failure
       uses: actions/upload-artifact@v2
@@ -85,12 +85,6 @@ jobs:
       with:
         name: cypress-screenshots
         path: UI/cypress/screenshots
-    - name: Store videos
-      uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        name: cypress-videos
-        path: UI/cypress/videos
 
     - name: Slack Notification
       uses: rtCamp/action-slack-notify@v2

--- a/UI/Pages/SearchResults.cshtml.js
+++ b/UI/Pages/SearchResults.cshtml.js
@@ -82,23 +82,30 @@ const onUnChecked = async (checkbox) => {
     });
 };
 
+let lastCheckboxPromise = null;
+
 const onCheckboxClick = async (event) => {
   const checkbox = event.target;
-  if (checkbox.checked) {
-    try {
-      const result = await onChecked(checkbox);
-      updateSearchResultPage(result, checkbox, false);
-    } catch (e) {
-      checkbox.checked = false;
+
+  lastCheckboxPromise = (async (previousPromise) => {
+    await previousPromise;
+
+    if (checkbox.checked) {
+      try {
+        const result = await onChecked(checkbox);
+        updateSearchResultPage(result, checkbox, false);
+      } catch (e) {
+        checkbox.checked = false;
+      }
+    } else {
+      try {
+        const result = await onUnChecked(checkbox);
+        updateSearchResultPage(result, checkbox, true);
+      } catch (e) {
+        checkbox.checked = true;
+      }
     }
-  } else {
-    try {
-      const result = await onUnChecked(checkbox);
-      updateSearchResultPage(result, checkbox, true);
-    } catch (e) {
-      checkbox.checked = true;
-    }
-  }
+  })(lastCheckboxPromise);
 };
 
 const addClickEventListenerToTuitionPartnerCheckboxes = () => {

--- a/UI/Pages/SearchResults.cshtml.js
+++ b/UI/Pages/SearchResults.cshtml.js
@@ -86,12 +86,12 @@ let lastCheckboxPromise = null;
 
 const onCheckboxClick = async (event) => {
   const checkbox = event.target;
+  const checked = checkbox.checked;
 
   lastCheckboxPromise = (async (previousPromise) => {
     await previousPromise;
 
     try {
-      const checked = checkbox.checked;
       const updateFunction = checked ? onChecked : onUnChecked;
 
       const result = await updateFunction(checkbox);

--- a/UI/Pages/SearchResults.cshtml.js
+++ b/UI/Pages/SearchResults.cshtml.js
@@ -90,20 +90,14 @@ const onCheckboxClick = async (event) => {
   lastCheckboxPromise = (async (previousPromise) => {
     await previousPromise;
 
-    if (checkbox.checked) {
-      try {
-        const result = await onChecked(checkbox);
-        updateSearchResultPage(result, checkbox, false);
-      } catch (e) {
-        checkbox.checked = false;
-      }
-    } else {
-      try {
-        const result = await onUnChecked(checkbox);
-        updateSearchResultPage(result, checkbox, true);
-      } catch (e) {
-        checkbox.checked = true;
-      }
+    try {
+      const checked = checkbox.checked;
+      const updateFunction = checked ? onChecked : onUnChecked;
+
+      const result = await updateFunction(checkbox);
+      updateSearchResultPage(result, checkbox, !checked);
+    } catch (e) {
+      checkbox.checked = checked;
     }
   })(lastCheckboxPromise);
 };

--- a/UI/cypress/e2e/shortlist.feature
+++ b/UI/cypress/e2e/shortlist.feature
@@ -13,6 +13,11 @@ Feature: Tuition Partner shortlist
         And 'm2r Education' is marked as shortlisted on the results page
         And the shortlist shows as having 2 entries on the results page
 
+    Scenario: User can add lots of TPs to their shortlist in quick succession from the results page
+        Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+        When they programmatically add the first 20 results to their shortlist on the results page
+        Then the shortlist shows as having 20 entries on the results page
+
     Scenario: User can remove a TP from their shortlist from the results page
         Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
         And they add 'Action Tutoring' to their shortlist on the results page

--- a/UI/cypress/e2e/shortlist.js
+++ b/UI/cypress/e2e/shortlist.js
@@ -117,9 +117,18 @@ Then("they click confirm button", () => {
   cy.get('[data-testid="call-to-action"]').click();
 });
 
-When("they programmatically add the first {int} results to their shortlist on the results page", (num) => {
-  // We will do this programmatically so that it happens quickly enough to potentially cause a race condition
-  cy.window().then(win => {
-    [...win.document.querySelectorAll(`input[name="ShortlistedTuitionPartners"]`)].slice(0, num).forEach(_ => _.click());
-  });
-});
+When(
+  "they programmatically add the first {int} results to their shortlist on the results page",
+  (num) => {
+    // We will do this programmatically so that it happens quickly enough to potentially cause a race condition
+    cy.window().then((win) => {
+      [
+        ...win.document.querySelectorAll(
+          `input[name="ShortlistedTuitionPartners"]`
+        ),
+      ]
+        .slice(0, num)
+        .forEach((_) => _.click());
+    });
+  }
+);

--- a/UI/cypress/e2e/shortlist.js
+++ b/UI/cypress/e2e/shortlist.js
@@ -116,3 +116,10 @@ Then("they click the cancel link", () => {
 Then("they click confirm button", () => {
   cy.get('[data-testid="call-to-action"]').click();
 });
+
+When("they programmatically add the first {int} results to their shortlist on the results page", (num) => {
+  // We will do this programmatically so that it happens quickly enough to potentially cause a race condition
+  cy.window().then(win => {
+    [...win.document.querySelectorAll(`input[name="ShortlistedTuitionPartners"]`)].slice(0, num).forEach(_ => _.click());
+  });
+});


### PR DESCRIPTION
## Context

We have a race condition where the shortlist becomes inconsistent if another shortlist checkbox is selected before the result of a previous one has returned (due to the cookie storage). This is causing some e2e tests to randomly fail.

## Changes proposed in this pull request

Chaining the promises for the shortlist updates so that it waits for the result of one to come back before starting the next.

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-837

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**