### PR TITLE
NTP-867: Changing 'Enter a valid postcode' to 'Enter a real postcode'

### DIFF
--- a/Application/Extensions/LocationFilterParametersExtensions.cs
+++ b/Application/Extensions/LocationFilterParametersExtensions.cs
@@ -43,7 +43,7 @@ public class LocationNotAvailableResult : ErrorResult<LocationFilterParameters, 
 
 public class LocationNotFoundResult : ErrorResult<LocationFilterParameters, string>
 {
-    public LocationNotFoundResult() : base("Enter a valid postcode")
+    public LocationNotFoundResult() : base("Enter a real postcode")
     {
     }
 }

--- a/Tests/SearchForAPostcode.cs
+++ b/Tests/SearchForAPostcode.cs
@@ -33,7 +33,7 @@ public class SearchForAPostcode
         var model = new Index.Command { Postcode = postcode };
         var result = new Index.Validator().TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.Postcode)
-            .WithErrorMessage("Enter a valid postcode");
+            .WithErrorMessage("Enter a real postcode");
     }
 
     [Theory]

--- a/Tests/SearchForResults.cs
+++ b/Tests/SearchForResults.cs
@@ -24,7 +24,7 @@ public class SearchForResults : CleanSliceFixture
         var model = new Index.Command { Postcode = postcode };
         var result = new Index.Validator().TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.Postcode)
-            .WithErrorMessage("Enter a valid postcode");
+            .WithErrorMessage("Enter a real postcode");
     }
 
     [Theory]
@@ -39,7 +39,7 @@ public class SearchForResults : CleanSliceFixture
 
         var validationResult = new TestValidationResult<SearchResults.Query>(result.Validation);
         validationResult.ShouldHaveValidationErrorFor(x => x.Postcode)
-            .WithErrorMessage("Enter a valid postcode");
+            .WithErrorMessage("Enter a real postcode");
     }
 
     [Theory]
@@ -272,7 +272,7 @@ public class SearchForResults : CleanSliceFixture
 
         // Assert
         result!.Results.Should().BeNull();
-        PostCodeEmptyOrInvalidShouldHaveValidationError(result, "Enter a valid postcode");
+        PostCodeEmptyOrInvalidShouldHaveValidationError(result, "Enter a real postcode");
     }
 
     [Theory]

--- a/Tests/ShortlistPageTests.cs
+++ b/Tests/ShortlistPageTests.cs
@@ -19,7 +19,7 @@ public class ShortlistPageTests : CleanSliceFixture
         var model = new ShortlistModel.Query() { Postcode = postcode };
         var result = new ShortlistModel.Validator().TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.Postcode)
-            .WithErrorMessage("Enter a valid postcode");
+            .WithErrorMessage("Enter a real postcode");
     }
 
     [Theory]

--- a/UI/MediatR/Handlers/GetTuitionPartnerQueryHandler.cs
+++ b/UI/MediatR/Handlers/GetTuitionPartnerQueryHandler.cs
@@ -266,7 +266,7 @@ public class GetTuitionPartnerQueryHandler : IRequestHandler<GetTuitionPartnerQu
         {
             RuleFor(m => m.Postcode)
                 .Matches(StringConstants.PostcodeRegExp)
-                .WithMessage("Enter a valid postcode")
+                .WithMessage("Enter a real postcode")
                 .When(m => !string.IsNullOrEmpty(m.Postcode));
         }
     }

--- a/UI/Pages/Index.cshtml.cs
+++ b/UI/Pages/Index.cshtml.cs
@@ -56,7 +56,7 @@ public partial class Index : PageModel
 
             RuleFor(m => m.Postcode)
                 .Matches(StringConstants.PostcodeRegExp)
-                .WithMessage("Enter a valid postcode");
+                .WithMessage("Enter a real postcode");
         }
     }
 

--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -201,7 +201,7 @@ public class SearchResults : PageModel
 
             RuleFor(m => m.Postcode)
                 .Matches(StringConstants.PostcodeRegExp)
-                .WithMessage("Enter a valid postcode")
+                .WithMessage("Enter a real postcode")
                 .When(m => !string.IsNullOrEmpty(m.Postcode));
 
             RuleForEach(m => m.Subjects)

--- a/UI/Pages/Shortlist.cshtml.cs
+++ b/UI/Pages/Shortlist.cshtml.cs
@@ -87,7 +87,7 @@ public class ShortlistModel : PageModel
 
             RuleFor(m => m.Postcode)
                 .Matches(StringConstants.PostcodeRegExp)
-                .WithMessage("Enter a valid postcode")
+                .WithMessage("Enter a real postcode")
                 .When(m => !string.IsNullOrEmpty(m.Postcode));
         }
     }

--- a/UI/cypress/e2e/postcode.feature
+++ b/UI/cypress/e2e/postcode.feature
@@ -46,7 +46,7 @@ Feature: User enters postcode to begin search
     Given a user has started the 'Find a tuition partner' journey
     When they enter 'INVALID' as the school's postcode
     And they click 'Continue'
-    Then they will see 'Enter a valid postcode' as an error message for the 'postcode'
+    Then they will see 'Enter a real postcode' as an error message for the 'postcode'
 
   Scenario: user enters a postcode in Wales
     Given a user has started the 'Find a tuition partner' journey

--- a/UI/cypress/e2e/results.feature
+++ b/UI/cypress/e2e/results.feature
@@ -37,7 +37,7 @@ Feature: User is shown search results
     Given a user has arrived on the 'Search results' page for 'Key stage 1 English'
     When they enter 'INVALID' as the school's postcode
     And they click 'Continue'
-    Then they will see 'Enter a valid postcode' as an error message for the 'postcode'
+    Then they will see 'Enter a real postcode' as an error message for the 'postcode'
 
   Scenario: user enters a postcode in Wales
     Given a user has arrived on the 'Search results' page for 'Key stage 1 English'

--- a/UI/cypress/e2e/shortlist.feature
+++ b/UI/cypress/e2e/shortlist.feature
@@ -45,7 +45,7 @@ Feature: Tuition Partner shortlist
     Scenario: On the Shortlist page invalid postcode user redirect back to the search results page with a validation error shown
       Given a user has arrived on the 'My shortlisted tuition partners' page for postcode 'invalid postcode'
       Then the page URL ends with '/search-results'
-      And they will see 'Enter a valid postcode' as an error message for the 'postcode'
+      And they will see 'Enter a real postcode' as an error message for the 'postcode'
 
   Scenario: User views their shortlisted TPs on the shortlist page
     Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'


### PR DESCRIPTION
## Context

'Enter a valid postcode' should read 'Enter a real postcode' as per GDS guidelines

## Guidance to review

When a user enters an invalid postcode, the error message says ‘Enter a valid postcode’. The use of ‘valid’ is against GDS guidelines for error messages: https://design-system.service.gov.uk/components/error-message/#be-clear-and-concise

We should use ‘Enter a real postcode’ as per the address pattern here: https://design-system.service.gov.uk/patterns/addresses/#error-messages

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-867

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [x] Database migrations can be applied to the current codebase in main without causing exceptions
- [x] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**