### PR TITLE
NTP-863: Change log level from warning to info when no Tuition Partner is found

### DIFF
--- a/UI/MediatR/Handlers/GetTuitionPartnerQueryHandler.cs
+++ b/UI/MediatR/Handlers/GetTuitionPartnerQueryHandler.cs
@@ -129,7 +129,7 @@ public class GetTuitionPartnerQueryHandler : IRequestHandler<GetTuitionPartnerQu
         if (id == null)
         {
             //shouldn't get here, unless manually changed query string
-            _logger.LogWarning("No TP found for the invalid Id '{Id}' provided", request.Id);
+            _logger.LogInformation("No TP found for the invalid Id '{Id}' provided", request.Id);
             return Result.Error<TuitionPartnerResult>();
         }
 

--- a/UI/Pages/TuitionPartner.cshtml.cs
+++ b/UI/Pages/TuitionPartner.cshtml.cs
@@ -21,7 +21,7 @@ public class TuitionPartner : PageModel
         SearchModel = new SearchModel(query);
 
         if (string.IsNullOrWhiteSpace(query.Id))
-            return ReturnNotFound($"Null or whitespace id '{query.Id}' provided");
+            return ReturnNotFoundWithLogging($"Null or whitespace id '{query.Id}' provided", LogLevel.Information);
 
         Data = await _mediator.Send(query);
 
@@ -29,7 +29,7 @@ public class TuitionPartner : PageModel
         {
             var seoUrl = query.Id.ToSeoUrl();
 
-            if (query.Id == seoUrl) return ReturnNotFound($"No Tuition Partner found for id '{query.Id}'");
+            if (query.Id == seoUrl) return ReturnNotFoundWithLogging($"No Tuition Partner found for id '{query.Id}'", LogLevel.Information);
 
             _logger.LogInformation("Non SEO id '{Id}' provided. Redirecting to {SeoUrl}", query.Id, seoUrl);
             return RedirectToPage((query with { Id = seoUrl }).ToRouteData());
@@ -79,9 +79,9 @@ public class TuitionPartner : PageModel
     private ArgumentException GetArgumentException(string name) => new($"{name} is null or whitespace");
     private JsonResult GetShortlistJsonResult(bool status) => new(new { Updated = status });
 
-    private IActionResult ReturnNotFound(string logMessage)
+    private IActionResult ReturnNotFoundWithLogging(string logMessage, LogLevel logLevel)
     {
-        _logger.LogWarning("{LogMessage}", logMessage);
+        _logger.Log(logLevel, "{LogMessage}", logMessage);
         return NotFound();
     }
 


### PR DESCRIPTION
## Context

Currently, when someone passes an invalid tuition partner id not found on our system, we log a warning that creates an alert for us to look into that. As the tuition partner id is not found, an error classed as 404 error, we will log that as info instead of a warning that will not trigger an alert.

## Changes proposed in this pull request

Change log level from warning to information when there is no TP found.

## Guidance to review

Ensure that when no Tuition Partner is found for a given id on the`TuitionPartner.cshtml.cs`, the error is logged as information, and we do not get an alert for that error.

## Link to Jira ticket

[https://dfedigital.atlassian.net/browse/NTP-863](https://dfedigital.atlassian.net/browse/NTP-863)

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**