### PR TITLE
NTP-921: Changes for VAT

### DIFF
--- a/Application.Tests/Extensions/DecimalExtensionsTests.cs
+++ b/Application.Tests/Extensions/DecimalExtensionsTests.cs
@@ -1,0 +1,40 @@
+﻿using Application.Extensions;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Tests.Extensions;
+
+public class DecimalExtensionsTests
+{
+    [Theory]
+    [InlineData(0.0, 0.0)]
+    [InlineData(10.46, 12.55)]
+    [InlineData(10.47, 12.56)]
+    [InlineData(10.48, 12.58)]
+    [InlineData(10.49, 12.59)]
+    [InlineData(10.50, 12.60)]
+    [InlineData(10.51, 12.61)]
+    [InlineData(10.52, 12.62)]
+    [InlineData(10.53, 12.64)]
+    public void AddVAT_AddsCorrectPercentage(decimal vatExclusive, decimal vatInclusive)
+    {
+        vatExclusive.AddVAT().Should().Be(vatInclusive);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.0)]
+    [InlineData(12.55, 10.46)]
+    [InlineData(12.56, 10.47)]
+    [InlineData(12.57, 10.48)]
+    [InlineData(12.58, 10.48)]
+    [InlineData(12.59, 10.49)]
+    [InlineData(12.60, 10.50)]
+    [InlineData(12.61, 10.51)]
+    [InlineData(12.62, 10.52)]
+    [InlineData(12.63, 10.53)]
+    [InlineData(12.64, 10.53)]
+    public void RemoveVAT_RemovesCorrectPercentage(decimal vatExclusive, decimal vatInclusive)
+    {
+        vatExclusive.RemoveVAT().Should().Be(vatInclusive);
+    }
+}

--- a/Application.Tests/Extensions/DecimalExtensionsTests.cs
+++ b/Application.Tests/Extensions/DecimalExtensionsTests.cs
@@ -33,8 +33,8 @@ public class DecimalExtensionsTests
     [InlineData(12.62, 10.52)]
     [InlineData(12.63, 10.53)]
     [InlineData(12.64, 10.53)]
-    public void RemoveVAT_RemovesCorrectPercentage(decimal vatExclusive, decimal vatInclusive)
+    public void RemoveVAT_RemovesCorrectPercentage(decimal vatInclusive, decimal vatExclusive)
     {
-        vatExclusive.RemoveVAT().Should().Be(vatInclusive);
+        vatInclusive.RemoveVAT().Should().Be(vatExclusive);
     }
 }

--- a/Application/Common/Models/SearchModel.cs
+++ b/Application/Common/Models/SearchModel.cs
@@ -24,6 +24,7 @@ namespace Application.Common.Models
             ShortlistOrderByDirection = model.ShortlistOrderByDirection;
             ShortlistTuitionType = model.ShortlistTuitionType;
             ShortlistGroupSize = model.ShortlistGroupSize;
+            ShortlistShowWithVAT = model.ShortlistShowWithVAT;
         }
 
         public ReferrerList? From { get; set; }
@@ -45,5 +46,7 @@ namespace Application.Common.Models
         public TuitionType? ShortlistTuitionType { get; set; }
 
         public GroupSize? ShortlistGroupSize { get; set; }
+
+        public bool? ShortlistShowWithVAT { get; set; }
     }
 }

--- a/Application/Extensions/DecimalExtensions.cs
+++ b/Application/Extensions/DecimalExtensions.cs
@@ -13,11 +13,11 @@ public static class DecimalExtensions
 
     public static decimal AddVAT(this decimal price)
     {
-        return Math.Round(price * ((100 + VATRate) / 100), 2);
+        return Math.Round(price * ((100 + VATRate) / 100), 2, MidpointRounding.AwayFromZero);
     }
 
     public static decimal RemoveVAT(this decimal price)
     {
-        return Math.Round(price / (100 + VATRate) * 100, 2);
+        return Math.Round(price / (100 + VATRate) * 100, 2, MidpointRounding.AwayFromZero);
     }
 }

--- a/Application/Extensions/DecimalExtensions.cs
+++ b/Application/Extensions/DecimalExtensions.cs
@@ -2,9 +2,22 @@
 
 public static class DecimalExtensions
 {
+    //Current VAT is 20%
+    private const decimal VATRate = 20m;
+
     public static string FormatPrice(this decimal price)
     {
         var str = $"{price:C}";
         return str.EndsWith(".00") ? str[0..^3] : str;
+    }
+
+    public static decimal AddVAT(this decimal price)
+    {
+        return Math.Round(price * ((100 + VATRate) / 100), 2);
+    }
+
+    public static decimal RemoveVAT(this decimal price)
+    {
+        return Math.Round(price / (100 + VATRate) * 100, 2);
     }
 }

