### PR TITLE
NTP-879: School user is informed when a response is received

### DIFF
--- a/Application/Commands/SendEnquirerEnquiryResponseReceivedEmailCommand.cs
+++ b/Application/Commands/SendEnquirerEnquiryResponseReceivedEmailCommand.cs
@@ -43,7 +43,7 @@ public class SendEnquirerEnquiryResponseReceivedEmailCommandHandler : IRequestHa
         {
             _logger.LogError("Unable to send enquirer enquiry response received email. " +
                              "Can't find magic link token with the type {type} by enquiry Id {enquiryId}",
-                request.Data.EnquiryId, MagicLinkType.EnquirerViewAllResponses.ToString());
+                MagicLinkType.EnquirerViewAllResponses.ToString(), request.Data.EnquiryId);
 
             return Unit.Value;
         }

--- a/Application/Commands/SendEnquirerEnquiryResponseReceivedEmailCommand.cs
+++ b/Application/Commands/SendEnquirerEnquiryResponseReceivedEmailCommand.cs
@@ -1,0 +1,91 @@
+using Application.Common.DTO;
+using Application.Common.Interfaces;
+using Application.Common.Models;
+using Domain.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Commands;
+
+public record SendEnquirerEnquiryResponseReceivedEmailCommand : IRequest<Unit>
+{
+    public EnquiryResponseModel Data { get; set; } = null!;
+}
+
+public class SendEnquirerEnquiryResponseReceivedEmailCommandHandler : IRequestHandler<SendEnquirerEnquiryResponseReceivedEmailCommand, Unit>
+{
+    private const string EnquiryTextVariableKey = "enquiry";
+    private const string EnquiryResponderVariableKey = "enquiry_responder";
+    private const string EnquiryResponseTextVariableKey = "enquiry_response";
+    private const string EnquirerViewAllResponsesPageLinkKey = "link_to_enquirer_view_all_responses_page";
+
+    private readonly INotificationsClientService _notificationsClientService;
+
+    private readonly IUnitOfWork _unitOfWork;
+
+    private readonly ILogger<SendEnquirerEnquiryResponseReceivedEmailCommandHandler> _logger;
+
+    public SendEnquirerEnquiryResponseReceivedEmailCommandHandler(INotificationsClientService notificationsClientService,
+        IUnitOfWork unitOfWork, ILogger<SendEnquirerEnquiryResponseReceivedEmailCommandHandler> logger)
+    {
+        _notificationsClientService = notificationsClientService;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<Unit> Handle(SendEnquirerEnquiryResponseReceivedEmailCommand request,
+        CancellationToken cancellationToken)
+    {
+        var enquirerEnquiryResponseReceivedData =
+            await _unitOfWork.MagicLinkRepository.
+                GetEnquirerEnquiryResponseReceivedData(request.Data.EnquiryId!, request.Data.TuitionPartnerId);
+
+        if (enquirerEnquiryResponseReceivedData == null)
+        {
+            _logger.LogError("Unable to send enquirer enquiry response received email. " +
+                             "Can't find magic link token with the type {type} by enquiry Id {enquiryId}",
+                request.Data.EnquiryId, MagicLinkType.EnquirerViewAllResponses.ToString());
+
+            return Unit.Value;
+        }
+
+        request.Data.Token = enquirerEnquiryResponseReceivedData.Token!;
+        request.Data.Email = enquirerEnquiryResponseReceivedData.Email!;
+        request.Data.EnquiryText = enquirerEnquiryResponseReceivedData.EnquiryText!;
+
+        var notificationsRecipient = GetNotificationsRecipient(request, enquirerEnquiryResponseReceivedData.TuitionPartnerName);
+
+        await _notificationsClientService.SendEmailAsync(
+            notificationsRecipient,
+            EmailTemplateType.EnquiryResponseReceivedConfirmationToEnquirer);
+        return Unit.Value;
+    }
+
+    private NotificationsRecipientDto GetNotificationsRecipient(SendEnquirerEnquiryResponseReceivedEmailCommand request, string enquiryResponderText)
+    {
+        var pageLink = $"{request.Data?.BaseServiceUrl}/enquirer-view-all-responses?token={request.Data?.Token}";
+
+        var result = new NotificationsRecipientDto()
+        {
+            Email = request.Data?.Email!,
+            EnquirerEmailForTestingPurposes = request.Data?.Email!,
+            Personalisation = GetPersonalisation(request.Data?.EnquiryText!,
+                request.Data?.EnquiryResponseText!, enquiryResponderText, pageLink)
+        };
+        return result;
+    }
+
+    private static Dictionary<string, dynamic> GetPersonalisation(string enquiryText, string enquiryResponseText,
+        string enquiryResponderText,
+        string enquirerViewAllResponsesPageLink)
+    {
+        var personalisation = new Dictionary<string, dynamic>()
+        {
+            { EnquiryTextVariableKey, enquiryText },
+            { EnquiryResponderVariableKey, enquiryResponderText },
+            { EnquiryResponseTextVariableKey, enquiryResponseText },
+            { EnquirerViewAllResponsesPageLinkKey, enquirerViewAllResponsesPageLink }
+        };
+
+        return personalisation;
+    }
+}

--- a/Application/Common/DTO/EnquirerEnquiryResponseReceivedDto.cs
+++ b/Application/Common/DTO/EnquirerEnquiryResponseReceivedDto.cs
@@ -1,0 +1,8 @@
+using Application.Common.Models;
+
+namespace Application.Common.DTO;
+
+public class EnquirerEnquiryResponseReceivedDto : EnquiryResponseModel
+{
+    public string TuitionPartnerName { get; set; } = string.Empty;
+}

--- a/Application/Common/Interfaces/Repositories/IMagicLinkRepository.cs
+++ b/Application/Common/Interfaces/Repositories/IMagicLinkRepository.cs
@@ -1,8 +1,10 @@
+using Application.Common.DTO;
 using Domain;
 
 namespace Application.Common.Interfaces.Repositories;
 
 public interface IMagicLinkRepository : IGenericRepository<MagicLink>
 {
-
+    Task<EnquirerEnquiryResponseReceivedDto?>
+        GetEnquirerEnquiryResponseReceivedData(int enquiryId, int tuitionPartnerId);
 }

--- a/Application/Common/Models/EnquiryResponseModel.cs
+++ b/Application/Common/Models/EnquiryResponseModel.cs
@@ -3,7 +3,8 @@ namespace Application.Common.Models;
 public class EnquiryResponseModel : EnquiryBaseModel
 {
     public int TuitionPartnerId { get; set; }
-
+    public string Email { get; set; } = string.Empty;
     public string Token { get; set; } = string.Empty;
+    public string EnquiryText { get; set; } = string.Empty;
     public string EnquiryResponseText { get; set; } = null!;
 }

--- a/Domain/Enums/EmailTemplateType.cs
+++ b/Domain/Enums/EmailTemplateType.cs
@@ -3,5 +3,6 @@ namespace Domain.Enums;
 public enum EmailTemplateType
 {
     EnquirySubmittedConfirmationToEnquirer,
-    EnquirySubmittedToTp
+    EnquirySubmittedToTp,
+    EnquiryResponseReceivedConfirmationToEnquirer
 }

--- a/Infrastructure/Configuration/GovUkNotifyOptions.cs
+++ b/Infrastructure/Configuration/GovUkNotifyOptions.cs
@@ -10,4 +10,6 @@ public class GovUkNotifyOptions
 
     public string TemplateIdEnquirySubmittedToTp { get; set; } = string.Empty;
 
+    public string TemplateIdEnquiryResponseReceivedConfirmationToEnquirer { get; set; } = string.Empty;
+
 }

