### PR TITLE
NTP-863: Reduce the 404 alerting when there is no TP found.

### DIFF
--- a/UI/MediatR/Handlers/GetTuitionPartnerQueryHandler.cs
+++ b/UI/MediatR/Handlers/GetTuitionPartnerQueryHandler.cs
@@ -129,7 +129,7 @@ public class GetTuitionPartnerQueryHandler : IRequestHandler<GetTuitionPartnerQu
         if (id == null)
         {
             //shouldn't get here, unless manually changed query string
-            _logger.LogWarning("No TP found for the invalid Id '{Id}' provided", request.Id);
+            _logger.LogInformation("No TP found for the invalid Id '{Id}' provided", request.Id);
             return Result.Error<TuitionPartnerResult>();
         }
 


### PR DESCRIPTION
## Context

Currently, when someone passes an invalid tuition partner id not found on our system, we log a warning that creates an alert for us to look into that. As the tuition partner id is not found, an error classed as 404 error, we will log that as info instead of a warning that will not trigger an alert.

## Changes proposed in this pull request

Change log level from warning to information when there is no TP found.

## Guidance to review

Ensure that when there is no TP found, the error is logged as information, and we do not get an alert for that error.

## Link to Jira ticket

[https://dfedigital.atlassian.net/browse/NTP-863](https://dfedigital.atlassian.net/browse/NTP-863)

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**