--- a/Application/Extensions/SpreadsheetExtensions.cs
+++ b/Application/Extensions/SpreadsheetExtensions.cs
@@ -26,12 +26,12 @@ public static class SpreadsheetExtensions
 
     public static decimal ParsePrice(this string? cellValue, decimal vatPercentageToApply)
     {
-        return Math.Round(cellValue.ParseDecimal() * (1 + (vatPercentageToApply / 100)), 2);
+        return Math.Round(cellValue.ParseDecimal() * (1 + (vatPercentageToApply / 100)), 2, MidpointRounding.AwayFromZero);
     }
 
     public static decimal ParsePrice(this string? cellValue)
     {
-        return Math.Round(cellValue.ParseDecimal(), 2);
+        return Math.Round(cellValue.ParseDecimal(), 2, MidpointRounding.AwayFromZero);
     }
 
     public static DateOnly? ParseDateOnly(this string? cellValue)

--- a/Domain/Search/TuitionPartnersDataFilter.cs
+++ b/Domain/Search/TuitionPartnersDataFilter.cs
@@ -5,4 +5,5 @@ public class TuitionPartnersDataFilter
     public int? GroupSize { get; set; }
     public int? TuitionTypeId { get; set; }
     public IEnumerable<int>? SubjectIds { get; set; }
+    public bool? ShowWithVAT { get; set; }
 }

--- a/Infrastructure/Factories/QualityAssuredSpreadsheetTuitionPartnerFactory.cs
+++ b/Infrastructure/Factories/QualityAssuredSpreadsheetTuitionPartnerFactory.cs
@@ -266,7 +266,7 @@ public class QualityAssuredSpreadsheetTuitionPartnerFactory : ITuitionPartnerFac
                     TuitionTypeId = (int)tuitionType,
                     SubjectId = subjectId,
                     GroupSize = i + 1,
-                    HourlyRate = subjectHourlyRate
+                    HourlyRate = tuitionPartner.IsVatCharged ? subjectHourlyRate.RemoveVAT() : subjectHourlyRate //These are stored with VAT inclusive in the spreadsheets, but need to store exclusive in database
                 };
 
                 tuitionPartner.Prices.Add(price);

--- a/Infrastructure/Factories/TribalSpreadsheetTuitionPartnerFactory.cs
+++ b/Infrastructure/Factories/TribalSpreadsheetTuitionPartnerFactory.cs
@@ -19,7 +19,6 @@ public class TribalSpreadsheetTuitionPartnerFactory : ITribalSpreadsheetTuitionP
     private const string DeliverySheetName = "Delivery";
     private const string PricingSheetName = "Pricing";
     private const int MaxRows = 100000;
-    private const decimal VATRatePercentage = 20;
 
     private readonly ILogger<TribalSpreadsheetTuitionPartnerFactory> _logger;
     private readonly IDictionary<string, ImportMap> _organisationDetailsMapping;
