### PR TITLE
NTP-798: Fix a bug with the Invalid or Blank PostCode search on the results page

### DIFF
--- a/Tests/SearchForResults.cs
+++ b/Tests/SearchForResults.cs
@@ -177,7 +177,7 @@ public class SearchForResults : CleanSliceFixture
     [Fact]
     public async Task Displays_all_tutor_types_in_database()
     {
-        // Given
+        // Arrange
         await Fixture.AddTuitionPartner(A.TuitionPartner
             .WithName("a", "Alpha")
             .TaughtIn(District.Dacorum, TuitionTypes.InSchool)
@@ -185,11 +185,11 @@ public class SearchForResults : CleanSliceFixture
                 .Subject(Subjects.Id.KeyStage1English, l => l
                     .InSchool().Costing(12m).ForGroupSizes(2))));
 
-        // When
+        // Act
         var result = await Fixture.SendAsync(
             Basic.SearchResultsQuery with { Postcode = District.Dacorum.SamplePostcode });
 
-        // Then
+        // Assert
         result.Results.Should().NotBeNull();
         result.Results!.Results.Should().BeEquivalentTo(new[]
         {
@@ -200,11 +200,11 @@ public class SearchForResults : CleanSliceFixture
     [Fact]
     public async Task Displays_local_authority()
     {
-        // When
+        // Act
         var result = await Fixture.SendAsync(
             Basic.SearchResultsQuery with { Postcode = District.Dacorum.SamplePostcode });
 
-        // Then
+        // Assert
         result?.Results?.LocalAuthorityName.Should().Be("Hertfordshire");
     }
 

--- a/Tests/SearchForResults.cs
+++ b/Tests/SearchForResults.cs
@@ -79,19 +79,19 @@ public class SearchForResults : CleanSliceFixture
     }
 
     [Fact]
-    public async void With_a_blank_postcode()
+    public async void With_a_blank_postcode_should_have_postcode_validation_error()
     {
-        // Given
+        // Arrange
         await Fixture.AddTuitionPartner(A.TuitionPartner);
 
-        // When
-        var result = await Fixture.SendAsync(Basic.SearchResultsQuery);
+        var searchResultsQuery = Basic.SearchResultsQuery;
+        searchResultsQuery.Postcode = "";
 
-        // Then
-        new TestValidationResult<SearchResults.Query>(result.Validation)
-            .ShouldNotHaveValidationErrorFor(x => x.Postcode);
+        // Act
+        var result = await Fixture.SendAsync(searchResultsQuery);
 
-        result.Results!.Results.Should().NotBeEmpty();
+        // Assert
+        PostCodeEmptyOrInvalidShouldHaveValidationError(result, "Enter a postcode");
     }
 
     [Fact]
@@ -211,10 +211,16 @@ public class SearchForResults : CleanSliceFixture
     [Fact]
     public async Task Preserves_selected_from_querystring()
     {
+        // Arrange
         await Fixture.AddTuitionPartner(A.TuitionPartner);
 
-        var result = await Fixture.SendAsync(Basic.SearchResultsQuery);
+        var searchResultsQuery = Basic.SearchResultsQuery;
+        searchResultsQuery.Postcode = District.Dacorum.SamplePostcode;
 
+        // Act
+        var result = await Fixture.SendAsync(searchResultsQuery);
+
+        // Assert
         result.Results.Should().NotBeNull();
         result.AllSubjects.Should().ContainKey(KeyStage.KeyStage1)
             .WhoseValue.Should().BeEquivalentTo(new[]
@@ -223,23 +229,50 @@ public class SearchForResults : CleanSliceFixture
                 new { Name = "Maths", Selected = false },
                 new { Name = "Science", Selected = false },
             });
+
+        result.Postcode.Should().Be(District.Dacorum.SamplePostcode);
     }
 
     [Fact]