--- a/Infrastructure/Repositories/MagicLinkRepository.cs
+++ b/Infrastructure/Repositories/MagicLinkRepository.cs
@@ -1,5 +1,8 @@
+using Application.Common.DTO;
 using Application.Common.Interfaces.Repositories;
 using Domain;
+using Microsoft.EntityFrameworkCore;
+using MagicLinkType = Domain.Enums.MagicLinkType;
 
 namespace Infrastructure.Repositories;
 
@@ -7,5 +10,31 @@ public class MagicLinkRepository : GenericRepository<MagicLink>, IMagicLinkRepos
 {
     public MagicLinkRepository(NtpDbContext context) : base(context)
     {
+    }
+
+    public async Task<EnquirerEnquiryResponseReceivedDto?> GetEnquirerEnquiryResponseReceivedData(int enquiryId, int tuitionPartnerId)
+    {
+        var magicLink = await _context.MagicLinks.AsNoTracking()
+            .Where(e => e.EnquiryId == enquiryId && e.MagicLinkTypeId == (int)MagicLinkType.EnquirerViewAllResponses)
+            .Include(e => e.Enquiry)
+            .ThenInclude(e => e!.TuitionPartnerEnquiry)
+            .ThenInclude(e => e!.TuitionPartner).SingleOrDefaultAsync();
+
+        if (magicLink == null) return null;
+
+        var tpName = string.Empty;
+
+        if (magicLink.Enquiry!.TuitionPartnerEnquiry.Any())
+        {
+            tpName = magicLink.Enquiry.TuitionPartnerEnquiry
+                .First(x => x.TuitionPartnerId == tuitionPartnerId).TuitionPartner.Name;
+        }
+        return new EnquirerEnquiryResponseReceivedDto()
+        {
+            TuitionPartnerName = tpName,
+            Email = magicLink.Enquiry.Email,
+            EnquiryText = magicLink.Enquiry.EnquiryText,
+            Token = magicLink.Token
+        };
     }
 }