@@ -468,12 +467,8 @@ public class TribalSpreadsheetTuitionPartnerFactory : ITribalSpreadsheetTuitionP
                 var key = (groupSize, keyStage, subjectEnum, subjectId, tuitionType);
                 if (!subjectCoverageAndPrices.ContainsKey(key))
                 {
-                    //If "Is Vat Charged" is true then apply VAT, we store all rates inclusive of VAT
-                    var rate = tuitionPartner.IsVatCharged ?
-                        spreadsheetExtractor!.GetCellValue(sheetName, RateColumn, row).ParsePrice(VATRatePercentage) :
-                        spreadsheetExtractor!.GetCellValue(sheetName, RateColumn, row).ParsePrice();
-
-                    subjectCoverageAndPrices[key] = rate;
+                    //We store all prices exclusive of VAT
+                    subjectCoverageAndPrices[key] = spreadsheetExtractor!.GetCellValue(sheetName, RateColumn, row).ParsePrice();
                 }
                 else
                 {

--- a/Infrastructure/Services/TuitionPartnerService.cs
+++ b/Infrastructure/Services/TuitionPartnerService.cs
@@ -91,6 +91,15 @@ public class TuitionPartnerService : ITuitionPartnerService
             if (prices.Any())
             {
                 tpResult.Prices = prices.ToArray();
+
+                if (tpResult.IsVatCharged && (dataFilter.ShowWithVAT == null || dataFilter.ShowWithVAT.Value))
+                {
+                    foreach (var price in prices)
+                    {
+                        price.HourlyRate = price.HourlyRate.AddVAT();
+                    }
+                }
+
                 var tuitionTypes = prices.Select(x => x.TuitionTypeId).Distinct();
                 var subjects = prices.Select(x => x.SubjectId).Distinct();
 

--- a/Tests/TuitionPartnerDetailsPagePriceTable.cs
+++ b/Tests/TuitionPartnerDetailsPagePriceTable.cs
@@ -102,56 +102,64 @@ public class TuitionPartnerDetailsPagePriceTable
 
     [Theory]
     [MemberData(nameof(GroupPriceFormat))]
-    public void Formats_group_price(TuitionType tuitionType, GroupPrice price, string expected)
+    public void Formats_group_price(TuitionType tuitionType, GroupPrice price, string expected, bool addVAT)
     {
-        price.FormatFor(tuitionType, true).Should().Be(expected);
+        price.FormatFor(tuitionType, addVAT).Should().Be(expected);
     }
 
     public static IEnumerable<object[]> GroupPriceFormat()
     {
         yield return new object[]
         {
-            TuitionType.InSchool, new GroupPrice(SchoolMin: null, null, OnlineMin: null, null), ""
+            TuitionType.InSchool, new GroupPrice(SchoolMin: null, null, OnlineMin: null, null), "", false
         };
         yield return new object[]
         {
-            TuitionType.InSchool, new GroupPrice(SchoolMin: 1, SchoolMax: 2, OnlineMin: 3, OnlineMax: 4), "£1 to £2"
+            TuitionType.InSchool, new GroupPrice(SchoolMin: 1, SchoolMax: 2, OnlineMin: 3, OnlineMax: 4), "£1 to £2", false
         };
         yield return new object[]
         {
-            TuitionType.InSchool, new GroupPrice(SchoolMin: 1.12m, SchoolMax: 2.99m, OnlineMin: 3.33m, OnlineMax: 4.99m), "£1.12 to £2.99"
+            TuitionType.InSchool, new GroupPrice(SchoolMin: 1.12m, SchoolMax: 2.99m, OnlineMin: 3.33m, OnlineMax: 4.99m), "£1.12 to £2.99", false
         };
         yield return new object[]
         {
-            TuitionType.InSchool, new GroupPrice(SchoolMin: 1.1m, SchoolMax: 2.8m, OnlineMin: 3.33m, OnlineMax: 4.99m), "£1.10 to £2.80"
+            TuitionType.InSchool, new GroupPrice(SchoolMin: 1.1m, SchoolMax: 2.8m, OnlineMin: 3.33m, OnlineMax: 4.99m), "£1.10 to £2.80", false
         };
         yield return new object[]
         {
-            TuitionType.InSchool, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12, OnlineMax: 12), "£8"
+            TuitionType.InSchool, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12, OnlineMax: 12), "£8", false
         };
         yield return new object[]
         {
-            TuitionType.Online, new GroupPrice(SchoolMin: null, null, OnlineMin: null, null), ""
+            TuitionType.Online, new GroupPrice(SchoolMin: null, null, OnlineMin: null, null), "", false
         };
         yield return new object[]
         {
-            TuitionType.Online, new GroupPrice(SchoolMin: 1, SchoolMax: 2, OnlineMin: 3, OnlineMax: 4), "£3 to £4"
+            TuitionType.Online, new GroupPrice(SchoolMin: 1, SchoolMax: 2, OnlineMin: 3, OnlineMax: 4), "£3 to £4", false
         };
         yield return new object[]
         {
-            TuitionType.Online, new GroupPrice(SchoolMin: 1.12m, SchoolMax: 2.99m, OnlineMin: 3.33m, OnlineMax: 4.99m), "£3.33 to £4.99"
+            TuitionType.Online, new GroupPrice(SchoolMin: 1.12m, SchoolMax: 2.99m, OnlineMin: 3.33m, OnlineMax: 4.99m), "£3.33 to £4.99", false
         };
         yield return new object[]
         {
-            TuitionType.Online, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12, OnlineMax: 12), "£12"
+            TuitionType.Online, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12, OnlineMax: 12), "£12", false
         };
         yield return new object[]
         {
-            TuitionType.Online, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12.22m, OnlineMax: 12.22m), "£12.22"
+            TuitionType.Online, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12.22m, OnlineMax: 12.22m), "£12.22", false
         };
         yield return new object[]
         {
-            TuitionType.Online, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12.20m, OnlineMax: 12.20m), "£12.20"
+            TuitionType.Online, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12.20m, OnlineMax: 12.20m), "£12.20", false
+        };
+        yield return new object[]
+        {
+            TuitionType.Online, new GroupPrice(SchoolMin: 1.12m, SchoolMax: 2.99m, OnlineMin: 3.33m, OnlineMax: 4.99m), "£4 to £5.99", true
+        };
+        yield return new object[]
+        {
+            TuitionType.Online, new GroupPrice(SchoolMin: 8, SchoolMax: 8, OnlineMin: 12.20m, OnlineMax: 12.20m), "£14.64", true
         };
     }
 }