-    public async Task Verify_Search_Results_Count()
+    public async Task Verify_Search_Results_Count_With_Valid_PostCode()
     {
+        // Arrange
         const int numberOfTuitionPartners = 55;
 
-        // Given
         for (int tuitionPartnersAdded = 1; tuitionPartnersAdded <= numberOfTuitionPartners; tuitionPartnersAdded++)
-            await Fixture.AddTuitionPartner(A.TuitionPartner);
+            await Fixture.AddTuitionPartner(A.TuitionPartner.
+                TaughtIn(District.EastRidingOfYorkshire, TuitionTypes.InSchool, TuitionTypes.Online));
 
-        // When
-        var result = await Fixture.SendAsync(new SearchResults.Query());
+        var searchResultsQuery = Basic.SearchResultsQuery;
+        searchResultsQuery.Postcode = District.EastRidingOfYorkshire.SamplePostcode;
 
-        // Then
+        // Act
+        var result = await Fixture.SendAsync(searchResultsQuery);
+
+        // Assert
         result!.Results.Should().NotBeNull();
         result!.Results!.Count.Should().Be(numberOfTuitionPartners);
+    }
+
+    [Fact]
+    public async Task Verify_Search_Results_With_InValid_PostCode()
+    {
+        // Arrange
+        const int numberOfTuitionPartners = 55;
+
+        for (int tuitionPartnersAdded = 1; tuitionPartnersAdded <= numberOfTuitionPartners; tuitionPartnersAdded++)
+            await Fixture.AddTuitionPartner(A.TuitionPartner.
+                TaughtIn(District.EastRidingOfYorkshire, TuitionTypes.InSchool, TuitionTypes.Online));
+
+        var searchResultsQuery = Basic.SearchResultsQuery;
+        searchResultsQuery.Postcode = "AAAA BBCCD"; ;
+
+        // Act
+        var result = await Fixture.SendAsync(searchResultsQuery);
+
+        // Assert
+        result!.Results.Should().BeNull();
+        PostCodeEmptyOrInvalidShouldHaveValidationError(result, "Enter a valid postcode");
     }
 
     [Theory]
@@ -247,19 +280,31 @@ public class SearchForResults : CleanSliceFixture
     [InlineData("image-data", true)]
     public async Task Results_show_logos(string? logo, bool hasLogo)
     {
-        // Given
+        // Arrange
+        var searchResultsQuery = Basic.SearchResultsQuery;
+        searchResultsQuery.Postcode = District.EastRidingOfYorkshire.SamplePostcode;
+
         var partner = logo == null
-            ? A.TuitionPartner
-            : A.TuitionPartner.WithLogo(logo);
+            ? A.TuitionPartner.TaughtIn(District.EastRidingOfYorkshire, TuitionTypes.InSchool, TuitionTypes.Online)
+            : A.TuitionPartner.WithLogo(logo).TaughtIn(District.EastRidingOfYorkshire, TuitionTypes.InSchool, TuitionTypes.Online);
         await Fixture.AddTuitionPartner(partner);
 
-        // When
-        var result = await Fixture.SendAsync(Basic.SearchResultsQuery);
+        // Act
+        var result = await Fixture.SendAsync(searchResultsQuery);
 
-        // Then
+        // Assert
         result!.Results!.Results.Should().ContainEquivalentOf(new
         {
             HasLogo = hasLogo,
         });
+    }
+
+    private static void PostCodeEmptyOrInvalidShouldHaveValidationError(SearchResults.ResultsModel result, string errorMessage)
+    {
+        result.Validation?.IsValid.Should().Be(false);
+
+        result.Validation?.Errors.Count.Should().Be(1);
+
+        result.Validation?.Errors[0].ErrorMessage.Should().Be(errorMessage);
     }
 }

