### PR TITLE
NTP-868: No order by on the TP details price group

### DIFF
--- a/UI/MediatR/Handlers/GetTuitionPartnerQueryHandler.cs
+++ b/UI/MediatR/Handlers/GetTuitionPartnerQueryHandler.cs
@@ -202,6 +202,7 @@ public class GetTuitionPartnerQueryHandler : IRequestHandler<GetTuitionPartnerQu
                 )
             )
             .Where(x => x.Value.HasAtLeastOnePrice)
+            .OrderBy(x => x.Key)
             .ToDictionary(k => k.Key, v => v.Value);
 
         static decimal? MinPrice(IEnumerable<Price> value, TuitionTypes tuitionType)

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -149,7 +149,7 @@
     @foreach (var item in Model.Data.Prices)
     {
         <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">@(((Domain.Enums.GroupSize)item.Key).DisplayName())</th>
+            <th scope="row" class="govuk-table__header" data-testid="pricing-group-size-column">@(((Domain.Enums.GroupSize)item.Key).DisplayName())</th>
             <td show-if="@Model.Data.Prices.ContainsInSchoolPrice()" class="govuk-table__cell">
                 @item.Value.FormatFor(TuitionTypes.InSchool)
             </td>

--- a/UI/cypress/e2e/full-list.feature
+++ b/UI/cypress/e2e/full-list.feature
@@ -87,7 +87,7 @@ Scenario: Logos are not displayed for tution partners
     Given a user has arrived on the all quality-assured tuition partners page
     Then logos are not shown for tuition partners
 
-  Scenario: From the full list we can visit each TP details page and see the Type of Tuition details and is returned to the location of the selected TP on the list
+  Scenario: From the full list we can visit each TP details page and see the Type of Tuition details and the pricing in the correct order then is returned to the location of the selected TP on the list
     Given a user has started the 'Find a tuition partner' journey
     When they click the 'All quality-assured tuition partners' link
-    Then they can visit each TP details page and see the Type of Tuition details
+    Then they can visit each TP details page and see the Type of Tuition details and the pricing in the correct order

--- a/UI/cypress/e2e/full-list.js
+++ b/UI/cypress/e2e/full-list.js
@@ -193,7 +193,7 @@ Then(
   "they can visit each TP details page and see the Type of Tuition details and the pricing in the correct order",
   () => {
     cy.get('[data-testid="tuition-partner-name-link"]').each(($element) => {
-      cy.isCorrectJumpToLocation($element);
+      cy.validateTPPageAndReturnLink($element);
     });
   }
 );

--- a/UI/cypress/e2e/full-list.js
+++ b/UI/cypress/e2e/full-list.js
@@ -190,7 +190,7 @@ Then("logos are not shown for tuition partners", () => {
 });
 
 Then(
-  "they can visit each TP details page and see the Type of Tuition details",
+  "they can visit each TP details page and see the Type of Tuition details and the pricing in the correct order",
   () => {
     cy.get('[data-testid="tuition-partner-name-link"]').each(($element) => {
       cy.isCorrectJumpToLocation($element);

--- a/UI/cypress/support/commands.js
+++ b/UI/cypress/support/commands.js
@@ -77,6 +77,20 @@ Cypress.Commands.add("isWithinViewPort", (element) => {
 Cypress.Commands.add("isCorrectJumpToLocation", ($element) => {
   cy.visit($element.attr("href"));
   cy.get('[data-testid="type-of-tuition"]').first().should("not.be.empty");
+  cy.get('[data-testid="pricing-group-size-column"]')
+    .first()
+    .should("not.be.empty");
+  const names = [];
+  cy.get('[data-testid="pricing-group-size-column"]')
+    .each(($element, index) => {
+      names[index] = $element.text();
+    })
+    .then(() => {
+      const sortedNames = names.slice().sort(function (a, b) {
+        return a.localeCompare(b, "en", { sensitivity: "base" });
+      });
+      expect(names).to.deep.equal(sortedNames);
+    });
   cy.get(".govuk-back-link").click();
   cy.get(`[id="${getJumpToLocationId($element)}"]`).then(($el) => {
     cy.isWithinViewPort($el);

--- a/UI/cypress/support/commands.js
+++ b/UI/cypress/support/commands.js
@@ -74,7 +74,7 @@ Cypress.Commands.add("isWithinViewPort", (element) => {
   return element;
 });
 
-Cypress.Commands.add("isCorrectJumpToLocation", ($element) => {
+Cypress.Commands.add("validateTPPageAndReturnLink", ($element) => {
   cy.visit($element.attr("href"));
   cy.get('[data-testid="type-of-tuition"]').first().should("not.be.empty");
   cy.get('[data-testid="pricing-group-size-column"]')

--- a/UI/cypress/support/step_definitions/results-page.js
+++ b/UI/cypress/support/step_definitions/results-page.js
@@ -191,7 +191,7 @@ Then(
   "they can visit each TP details page and be returned back to the correct TP location",
   () => {
     cy.get('[data-testid="tuition-partner-name-link"]').each(($element) => {
-      cy.isCorrectJumpToLocation($element);
+      cy.validateTPPageAndReturnLink($element);
     });
   }
 );


### PR DESCRIPTION
## Context

Ordering for pricing by group sizes is not always correct on the TP details page, e.g. https://www.find-tuition-partner.service.gov.uk/tuition-partner/tutor-doctor-beeston-park

![image](https://user-images.githubusercontent.com/113545700/215832019-50ef1ee2-680c-4831-ad12-2f1517f530d9.png)

## Changes proposed in this pull request

Ensure that the pricing is ordered by group size

## Guidance to review

Run updated end to end tests and check the "tutor-doctor-beeston-park" TP

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-868

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [x] **PR deployment has been signed off by wider team**