--- a/UI/Extensions/GroupPriceExtensions.cs
+++ b/UI/Extensions/GroupPriceExtensions.cs
@@ -10,20 +10,20 @@ namespace UI.Extensions
         public static bool ContainsOnlinePrice(this Dictionary<int, GroupPrice> prices)
             => prices.Any(x => x.Value.OnlineMin.HasValue || x.Value.OnlineMax.HasValue);
 
-        public static string FormatFor(this GroupPrice price, TuitionTypes tuitionType)
+        public static string FormatFor(this GroupPrice price, TuitionTypes tuitionType, bool addVAT)
         {
             return tuitionType switch
             {
-                TuitionTypes.InSchool => FormatPrices(price.SchoolMin, price.SchoolMax),
-                TuitionTypes.Online => FormatPrices(price.OnlineMin, price.OnlineMax),
+                TuitionTypes.InSchool => FormatPrices(price.SchoolMin, price.SchoolMax, addVAT),
+                TuitionTypes.Online => FormatPrices(price.OnlineMin, price.OnlineMax, addVAT),
                 _ => "",
             };
 
-            static string FormatPrices(decimal? min, decimal? max) =>
+            static string FormatPrices(decimal? min, decimal? max, bool addVAT) =>
                 (min, max) switch
                 {
-                    _ when min != null && min == max => $"{min.Value.FormatPrice()}",
-                    _ when min != null && max != null => $"{min.Value.FormatPrice()} to {max.Value.FormatPrice()}",
+                    _ when min != null && min == max => addVAT ? $"{min.Value.AddVAT().FormatPrice()}" : $"{min.Value.FormatPrice()}",
+                    _ when min != null && max != null => addVAT ? $"{min.Value.AddVAT().FormatPrice()} to {max.Value.AddVAT().FormatPrice()}" : $"{min.Value.FormatPrice()} to {max.Value.FormatPrice()}",
                     _ => "",
                 };
         }

--- a/UI/Extensions/SearchModelExtensions.cs
+++ b/UI/Extensions/SearchModelExtensions.cs
@@ -42,6 +42,7 @@ namespace UI.Extensions
             model.Add(x => x.ShortlistOrderByDirection, dictionary);
             model.Add(x => x.ShortlistTuitionType, dictionary);
             model.Add(x => x.ShortlistGroupSize, dictionary);
+            model.Add(x => x.ShortlistShowWithVAT, dictionary);
 
             return dictionary;
         }

--- a/UI/Pages/Shortlist.cshtml
+++ b/UI/Pages/Shortlist.cshtml
@@ -76,6 +76,14 @@
                         </div>
 
                         <div class="govuk-grid-column-shortlist">
+                            <govuk-select asp-for="Data.ShortlistShowWithVAT" data-testid="shortlist-show-vat-refine">
+                                <govuk-select-label>VAT</govuk-select-label>
+                                <govuk-select-item value="true" selected="@Model.Data.ShortlistShowWithVAT == null || Model.Data.ShortlistShowWithVAT.Value == true">Show prices including VAT</govuk-select-item>
+                                <govuk-select-item value="false" selected="@Model.Data.ShortlistShowWithVAT != null && Model.Data.ShortlistShowWithVAT.Value == false">Show prices excluding VAT</govuk-select-item>
+                            </govuk-select>
+                        </div>
+
+                        <div class="govuk-grid-column-shortlist">
                             <div class="govuk-button-group app-shortlist--apply-refinement">
                                 <button class="govuk-button govuk-button--primary remove-shortlist-table-button" data-module="govuk-button" type="submit" asp-page-handler="applyrefinement" asp-all-route-data="@Model.Data.ToRouteData()">Apply refinement</button>
                             </div>