--- a/Tests/ShortlistPageTests.cs
+++ b/Tests/ShortlistPageTests.cs
@@ -1,0 +1,55 @@
+using FluentValidation.TestHelper;
+using Microsoft.AspNetCore.Mvc;
+using UI.Pages;
+
+namespace Tests;
+
+[Collection(nameof(SliceFixture))]
+public class ShortlistPageTests : CleanSliceFixture
+{
+    public ShortlistPageTests(SliceFixture fixture) : base(fixture)
+    {
+    }
+
+    [Theory]
+    [InlineData("not a postcode")]
+    [InlineData("ABCDD EFG")]
+    public void With_an_invalid_postcode(string postcode)
+    {
+        var model = new ShortlistModel.Query() { Postcode = postcode };
+        var result = new ShortlistModel.Validator().TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Postcode)
+            .WithErrorMessage("Enter a valid postcode");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void With_a_blank_or_null_postcode(string postcode)
+    {
+        var model = new ShortlistModel.Query() { Postcode = postcode };
+        var result = new ShortlistModel.Validator().TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Postcode)
+            .WithErrorMessage("Enter a postcode");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("not a postcode")]
+    [InlineData("ABCDD EFG")]
+    public async Task With_a_blank_or_invalid_postcode_user_should_be_redirect_to_search_results_page(string postcode)
+    {
+        const string pageNameProp = "PageName";
+        var query = new ShortlistModel.Query() { Postcode = postcode };
+        var result = await Fixture.GetPage<ShortlistModel>().Execute(async page => await page.OnGet(query));
+        result.Should().BeOfType<RedirectToPageResult>();
+        var pageName = GetPropValue(result, pageNameProp);
+        pageName.Should().Be(nameof(SearchResults));
+    }
+
+    private static object? GetPropValue(object src, string propName)
+    {
+        return src.GetType().GetProperty(propName)?.GetValue(src, null);
+    }
+}

