### PR TITLE
NTP-837: Adding some promise chaining so that shortlisting works when checkboxes are selected rapidly v2

### DIFF
--- a/UI/cypress/e2e/shortlist.js
+++ b/UI/cypress/e2e/shortlist.js
@@ -13,12 +13,14 @@ import {
 
 When("they add {string} to their shortlist on the results page", (tpName) => {
   cy.get(`#shortlist-cb-${kebabCase(tpName)}`).check();
+  cy.wait(500);
 });
 
 When(
   "they remove {string} from their shortlist on the results page",
   (tpName) => {
     cy.get(`#shortlist-cb-${kebabCase(tpName)}`).uncheck();
+    cy.wait(500);
   }
 );
 
@@ -139,5 +141,6 @@ When(
         .slice(0, num)
         .forEach((_) => _.click());
     });
+    cy.wait(500);
   }
 );


### PR DESCRIPTION
## Context

Is a nasty fix to ensure cypress tests do not fail, waiting for shortlist checkbox to complete before going to next test.

Builds on top of main fix https://github.com/DFE-Digital/find-a-tuition-partner/pull/222

## Changes proposed in this pull request

Add 500ms wait after shortlist checkbox is selected on search results page, so that the UI and cookie can update before the next test.

## Guidance to review

Run cypress test

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-837

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**