@@ -114,9 +122,12 @@
                                 }
                                 else
                                 {
+                                    var includeVatMsg = (Model.Data.ShortlistShowWithVAT ?? true);
+                                    var vatMsg = !item.IsVatCharged ? " VAT does not apply" : includeVatMsg ? " including VAT" : " excluding VAT";
                                     var minPrice = item.Prices.Min(e => e.HourlyRate).FormatPrice();
                                     var maxPrice = item.Prices.Max(e => e.HourlyRate).FormatPrice();
                                     var prices = (minPrice == maxPrice) ? minPrice : $"{minPrice} to {maxPrice}";
+                                    prices += vatMsg;
                                 <td class="govuk-table__cell">
                                     1 to @string.Join(", ", item.Prices!.Select(e => e.GroupSize).Distinct().OrderBy(x => x))
                                 </td>

--- a/UI/Pages/Shortlist.cshtml
+++ b/UI/Pages/Shortlist.cshtml
@@ -76,7 +76,7 @@
                         </div>
 
                         <div class="govuk-grid-column-shortlist">
-                            <govuk-select asp-for="Data.ShortlistShowWithVAT" data-testid="shortlist-show-vat-refine">
+                            <govuk-select asp-for="Data.ShortlistShowWithVAT" data-testid="shortlist-show-vat-toggle">
                                 <govuk-select-label>VAT</govuk-select-label>
                                 <govuk-select-item value="true" selected="@Model.Data.ShortlistShowWithVAT == null || Model.Data.ShortlistShowWithVAT.Value == true">Show prices including VAT</govuk-select-item>
                                 <govuk-select-item value="false" selected="@Model.Data.ShortlistShowWithVAT != null && Model.Data.ShortlistShowWithVAT.Value == false">Show prices excluding VAT</govuk-select-item>

--- a/UI/Pages/Shortlist.cshtml.cs
+++ b/UI/Pages/Shortlist.cshtml.cs
@@ -80,10 +80,10 @@ public class ShortlistModel : PageModel
         return GetJsonResult(response.IsCallSuccessful, shortlistModel.TotalShortlistedTuitionPartners);
     }
 
-    private JsonResult GetJsonResult(bool isCallSuccessful, int totalShortlistedTuitionPartners) =>
+    private static JsonResult GetJsonResult(bool isCallSuccessful, int totalShortlistedTuitionPartners) =>
         new(new ShortlistedTuitionPartnerResult(isCallSuccessful, totalShortlistedTuitionPartners));
 
-    private bool IsStringWhitespaceOrNull(string? parameter) => string.IsNullOrWhiteSpace(parameter);
+    private static bool IsStringWhitespaceOrNull(string? parameter) => string.IsNullOrWhiteSpace(parameter);
 
     public record Query : SearchModel, IRequest<ResultsModel>
     {
@@ -204,7 +204,7 @@ public class ShortlistModel : PageModel
                 if (invalidSeoUrls.Any())
                 {
                     invalidResults = await FindInvalidTuitionPartners(invalidSeoUrls.ToArray(), shortlistOrderBy, shortlistOrderByDirection, cancellationToken);
-                    _logger.LogInformation("{Count} invalid SeoUrls '{InvalidSeoUrls}' provided on shortlist page for postcode '{Postcode}'", invalidSeoUrls.Count(), string.Join(", ", invalidSeoUrls), request.Postcode);
+                    _logger.LogInformation("{Count} invalid SeoUrls '{InvalidSeoUrls}' provided on shortlist page for postcode '{Postcode}'", invalidSeoUrls.Count, string.Join(", ", invalidSeoUrls), request.Postcode);
                 }
             }
 
@@ -273,7 +273,8 @@ public class ShortlistModel : PageModel
                         {
                             GroupSize = (request.ShortlistGroupSize == null || request.ShortlistGroupSize == GroupSize.Any) ? null : (int)request.ShortlistGroupSize,
                             TuitionTypeId = (request.ShortlistTuitionType == null || request.ShortlistTuitionType == Domain.Enums.TuitionType.Any) ? null : (int)request.ShortlistTuitionType,
-                            SubjectIds = request.SubjectIds
+                            SubjectIds = request.SubjectIds,
+                            ShowWithVAT = request.ShortlistShowWithVAT
                         },
                         cancellationToken);
 

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -134,6 +134,7 @@
         Some prices are different depending on key stage or subject. Please contact @Model.Data.Name for more information.
     </span>
     <span show-if="@Model.Data.IsVatCharged" data-testid="price-includes-vat"><br/>Prices shown include VAT.</span>
+    <span show-if="@Model.Data.IsVatCharged==false" data-testid="price-vat-not-applicable"><br/>VAT does not apply to these prices because @Model.Data.Name is VAT exempt.</span>
 </p>
 
 <table class="govuk-table" data-testid="pricing-table" show-if="@(!Model.Data.AllPrices.Any())">

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -151,11 +151,11 @@
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header" data-testid="pricing-group-size-column">@(((Domain.Enums.GroupSize)item.Key).DisplayName())</th>
             <td show-if="@Model.Data.Prices.ContainsInSchoolPrice()" class="govuk-table__cell">
-                @item.Value.FormatFor(TuitionTypes.InSchool)
+                @item.Value.FormatFor(TuitionTypes.InSchool, Model.Data.IsVatCharged)
             </td>
 
             <td show-if="@Model.Data.Prices.ContainsOnlinePrice()" class="govuk-table__cell">
