### PR TITLE
NTP-993: Update the importer to match the updated Tribal spreadsheet …

### DIFF
--- a/Infrastructure/Factories/TribalSpreadsheetTuitionPartnerFactory.cs
+++ b/Infrastructure/Factories/TribalSpreadsheetTuitionPartnerFactory.cs
@@ -213,7 +213,7 @@ public class TribalSpreadsheetTuitionPartnerFactory : ITribalSpreadsheetTuitionP
         postcode
         };
 
-        tuitionPartner.Address = string.Join(Environment.NewLine, addressLines.Where(x => x != null));
+        tuitionPartner.Address = string.Join(Environment.NewLine, addressLines.Where(x => x != null).Distinct());
 
         tuitionPartner.SeoUrl = tuitionPartner.Name.ToSeoUrl() ?? "";
 

--- a/Infrastructure/Factories/TribalSpreadsheetTuitionPartnerFactory.cs
+++ b/Infrastructure/Factories/TribalSpreadsheetTuitionPartnerFactory.cs
@@ -39,7 +39,8 @@ public class TribalSpreadsheetTuitionPartnerFactory : ITribalSpreadsheetTuitionP
         TuitionPartner tpMapping = new();
         _organisationDetailsMapping = new Dictionary<string, ImportMap>
         {
-            { "Organisation_Ref_ID_s", new ImportMap(tpMapping, nameof(tpMapping.ImportId)) },
+            { "Organisation_ID_s", new ImportMap(tpMapping, nameof(tpMapping.ImportId)) },
+            { "Organisation_Ref_ID_s", new ImportMap() },
             { "Organisation_s", new ImportMap(tpMapping, nameof(tpMapping.Name)) { RecommendedMaxStringLength = 120 } },
             { "Organisation_Address1_s", new ImportMap(tpMapping, nameof(tpMapping.Address)) { RecommendedMaxStringLength = 100 } },
             { "Organisation_Address2_s", new ImportMap() { IsStoredInNtp = true, RecommendedMaxStringLength = 100 } },
@@ -52,7 +53,6 @@ public class TribalSpreadsheetTuitionPartnerFactory : ITribalSpreadsheetTuitionP
             { "Organisation_Email_s", new ImportMap(tpMapping, nameof(tpMapping.Email)) { RecommendedMaxStringLength = 100 } },
             { "Organisation_Introduction_s", new ImportMap(tpMapping, nameof(tpMapping.Description)) { RecommendedMaxStringLength = 350 } },
             { "Organisation_LegalStatus_s", new ImportMap() { IsStoredInNtp = true, IsRequired = true } },
-            { "Organisation_LogoVector_s", new ImportMap() },
             { "Organisation_ChargeVAT_s", new ImportMap(tpMapping, nameof(tpMapping.IsVatCharged)) {IsRequired = false} },
             { "Organisation_LastUpdated_d", new ImportMap(tpMapping, nameof(tpMapping.TPLastUpdatedData)) },
         };

--- a/UI/cypress/e2e/full-list.feature
+++ b/UI/cypress/e2e/full-list.feature
@@ -37,13 +37,13 @@ Scenario: all quality-assured tuition partners page url is '/all-tuition-partner
     Given a user has arrived on the all quality-assured tuition partners page
     Then the website link for each tuition partner opens their website in a new tab
 
-  Scenario: tuition partner summaries' phone number link initiates device's calling options
+  Scenario: tuition partner summaries' phone number link initiates device's calling options and is not empty
     Given a user has arrived on the all quality-assured tuition partners page
-    Then the phone number link for each tuition partner initiates their device's calling options
+    Then the phone number link for each tuition partner initiates their device's calling options and is not empty
 
-  Scenario: tuition partner summaries' email link initiates email client options
+  Scenario: tuition partner summaries' email link initiates email client options and is not empty
     Given a user has arrived on the all quality-assured tuition partners page
-    Then the email link for each tuition partner initiates their email client options
+    Then the email link for each tuition partner initiates their email client options and is not empty
 
   Scenario: tuition partner details page linked from all quality-assured tuition partners page has 'Back to tuition partners' back link
     Given a user has arrived on the all quality-assured tuition partners page

