### PR TITLE
NTP-897: provide email address bug fix

### DIFF
--- a/Tests/Enquiry/Build/EnquirerEmailPageTests.cs
+++ b/Tests/Enquiry/Build/EnquirerEmailPageTests.cs
@@ -55,6 +55,8 @@ public class EnquirerEmailPageTests
     [InlineData("_______@example.com")]
     [InlineData("firstname-lastname@example.com")]
     [InlineData("firstname'lastname@example.com")]
+    [InlineData("firstname'lastname@example")]
+    [InlineData("firstname'lastname@example_com")]
     public void With_a_valid_email(string email)
     {
         var model = new EnquirerEmailModel { Email = email };
@@ -64,7 +66,7 @@ public class EnquirerEmailPageTests
 
     [Theory]
     [InlineData("email@example.com")]
-    public async void With_a_valid_email_moves_to_next_page(string email)
+    public async Task With_a_valid_email_moves_to_next_page(string email)
     {
         var model = new EnquirerEmailModel { Email = email };
 
@@ -79,7 +81,7 @@ public class EnquirerEmailPageTests
 
     [Theory]
     [InlineData("email@example.com")]
-    public async void With_a_valid_email_moves_to_cya_page(string email)
+    public async Task With_a_valid_email_moves_to_cya_page(string email)
     {
         var model = new EnquirerEmailModel { Email = email, From = Domain.Enums.ReferrerList.CheckYourAnswers };
 

--- a/UI/Pages/Enquiry/Build/EnquirerEmail.cshtml
+++ b/UI/Pages/Enquiry/Build/EnquirerEmail.cshtml
@@ -15,7 +15,7 @@
                 <div asp-validation-group-for="Data.Email" data-testid="enquirer-email">
                     <govuk-input asp-for="Data.Email" input-class="govuk-input govuk-!-width-three-quarters" autocomplete="email" data-testid="enquirer-email-input-box" type="email" spellcheck="false" autocomplete="email">
                         <govuk-input-label>Email address</govuk-input-label>
-                        <govuk-input-hint>Tuition partners won’t see your email address until you agree to share it.  We’ll use this email to notify you if you get a response from a tuition partner.</govuk-input-hint>
+                        <govuk-input-hint>Tuition partners won&#8217;t see your email address until you agree to share it.  We&#8217;ll use this email to notify you if you get a response from a tuition partner.</govuk-input-hint>
                     </govuk-input>
                 </div>
             </div>

--- a/UI/Pages/Enquiry/Build/EnquirerEmail.cshtml.cs
+++ b/UI/Pages/Enquiry/Build/EnquirerEmail.cshtml.cs
@@ -26,13 +26,14 @@ public class EnquirerEmail : PageModel
     }
     public async Task<IActionResult> OnGetSubmit(EnquirerEmailModel data)
     {
+        Data = data;
         if (ModelState.IsValid)
         {
             await _sessionService.AddOrUpdateDataAsync(StringConstants.EnquirerEmail, data.Email!);
 
             if (data.From == ReferrerList.CheckYourAnswers)
             {
-                return RedirectToPage(nameof(CheckYourAnswers));
+                return RedirectToPage(nameof(CheckYourAnswers), new SearchModel(data));
             }
 
             return RedirectToPage(nameof(EnquiryQuestion), new SearchModel(data));

--- a/UI/Pages/Enquiry/Build/EnquiryQuestion.cshtml.cs
+++ b/UI/Pages/Enquiry/Build/EnquiryQuestion.cshtml.cs
@@ -34,6 +34,8 @@ public class EnquiryQuestion : PageModel
         if (!await _sessionService.SessionDataExistsAsync())
             return RedirectToPage("/Session/Timeout");
 
+        Data = data;
+
         if (ModelState.IsValid)
         {
             await _sessionService.AddOrUpdateDataAsync(StringConstants.EnquiryText, data.EnquiryText!);


### PR DESCRIPTION
## Context

Spotted 2 issues:
Curly quotes not displaying correctly in hint text when deployed (was OK locally) 
![image](https://user-images.githubusercontent.com/113545700/223540989-ad9ce30f-b427-4bd8-8e88-354ccea6c5f8.png)

If get validation error on email step twice (e.g. empty email) then use back button to search the data is lost in the query string, so shows no postcode.

Also, unit test changes missed from previous PR review

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

<!-- https://dfedigital.atlassian.net/browse/NTP-123 -->

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**