-                @item.Value.FormatFor(TuitionTypes.Online)
+                @item.Value.FormatFor(TuitionTypes.Online, Model.Data.IsVatCharged)
             </td>
         </tr>
     }

--- a/UI/cypress/e2e/shortlist.feature
+++ b/UI/cypress/e2e/shortlist.feature
@@ -83,12 +83,12 @@ Feature: Tuition Partner shortlist
     And they add 'Reeson Education' to their shortlist on the results page
     When they choose to view their shortlist from the results page
     Then there are 1 entries on the shortlist page
-    And entry 1 on the shortlist is the row 'Reeson Education', '1 to 1, 2, 3, 4, 5, 6', 'In School, Online', '£10 to £60'
+    And entry 1 on the shortlist is the row 'Reeson Education', '1 to 1, 2, 3, 4, 5, 6', 'In School, Online', '£10 to £60 including VAT'
     And they click 'Back'
     And they enter 'TN22 2BL' as the school's postcode
     And they click 'Search'
     And they choose to view their shortlist from the results page
-    And entry 1 on the shortlist is the row 'Reeson Education', '1 to 1, 2, 3, 4, 5, 6', 'Online', '£10 to £60'
+    And entry 1 on the shortlist is the row 'Reeson Education', '1 to 1, 2, 3, 4, 5, 6', 'Online', '£10 to £60 including VAT'
 
   Scenario: User views TP details from the shortlist
     Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
@@ -186,7 +186,7 @@ Feature: Tuition Partner shortlist
 
   Scenario: The shortlist can be refined by group size then TP rows and the price are updated
     Given a user has selected TPs to shortlist and journeyed forward to the shortlist page
-    Then the 'Reeson Education' price is '£10 to £60'
+    Then the 'Reeson Education' price is '	£10 to £60 including VAT'
     When '1 to 1' group size shortlist refinement option is selected
     Then 'Reeson Education' is entry 1 on the shortlist page
     And 'Career Tree' is entry 2 on the shortlist page
@@ -194,11 +194,11 @@ Feature: Tuition Partner shortlist
     And 'Tutors Green' is entry 4 on the shortlist page
     And 'Action Tutoring' is entry 5 on the shortlist page
     And 'Booster Club' is entry 6 on the shortlist page
-    And the 'Reeson Education' price is '£60'
+    And the 'Reeson Education' price is '£60 including VAT'
 
   Scenario: The shortlist can be refined by tuition type then TP rows and the price are updated
     Given a user has selected TPs to shortlist and journeyed forward to the shortlist page
-    Then the 'Tutors Green' price is '£10.42 to £55'
+    Then the 'Tutors Green' price is '£10.42 to £55 including VAT'
     When 'In School' tuition type shortlist refinement option is selected
     Then 'Career Tree' is entry 1 on the shortlist page
     And 'Booster Club' is entry 2 on the shortlist page
@@ -206,11 +206,11 @@ Feature: Tuition Partner shortlist
     And 'Tutors Green' is entry 4 on the shortlist page
     And 'Reeson Education' is entry 5 on the shortlist page
     And 'Action Tutoring' is entry 6 on the shortlist page
-    And the 'Tutors Green' price is '£11.25 to £55'
+    And the 'Tutors Green' price is '£11.25 to £55 including VAT'
 
   Scenario: The shortlist can be refined by group size and tuition type then TP rows and the price are updated
     Given a user has selected TPs to shortlist and journeyed forward to the shortlist page
-    Then the 'Tutors Green' price is '£10.42 to £55'
+    Then the 'Tutors Green' price is '£10.42 to £55 including VAT'
     When '1 to 1' group size shortlist refinement option is selected
     And 'Online' tuition type shortlist refinement option is selected
     Then 'Reeson Education' is entry 1 on the shortlist page
@@ -219,7 +219,7 @@ Feature: Tuition Partner shortlist
     And 'Action Tutoring' is entry 4 on the shortlist page
     And 'Booster Club' is entry 5 on the shortlist page
     And 'Zen Educate' is entry 6 on the shortlist page
-    And the 'Tutors Green' price is '£50'
+    And the 'Tutors Green' price is '£50 including VAT'
 
   Scenario: The shortlist price ordering works with refined data and any inavid TP data still follows the order they were added to shortlist
     Given a user has selected TPs to shortlist and journeyed forward to the shortlist page
@@ -286,3 +286,47 @@ Feature: Tuition Partner shortlist
     And they add 'Action Tutoring' to their shortlist on the results page
     When they choose to view their shortlist from the results page
     Then the shortlist key stage subjects header is not shown