--- a/UI/cypress/e2e/full-list.js
+++ b/UI/cypress/e2e/full-list.js
@@ -172,12 +172,12 @@ Then(
     let countOfElements = 0;
     cy.get('[data-testid="tuition-partner-summary"]').then(($elements) => {
       countOfElements = $elements.length;
+      $elements.length > 60 == true;
       cy.get('[data-testid="result-count"]')
         .invoke("text")
         .then(parseInt)
         .should("equal", countOfElements);
     });
-    countOfElements > 60;
   }
 );
 

--- a/UI/cypress/e2e/full-list.js
+++ b/UI/cypress/e2e/full-list.js
@@ -117,18 +117,23 @@ Then(
 );
 
 Then(
-  "the phone number link for each tuition partner initiates their device's calling options",
+  "the phone number link for each tuition partner initiates their device's calling options and is not empty",
   () => {
     cy.get('a[data-testid="tuition-partner-phone-number-link"]').each(
       ($element) => {
         cy.wrap($element).should("have.attr", "href", `tel:${$element.text()}`);
       }
     );
+    cy.get('a[data-testid="tuition-partner-phone-number-link"]').each(
+      ($element) => {
+        cy.wrap($element).should("not.be.empty");
+      }
+    );
   }
 );
 
 Then(
-  "the email link for each tuition partner initiates their email client options",
+  "the email link for each tuition partner initiates their email client options and is not empty",
   () => {
     cy.get('a[data-testid="tuition-partner-email-link"]').each(($element) => {
       cy.wrap($element).should(
@@ -137,6 +142,11 @@ Then(
         `mailto:${$element.text()}`
       );
     });
+    cy.get('a[data-testid="tuition-partner-email-link"]').each(
+      ($element) => {
+        cy.wrap($element).should("not.be.empty");
+      }
+    );
   }
 );
 
@@ -169,6 +179,7 @@ Then(
         .then(parseInt)
         .should("equal", countOfElements);
     });
+    countOfElements > 60
   }
 );
 

--- a/UI/cypress/e2e/full-list.js
+++ b/UI/cypress/e2e/full-list.js
@@ -142,11 +142,9 @@ Then(
         `mailto:${$element.text()}`
       );
     });
-    cy.get('a[data-testid="tuition-partner-email-link"]').each(
-      ($element) => {
-        cy.wrap($element).should("not.be.empty");
-      }
-    );
+    cy.get('a[data-testid="tuition-partner-email-link"]').each(($element) => {
+      cy.wrap($element).should("not.be.empty");
+    });
   }
 );
 
@@ -179,7 +177,7 @@ Then(
         .then(parseInt)
         .should("equal", countOfElements);
     });
-    countOfElements > 60
+    countOfElements > 60;
   }
 );
 

--- a/UI/cypress/e2e/tuition-partner-details.feature
+++ b/UI/cypress/e2e/tuition-partner-details.feature
@@ -19,14 +19,6 @@ Feature: User can view full details of a Tuition Parner
     Then the page URL ends with '/bright-heart-education'
     And the heading should say 'Bright Heart Education'
 
-  Scenario: don’t show email address where TP has not provided information
-    Given a user has arrived on the 'Tuition Partner' page for 'Pearson'
-    Then TP has not provided the information in the 'Email address' section
-
-  Scenario: don’t show phone number where TP has not provided information
-    Given a user has arrived on the 'Tuition Partner' page for 'Pearson'
-    Then TP has not provided the information in the 'Phone Number' section
-
   Scenario: show Contact Details where TP has provided information
     Given a user has arrived on the 'Tuition Partner' page for 'Bright Heart Education'
     Then TP has provided full contact details


### PR DESCRIPTION
## Context

Update the importer to match the updated Tribal spreadsheet format

Also updated the address import, so that any duplicates are excluded.  Since “London” was being shown twice, once as the Town and ones as the County

## Changes proposed in this pull request

Updated to use latest layout - using new Id that Tribal have supplied for import id and no longer having logo details in spreadsheet

## Guidance to review

Run the importer - the proper tests will be done as part of https://dfedigital.atlassian.net/browse/NTP-994
This will be released after the testing has been done

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-993

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [x] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**