--- a/Tests/ShowAllTuitionPartners.cs
+++ b/Tests/ShowAllTuitionPartners.cs
@@ -13,17 +13,17 @@ public class ShowAllTuitionPartners : CleanSliceFixture
     [Fact]
     public async Task Displays_all_tuition_partners_in_database_in_alphabetical_ordering()
     {
-        // Given
+        // Arrange
         await Fixture.AddTuitionPartner(A.TuitionPartner.WithName("Beta"));
         await Fixture.AddTuitionPartner(A.TuitionPartner.WithName("Gamma"));
         await Fixture.AddTuitionPartner(A.TuitionPartner.WithName("Alpha"));
 
-        // When
+        // Act
         CancellationTokenSource cts = new();
         CancellationToken cancellationToken = cts.Token;
         var page = await Fixture.GetPage<AllTuitionPartners>(page => page.OnGet(cancellationToken));
 
-        // Then
+        // Assert
         page.Results.Should().NotBeNull();
         page.Results!.Results.Should().BeEquivalentTo(new[]
         {
@@ -53,11 +53,11 @@ public class ShowAllTuitionPartners : CleanSliceFixture
     [Fact]
     public async Task Search_by_name()
     {
-        // Given
+        // Arrange
         await Fixture.AddTuitionPartner(A.TuitionPartner.WithName("Alpha"));
         await Fixture.AddTuitionPartner(A.TuitionPartner.WithName("Beta"));
 
-        // When
+        // Act
         var page = await Fixture.GetPage<AllTuitionPartners>(page =>
         {
             page.Data.Name = "LPh";
@@ -66,7 +66,7 @@ public class ShowAllTuitionPartners : CleanSliceFixture
             return page.OnGet(cancellationToken);
         });
 
-        // Then
+        // Assert
         page.Results.Should().NotBeNull();
         page.Results!.Results.Should().BeEquivalentTo(new[]
         {

--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -180,6 +180,10 @@ public class SearchResults : PageModel
         public Validator()
         {
             RuleFor(m => m.Postcode)
+                .NotEmpty()
+                .WithMessage("Enter a postcode");
+
+            RuleFor(m => m.Postcode)
                 .Matches(StringConstants.PostcodeRegExp)
                 .WithMessage("Enter a valid postcode")
                 .When(m => !string.IsNullOrEmpty(m.Postcode));
@@ -290,9 +294,6 @@ public class SearchResults : PageModel
             CancellationToken cancellationToken)
         {
             var validationResults = await new Validator().ValidateAsync(request, cancellationToken);
-
-            if (string.IsNullOrWhiteSpace(request.Postcode))
-                return Result.Success(new LocationFilterParameters());
 
             return !validationResults.IsValid
                 ? Result.Invalid<LocationFilterParameters>(validationResults.Errors)

--- a/UI/Pages/Shortlist.cshtml.cs
+++ b/UI/Pages/Shortlist.cshtml.cs
@@ -163,7 +163,7 @@ public class ShortlistModel : PageModel
             if (location is IErrorResult error)
             {
                 //Shouldn't be invalid, unless query string edited - since postcode on this page comes from previous page with validation
-                _logger.LogInformation("Invalid postcode '{Postcode}' provided on shortlist page", request.Postcode);
+                _logger.LogWarning("Invalid postcode '{Postcode}' provided on shortlist page", request.Postcode);
                 return error.Cast<TuitionPartnersResult>();
             }
             else if (location.Data.LocalAuthorityDistrictId is null)

--- a/UI/Pages/Shortlist.cshtml.cs
+++ b/UI/Pages/Shortlist.cshtml.cs
@@ -12,15 +12,16 @@ public class ShortlistModel : PageModel
 
     public ResultsModel Data { get; set; } = new();
 
-    public async Task OnGet(Query data)
+    public async Task<IActionResult> OnGet(Query data)
     {
-        data.From = Enums.ReferrerList.Shortlist;
+        data.From = ReferrerList.Shortlist;
+        var validator = new Validator();
+        var results = await validator.ValidateAsync(data);
+        if (!results.IsValid)
+            return RedirectToPage(nameof(SearchResults), new SearchModel(data));
 
         Data = await _mediator.Send(data);
-
-        if (!Data.Validation.IsValid)
-            foreach (var error in Data.Validation.Errors)
-                ModelState.AddModelError($"Data.{error.PropertyName}", error.ErrorMessage);
+        return Page();
     }
 
     public async Task<IActionResult> OnPostRemoveAsync(Query data)
@@ -64,10 +65,14 @@ public class ShortlistModel : PageModel
 
     }
 
-    private class Validator : AbstractValidator<Query>
+    public class Validator : AbstractValidator<Query>
     {
         public Validator()
         {
+            RuleFor(m => m.Postcode)
+                .NotEmpty()
+                .WithMessage("Enter a postcode");
+
             RuleFor(m => m.Postcode)
                 .Matches(StringConstants.PostcodeRegExp)
                 .WithMessage("Enter a valid postcode")
@@ -158,7 +163,7 @@ public class ShortlistModel : PageModel
             if (location is IErrorResult error)
             {
                 //Shouldn't be invalid, unless query string edited - since postcode on this page comes from previous page with validation
-                _logger.LogWarning("Invalid postcode '{Postcode}' provided on shortlist page", request.Postcode);
+                _logger.LogInformation("Invalid postcode '{Postcode}' provided on shortlist page", request.Postcode);
                 return error.Cast<TuitionPartnersResult>();
             }
             else if (location.Data.LocalAuthorityDistrictId is null)
@@ -178,13 +183,9 @@ public class ShortlistModel : PageModel
 
             return Result.Success(result);
         }
-
         private async Task<IResult<LocationFilterParameters>> GetSearchLocation(Query request, CancellationToken cancellationToken)
         {
             var validationResults = await new Validator().ValidateAsync(request, cancellationToken);
-
-            if (string.IsNullOrWhiteSpace(request.Postcode))
-                return Result.Success(new LocationFilterParameters { });
 
             if (!validationResults.IsValid)
             {

--- a/UI/cypress/e2e/privacy.feature
+++ b/UI/cypress/e2e/privacy.feature
@@ -46,7 +46,7 @@
     Then they will see contact secure dfe form link
     And the contact secure dfe link opens in a new window
 
-  Scenario: page as link to contact secure dfe
+  Scenario: page as link to contact secure dfe online form link
     Given a user has arrived on the privacy page
     Then they will see contact secure dfe online form link
     And the contact secure dfe online form link opens in a new window

--- a/UI/cypress/e2e/results.feature
+++ b/UI/cypress/e2e/results.feature
@@ -30,8 +30,8 @@ Feature: User is shown search results
 
   Scenario: user does not enter postcode
     Given a user has arrived on the 'Search results' page for 'Key stage 1 English' without a postcode
-    Then display all correct tuition partners that provide the selected subjects in any location
-    And they will not see an error message
+    And they click 'Continue'
+    Then they will see 'Enter a postcode' as an error message for the 'postcode'
 
   Scenario: user enters an invalid postcode
     Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
@@ -68,7 +68,7 @@ Feature: User is shown search results
 
   Scenario: lands on search results with blank URL
     Given a user has arrived on the 'Search results' page without subjects or postcode
-    Then display all correct tuition partners in any location
+    Then they will see 'Enter a postcode' as an error message for the 'postcode'
     And all subject filters are collapsed
 
   Scenario: unselects all boxes on the filters
@@ -116,13 +116,13 @@ Feature: User is shown search results
 
   Scenario: Nothing is selected if when clear all filters is clicked
     Given a user has arrived on the 'Search results' page
-    When the ‘clear filters’ button as been selected
+    When the ‘clear filters’ button has been selected
     Then no subject should be shown as selected
     And they will see the tuition type 'Any' is selected
 
   Scenario: All subject filters are collapsed when clear all filters is clicked
     Given a user has arrived on the 'Search results' page
-    When the ‘clear filters’ button as been selected
+    When the ‘clear filters’ button has been selected
     Then all subject filters are collapsed
 
   Scenario: Results are updated when clear all filters is clicked
@@ -131,7 +131,7 @@ Feature: User is shown search results
 
   Scenario: Postcode is retained after clear filters is selected
     Given a user has arrived on the 'Search results' page
-    When the ‘clear filters’ button as been selected
+    When the ‘clear filters’ button has been selected
     Then the postcode search parameter remains
 
   Scenario: Results page  contact us back link redirects to right page
@@ -140,26 +140,23 @@ Feature: User is shown search results
     When they click 'Back'
     Then they will see the results summary for 'Hertfordshire'
 
-  Scenario: Tuition partner details are displayed correctly when no postcode entered or filters selected on results page
-    Given a user has arrived on the 'Search results' page without subjects or postcode
-    When they enter '' as the school's postcode
-    Then all tuition partner parameters are populated correctly
+  Scenario: Tuition partner details are not displayed when no postcode entered
+    Given a user has arrived on the 'Search results' page without subjects for postcode ''
+    Then they will see 'Enter a postcode' as an error message for the 'postcode'
 
   Scenario: Tuition partner details are displayed correctly when postcode entered and no filters are selected on results page
-    Given a user has arrived on the 'Search results' page without subjects or postcode
-    When they enter 'SK1 1EB' as the school's postcode
+    Given a user has arrived on the 'Search results' page without subjects
     Then all tuition partner parameters are populated correctly
 
   Scenario: Tuition partner details are displayed correctly when postcode entered and filters are selected on results page
-    Given a user has arrived on the 'Search results' page without subjects or postcode
-    When they enter 'SK1 1EB' as the school's postcode
+    Given a user has arrived on the 'Search results' page without subjects
     And 'Key stage 1 English' is selected
     Then all tuition partner parameters are populated correctly
     And the number of tuition partners displayed matches the displayed count
 
   Scenario: Tuition partner details are displayed correctly after clear filters is selected on results page
-    Given a user has arrived on the 'Search results' page without subjects or postcode
-    When the ‘clear filters’ button as been selected
+    Given a user has arrived on the 'Search results' page for 'Key stage 1 English' for postcode 'SK1 1EB'
+    When the ‘clear filters’ button has been selected
     Then all tuition partner parameters are populated correctly
     And the number of tuition partners displayed matches the displayed count
 
@@ -185,17 +182,17 @@ Feature: User is shown search results
     Given a user has arrived on the 'Search results' page without subjects
     Then the number of tuition partners displayed matches the displayed count
 
-  Scenario: Search result matches the displayed count with no subjects or postcode
-    Given a user has arrived on the 'Search results' page without subjects or postcode
+  Scenario: Search result matches the displayed count with no subjects
+    Given a user has arrived on the 'Search results' page without subjects
     Then the number of tuition partners displayed matches the displayed count
 
-  Scenario: Logos are displayed for tution partners
-    Given a user has arrived on the 'Search results' page without subjects or postcode
+  Scenario: Logos are displayed for tuition partners
+    Given a user has arrived on the 'Search results' page without subjects
     Then logos are shown for tuition partners
 
-  Scenario: Logos are hidden on mobile for tution partners
+  Scenario: Logos are hidden on mobile for tuition partners
     Given a user is using a 'phone'
-    Given a user has arrived on the 'Search results' page without subjects or postcode
+    Given a user has arrived on the 'Search results' page without subjects
     Then logos are not shown for tuition partners
 
   Scenario: User is returned to the correction TP position on the search result page

--- a/UI/cypress/e2e/results.js
+++ b/UI/cypress/e2e/results.js
@@ -58,7 +58,7 @@ When("a user selects all subject", () => {
   cy.get('[id="key-stage-4-english"]').check();
 });
 
-Then("the ‘clear filters’ button as been selected", () => {
+Then("the ‘clear filters’ button has been selected", () => {
   cy.get('[data-testid="clear-all-filters"]').click();
 });
 

--- a/UI/cypress/e2e/shortlist.feature
+++ b/UI/cypress/e2e/shortlist.feature
@@ -35,6 +35,16 @@ Feature: Tuition Partner shortlist
         And they choose to view their shortlist from the results page
         When they click 'Back'
         Then the search results are displayed
+        
+    Scenario: On the Shortlist page blank postcode user redirect back to the search results page with a validation error shown
+        Given a user has arrived on the 'My shortlisted tuition partners' page for postcode ''
+        Then the page URL ends with '/search-results'
+        And they will see 'Enter a postcode' as an error message for the 'postcode'
+        
+    Scenario: On the Shortlist page invalid postcode user redirect back to the search results page with a validation error shown
+        Given a user has arrived on the 'My shortlisted tuition partners' page for postcode 'invalid postcode'
+        Then the page URL ends with '/search-results'
+        And they will see 'Enter a valid postcode' as an error message for the 'postcode'
 
     Scenario: User views their shortlisted TPs on the shortlist page
         Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'

--- a/UI/cypress/e2e/subjects.feature
+++ b/UI/cypress/e2e/subjects.feature
@@ -20,7 +20,7 @@ Feature: User can choose Key Stage and Subject
     Given a user has arrived on the 'Which subjects' page for 'Key stage 1'
     Then the page's title is 'Which subjects do you need tutoring support for?'
 
-  Scenario: user clicks service name on key stages page
+  Scenario: user clicks service name on which subjects page
     Given a user has arrived on the 'Which subjects' page for 'Key stage 1'
     When they click the 'Find a tuition partner' service name link
     Then they will be taken to the 'Find a tuition partner' journey start page

--- a/UI/cypress/support/step_definitions/shortlist-page.js
+++ b/UI/cypress/support/step_definitions/shortlist-page.js
@@ -1,0 +1,13 @@
+import {
+    Given,
+    When,
+    Then,
+    Step,
+} from "@badeball/cypress-cucumber-preprocessor";
+
+Given(
+    "a user has arrived on the 'My shortlisted tuition partners' page for postcode {string}",
+    (postcode) => {
+        cy.visit(`/shortlist?Postcode=${postcode}`);
+    }
+);


### PR DESCRIPTION
## Context

Fix a bug with the Invalid or Blank PostCode search on the results page.

This bug fix also covers the NTP-797: Shortlist page logs an error if the postcode is missing.

## Changes proposed in this pull request

Ensure that when a search is carried out with a blank or invalid postcode on the 'search results page, the postcode validator validates the postcode and displays the appropriate validation error message.

Ensure on the 'shortlist page' If the postcode is blank or invalid, and then we send the user straight back to the 'search results page; the postcode validator validates the postcode and displays the appropriate validation error message.

## Guidance to review

Ensure that the postcode validation works on the 'search results' and 'shortlist' pages, and with a blank or invalid postcode, ensure the functionality works. Test with and without js enabled on mobile and check accessibility.

## Link to Jira ticket

[https://dfedigital.atlassian.net/browse/NTP-798](https://dfedigital.atlassian.net/browse/NTP-798)

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**