+
+  Scenario: The shortlist displays VAT is not applicable if needed
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+    And they add 'Action Tutoring' to their shortlist on the results page
+    When they choose to view their shortlist from the results page
+    Then there are 1 entries on the shortlist page
+    And entry 1 on the shortlist is the row 'Action Tutoring', '1 to 2', 'Online', '£20.12 VAT does not apply'
+
+  Scenario: The shortlist can show VAT inclusive and then toggle to VAT exclusive prices
+    Given a user has selected TPs to shortlist and journeyed forward to the shortlist page
+    Then the 'Tutors Green' price is '£10.42 to £55 including VAT'
+    Then the 'Action Tutoring' price is '£20.12 VAT does not apply'
+    When 'Show prices excluding VAT' VAT shortlist refinement option is selected
+    Then the 'Tutors Green' price is '£8.68 to £45.83 excluding VAT'
+    And the 'Action Tutoring' price is '£20.12 VAT does not apply'
+
+  Scenario: The shortlist price ordering works with inclusive or exclusive prices
+    Given a user has selected TPs to shortlist and journeyed forward to the shortlist page
+    Then they choose to sort the shortlist by price
+    And 'Zen Educate' is entry 1 on the shortlist page
+    And 'Career Tree' is entry 2 on the shortlist page
+    And 'Reeson Education' is entry 3 on the shortlist page
+    And 'Tutors Green' is entry 4 on the shortlist page
+    And 'Action Tutoring' is entry 5 on the shortlist page
+    And 'Booster Club' is entry 6 on the shortlist page
+    When 'Show prices excluding VAT' VAT shortlist refinement option is selected
+    Then 'Zen Educate' is entry 1 on the shortlist page
+    And 'Career Tree' is entry 2 on the shortlist page
+    And 'Reeson Education' is entry 3 on the shortlist page
+    And 'Tutors Green' is entry 4 on the shortlist page
+    And 'Booster Club' is entry 5 on the shortlist page
+    And 'Action Tutoring' is entry 6 on the shortlist page
+
+  Scenario: The shortlist VAT defaults to inclusive on first load and then maintains own state after being selected
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+    And they add 'Action Tutoring' to their shortlist on the results page
+    When they choose to view their shortlist from the results page
+    Then the VAT select option is 'Show prices including VAT'
+    When 'Show prices excluding VAT' VAT shortlist refinement option is selected
+    Then the VAT select option is 'Show prices excluding VAT'
+    When they click 'Back'
+    Then the search results are displayed
+    When they choose to view their shortlist from the results page
+    Then the VAT select option is 'Show prices excluding VAT'

--- a/UI/cypress/e2e/shortlist.feature
+++ b/UI/cypress/e2e/shortlist.feature
@@ -206,7 +206,7 @@ Feature: Tuition Partner shortlist
     And 'Tutors Green' is entry 4 on the shortlist page
     And 'Reeson Education' is entry 5 on the shortlist page
     And 'Action Tutoring' is entry 6 on the shortlist page
-    And the 'Tutors Green' price is '£11.25 to £55 including VAT'
+    And the 'Tutors Green' price is '£11.26 to £55 including VAT'
 
   Scenario: The shortlist can be refined by group size and tuition type then TP rows and the price are updated
     Given a user has selected TPs to shortlist and journeyed forward to the shortlist page

--- a/UI/cypress/e2e/shortlist.js
+++ b/UI/cypress/e2e/shortlist.js
@@ -195,6 +195,13 @@ Then(
   }
 );
 