--- a/Infrastructure/Services/NotificationsClientService.cs
+++ b/Infrastructure/Services/NotificationsClientService.cs
@@ -158,11 +158,16 @@ public class NotificationsClientService : INotificationsClientService
     {
         return emailTemplateType switch
         {
-            EmailTemplateType.EnquirySubmittedConfirmationToEnquirer => !string.IsNullOrEmpty(notifyConfig.TemplateIdEnquirySubmittedConfirmationToEnquirer)
+            EmailTemplateType.EnquirySubmittedConfirmationToEnquirer =>
+                !string.IsNullOrEmpty(notifyConfig.TemplateIdEnquirySubmittedConfirmationToEnquirer)
                 ? notifyConfig.TemplateIdEnquirySubmittedConfirmationToEnquirer
                 : string.Empty,
             EmailTemplateType.EnquirySubmittedToTp => !string.IsNullOrEmpty(notifyConfig.TemplateIdEnquirySubmittedToTp)
                 ? notifyConfig.TemplateIdEnquirySubmittedToTp
+                : string.Empty,
+            EmailTemplateType.EnquiryResponseReceivedConfirmationToEnquirer =>
+                !string.IsNullOrEmpty(notifyConfig.TemplateIdEnquiryResponseReceivedConfirmationToEnquirer)
+                ? notifyConfig.TemplateIdEnquiryResponseReceivedConfirmationToEnquirer
                 : string.Empty,
             _ => string.Empty
         };

--- a/UI/Pages/EnquiryResponse.cshtml.cs
+++ b/UI/Pages/EnquiryResponse.cshtml.cs
@@ -70,6 +70,15 @@ public class EnquiryResponse : PageModel
 
             if (hasDataSaved)
             {
+                Data.BaseServiceUrl = $"{Request.Scheme}://{Request.Host}{Request.PathBase}";
+
+                var sendEnquirerEnquiryResponseReceivedEmail = new SendEnquirerEnquiryResponseReceivedEmailCommand()
+                {
+                    Data = Data
+                };
+
+                await _mediator.Send(sendEnquirerEnquiryResponseReceivedEmail);
+
                 SuccessMessage = $"The enquiry response was submitted successfully.";
                 ModelState.Clear();
                 Data = new();

--- a/manifest.yml
+++ b/manifest.yml
@@ -24,6 +24,7 @@ applications:
     GovUkNotify:ApiKey: ((govuk-notify-api-key))
     GovUkNotify:TemplateIdEnquirySubmittedConfirmationToEnquirer: ((govuk-notify-enquiry-submitted-confirmation-to-enquirer-template-id))
     GovUkNotify:TemplateIdEnquirySubmittedToTp: ((govuk-notify-enquiry-submitted-to-tp-template-id))
+    GovUkNotify:TemplateIdEnquiryResponseReceivedConfirmationToEnquirer: ((govuk-notify-enquiry-response-received-confirmation-to-enquirer-template-id))
     EmailSettings:OverrideAddress: ((override-email-address))
     EmailSettings:AmalgamateResponses: ((email-amalgamate-responses))
     EmailSettings:AllSentToEnquirer: ((email-all-sent-to-enquirer))

--- a/vars-pr.yml
+++ b/vars-pr.yml
@@ -9,6 +9,7 @@ google-analytics-measurement-id:
 dfe-analytics-dataset: fatp_events_development
 govuk-notify-enquiry-submitted-confirmation-to-enquirer-template-id: b1e29214-dfc0-4225-b65a-df6a20c4c297
 govuk-notify-enquiry-submitted-to-tp-template-id: b24ffca7-6119-4dbf-8ae2-dceb2c300ca4
+govuk-notify-enquiry-response-received-confirmation-to-enquirer-template-id: f64db52d-08ce-4f2a-9b37-a374db1ad77a
 override-email-address: 
 email-amalgamate-responses: true
 email-all-sent-to-enquirer: true

--- a/vars-production.yml
+++ b/vars-production.yml
@@ -9,6 +9,7 @@ google-analytics-measurement-id:
 dfe-analytics-dataset: fatp_events_production
 govuk-notify-enquiry-submitted-confirmation-to-enquirer-template-id: b1e29214-dfc0-4225-b65a-df6a20c4c297
 govuk-notify-enquiry-submitted-to-tp-template-id: b24ffca7-6119-4dbf-8ae2-dceb2c300ca4
+govuk-notify-enquiry-response-received-confirmation-to-enquirer-template-id: f64db52d-08ce-4f2a-9b37-a374db1ad77a
 override-email-address: 
 email-amalgamate-responses: false
 email-all-sent-to-enquirer: false

--- a/vars-qa.yml
+++ b/vars-qa.yml
@@ -9,6 +9,7 @@ google-analytics-measurement-id:
 dfe-analytics-dataset: fatp_events_qa
 govuk-notify-enquiry-submitted-confirmation-to-enquirer-template-id: b1e29214-dfc0-4225-b65a-df6a20c4c297
 govuk-notify-enquiry-submitted-to-tp-template-id: b24ffca7-6119-4dbf-8ae2-dceb2c300ca4
+govuk-notify-enquiry-response-received-confirmation-to-enquirer-template-id: f64db52d-08ce-4f2a-9b37-a374db1ad77a
 override-email-address: 
 email-amalgamate-responses: true
 email-all-sent-to-enquirer: true

--- a/vars-research.yml
+++ b/vars-research.yml
@@ -9,6 +9,7 @@ google-analytics-measurement-id:
 dfe-analytics-dataset: fatp_events_research
 govuk-notify-enquiry-submitted-confirmation-to-enquirer-template-id: b1e29214-dfc0-4225-b65a-df6a20c4c297
 govuk-notify-enquiry-submitted-to-tp-template-id: b24ffca7-6119-4dbf-8ae2-dceb2c300ca4
+govuk-notify-enquiry-response-received-confirmation-to-enquirer-template-id: f64db52d-08ce-4f2a-9b37-a374db1ad77a
 override-email-address: 
 email-amalgamate-responses: true
 email-all-sent-to-enquirer: true

--- a/vars-staging.yml
+++ b/vars-staging.yml
@@ -9,6 +9,7 @@ google-analytics-measurement-id:
 dfe-analytics-dataset: fatp_events_staging
 govuk-notify-enquiry-submitted-confirmation-to-enquirer-template-id: b1e29214-dfc0-4225-b65a-df6a20c4c297
 govuk-notify-enquiry-submitted-to-tp-template-id: b24ffca7-6119-4dbf-8ae2-dceb2c300ca4
+govuk-notify-enquiry-response-received-confirmation-to-enquirer-template-id: f64db52d-08ce-4f2a-9b37-a374db1ad77a
 override-email-address: 
 email-amalgamate-responses: false
 email-all-sent-to-enquirer: true


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

<!-- https://dfedigital.atlassian.net/browse/NTP-123 -->

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**