+Then("{string} VAT shortlist refinement option is selected", (optionText) => {
+  cy.get("[data-testid='shortlist-show-vat-toggle'] select").select(
+    `${optionText}`
+  );
+  cy.wait(1000);
+});
+
 Then("the group size select option is {string}", (optionText) => {
   cy.get(
     "[data-testid='shortlist-group-size-refine'] select option:selected"
@@ -204,6 +211,12 @@ Then("the group size select option is {string}", (optionText) => {
 Then("the tuition type select option is {string}", (optionText) => {
   cy.get(
     "[data-testid='shortlist-tuition-type-refine'] select option:selected"
+  ).should("contain.text", removeExcessWhitespaces(removeNewLine(optionText)));
+});
+
+Then("the VAT select option is {string}", (optionText) => {
+  cy.get(
+    "[data-testid='shortlist-show-vat-toggle'] select option:selected"
   ).should("contain.text", removeExcessWhitespaces(removeNewLine(optionText)));
 });
 

--- a/UI/cypress/e2e/vat.feature
+++ b/UI/cypress/e2e/vat.feature
@@ -4,5 +4,5 @@ Feature: Tuition Partner cost information VAT
     Then the prices include VAT content is displayed
 
   Scenario: tuition cost information does not show prices include VAT when tuition partner does not charge it
-    Given a user has arrived on the 'Tuition Partner' page for 'Coach Bright'
-    Then the prices with VAT does not apply content is displayed for 'Coach Bright'
+    Given a user has arrived on the 'Tuition Partner' page for 'CoachBright'
+    Then the prices with VAT does not apply content is displayed for 'CoachBright'

--- a/UI/cypress/e2e/vat.feature
+++ b/UI/cypress/e2e/vat.feature
@@ -5,4 +5,4 @@ Feature: Tuition Partner cost information VAT
 
   Scenario: tuition cost information does not show prices include VAT when tuition partner does not charge it
     Given a user has arrived on the 'Tuition Partner' page for 'Coach Bright'
-    Then the prices include VAT content is not displayed
+    Then the prices with VAT does not apply content is displayed for 'Coach Bright'

--- a/UI/cypress/e2e/vat.js
+++ b/UI/cypress/e2e/vat.js
@@ -6,6 +6,15 @@ Then("the prices include VAT content is displayed", () => {
     .and("contain.text", "Prices shown include VAT.");
 });
 
-Then("the prices include VAT content is not displayed", () => {
-  cy.get('[data-testid="price-includes-vat"]').should("not.exist");
-});
+Then(
+  "the prices with VAT does not apply content is displayed for {string}",
+  (name) => {
+    cy.get('[data-testid="price-includes-vat"]').should("not.exist");
+    cy.get('[data-testid="price-vat-not-applicable"]')
+      .should("exist")
+      .and(
+        "contain.text",
+        `VAT does not apply to these prices because ${name} is VAT exempt.'`
+      );
+  }
+);

--- a/UI/cypress/e2e/vat.js
+++ b/UI/cypress/e2e/vat.js
@@ -14,7 +14,7 @@ Then(
       .should("exist")
       .and(
         "contain.text",
-        `VAT does not apply to these prices because ${name} is VAT exempt.'`
+        `VAT does not apply to these prices because ${name} is VAT exempt.`
       );
   }
 );


### PR DESCRIPTION
## Context

Ensure that NTP shows VAT prices inc and exc VAT, especially when comparing prices

## Changes proposed in this pull request

Added in if VAT is included, VAT is excluded or not applicable against the prices.

Add in a new drop down option to toggle between the VAT inclusive
![image](https://user-images.githubusercontent.com/113545700/217068736-522a3a4a-c085-4bdb-a92d-f4bdf323c449.png)

And VAT exclusive prices
![image](https://user-images.githubusercontent.com/113545700/217068767-8acc41ca-2cc0-4059-81a9-d0b8108f1f41.png)

Default the drop down selection to inclusive of VAT

TP details page to have a label stating if VAT does not apply if this is the case, to match the table
![image](https://user-images.githubusercontent.com/113545700/217068833-07461a39-1354-414e-8693-1910a8798277.png)

Currently for VAT exempt companies: 

Currently for VAT inclusive companies:

![image](https://user-images.githubusercontent.com/113545700/217068977-e4568d05-d7dc-4c96-b228-6dc71b6f8b3a.png)


As part of this ticket we will change the way that we store the prices in the NTP database, so that they are exclusive of VAT.

When showing VAT inclusive prices we will add 20% and round to the nearest penny as per:

https://www.gov.uk/hmrc-internal-manuals/vat-trader-records/vatrec12030#:~:text=If%20the%20VAT%20on%20any,it%20should%20be%20rounded%20up .

## Guidance to review

AC1: The VAT information is now displayed against the pricing data

GIVEN a search has been made, the search subjects filters have been removed and some TPs have been added to the shortlist

WHEN the shortlist is displayed

THEN the prices now include if the VAT has been included, state if they exclude VAT (if VAT drop down is used) or if it does not apply (to meet exact wording supplied by content team)



AC2: The Prices are shown inclusive of VAT if this drop down option is selected

GIVEN a search has been made, search subjects have been filtered upon and some TPs have been added to the shortlist

WHEN the shortlist is displayed and the VAT drop down is set to show inclusive figures

THEN the TPs prices are shown inclusive of VAT where applicable.  The companies that do not charge VAT will be showing the exclusive figure.



AC3: The Prices are shown exclusive of VAT if this drop down option is selected

GIVEN a search has been made, search subjects have been filtered upon and some TPs have been added to the shortlist

WHEN the shortlist is displayed and the VAT drop down is set to show exclusive figures

THEN the TPs prices are shown exclusive of VAT.



AC4: The TP details page shows a label if the TP does not charge VAT

GIVEN via the search results or all TPs page

WHEN selecting a TP that does not charge VAT

THEN the pricing section will explicitly state that VAT does not apply (exact wording to be supplied by content)

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-921

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [x] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [x] **PR deployment has been signed off by wider team**