### PR TITLE
NTP-1008: Include KeyStage, Subjects, Tuition Type, Postcode and LAD to enquiry record

### DIFF
--- a/Application.Tests/Extensions/KeyStageSubjectsIdMapExtensionsTests.cs
+++ b/Application.Tests/Extensions/KeyStageSubjectsIdMapExtensionsTests.cs
@@ -18,7 +18,7 @@ public class KeyStageSubjectsIdMapExtensionsTests
         var keyStageSubjects = new[]
         {
             new KeyStageSubject(KeyStage.KeyStage1, StringConstants.English),
-            new KeyStageSubject(KeyStage.KeyStage2, StringConstants.Math),
+            new KeyStageSubject(KeyStage.KeyStage2, StringConstants.Maths),
             new KeyStageSubject(KeyStage.KeyStage3, StringConstants.Science),
             new KeyStageSubject(KeyStage.KeyStage4, StringConstants.Humanities)
         };

--- a/Application.Tests/Extensions/KeyStageSubjectsIdMapExtensionsTests.cs
+++ b/Application.Tests/Extensions/KeyStageSubjectsIdMapExtensionsTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using Application.Common.Models;
+using Application.Constants;
+using Application.Extensions;
+using Domain.Constants;
+using Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Tests.Extensions;
+
+public class KeyStageSubjectsIdMapExtensionsTests
+{
+    [Fact]
+    public void GetIdsForKeyStageSubjects_ReturnsCorrectMapping()
+    {
+        // Arrange
+        var keyStageSubjects = new[]
+        {
+            new KeyStageSubject(KeyStage.KeyStage1, StringConstants.English),
+            new KeyStageSubject(KeyStage.KeyStage2, StringConstants.Math),
+            new KeyStageSubject(KeyStage.KeyStage3, StringConstants.Science),
+            new KeyStageSubject(KeyStage.KeyStage4, StringConstants.Humanities)
+        };
+
+        var expectedMapping = new List<(int, int)>()
+        {
+            { (KeyStages.Id.One, Subjects.Id.KeyStage1English) },
+            { (KeyStages.Id.Two, Subjects.Id.KeyStage2Maths) },
+            { (KeyStages.Id.Three, Subjects.Id.KeyStage3Science) },
+            { (KeyStages.Id.Four, Subjects.Id.KeyStage4Humanities) },
+        };
+
+        // Act
+        var result = keyStageSubjects.GetIdsForKeyStageSubjects();
+
+        // Assert
+        result.Should().BeEquivalentTo(expectedMapping);
+    }
+
+    [Fact]
+    public void GetIdsForKeyStageSubjects_ReturnsEmptyList_WhenInputIsEmpty()
+    {
+        // Arrange
+        var keyStageSubjects = new KeyStageSubject[] { };
+
+        // Act
+        var result = keyStageSubjects.GetIdsForKeyStageSubjects();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetIdsForKeyStageSubjects_ReturnsEmptyList_WhenInputHasUnknownKeyStage()
+    {
+        // Arrange
+        var keyStageSubjects = new KeyStageSubject[]
+        {
+            new KeyStageSubject (KeyStage.Unspecified,StringConstants.English )
+        };
+
+        // Act
+        var result = keyStageSubjects.GetIdsForKeyStageSubjects();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetIdsForKeyStageSubjects_ReturnsEmptyList_WhenInputHasUnknownSubject()
+    {
+        // Arrange
+        var keyStageSubjects = new KeyStageSubject[]
+        {
+            new KeyStageSubject (KeyStage.KeyStage1,"French" )
+        };
+
+        // Act
+        var result = keyStageSubjects.GetIdsForKeyStageSubjects();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+}

--- a/Application.Tests/Extensions/StringExtensionsTests.cs
+++ b/Application.Tests/Extensions/StringExtensionsTests.cs
@@ -167,4 +167,19 @@ public class StringExtensionsTests
         List<string> list = new List<string>(stringArray);
         list.DisplayList().Should().Be(output);
     }
+
+    [Fact]
+    public void GroupByKeyAndConcatenateValues_ReturnsCorrectOutput()
+    {
+        // Arrange
+        var keyValuePairs = new List<string>() { "Key1: Value1", "Key2: Value2", "Key2: Value3", "Key3: Value4", "Key3: Value5", "Key3: Value6", "Key3: Value7" };
+        var expectedOutput = new List<string>() { "Key1: Value1", "Key2: Value2 and Value3", "Key3: Value4, Value5, Value6 and Value7" };
+
+        // Act
+        var actualOutput = keyValuePairs.GroupByKeyAndConcatenateValues();
+
+        // Assert
+
+        actualOutput.Should().BeEquivalentTo(expectedOutput);
+    }
 }

--- a/Application/Common/Interfaces/IUnitOfWork.cs
+++ b/Application/Common/Interfaces/IUnitOfWork.cs
@@ -13,5 +13,6 @@ public interface IUnitOfWork : IDisposable
     ISchoolRepository SchoolRepository { get; }
     IMagicLinkRepository MagicLinkRepository { get; }
     ITuitionPartnerEnquiryRepository TuitionPartnerEnquiryRepository { get; }
+    IKeyStageSubjectEnquiryRepository KeyStageSubjectEnquiryRepository { get; }
     Task<bool> Complete();
 }

--- a/Application/Common/Interfaces/Repositories/IEnquiryRepository.cs
+++ b/Application/Common/Interfaces/Repositories/IEnquiryRepository.cs
@@ -1,7 +1,9 @@
+using Application.Common.Models.Enquiry.Respond;
 using Domain;
 
 namespace Application.Common.Interfaces.Repositories;
 
 public interface IEnquiryRepository : IGenericRepository<Enquiry>
 {
+    Task<EnquirerViewAllResponsesModel> GetEnquirerViewAllResponses(int enquiryId, string baseServiceUrl);
 }

--- a/Application/Common/Interfaces/Repositories/IKeyStageSubjectEnquiryRepository.cs
+++ b/Application/Common/Interfaces/Repositories/IKeyStageSubjectEnquiryRepository.cs
@@ -1,0 +1,7 @@
+using Domain;
+
+namespace Application.Common.Interfaces.Repositories;
+
+public interface IKeyStageSubjectEnquiryRepository : IGenericRepository<KeyStageSubjectEnquiry>
+{
+}

--- a/Application/Common/Interfaces/Repositories/ITuitionPartnerEnquiryRepository.cs
+++ b/Application/Common/Interfaces/Repositories/ITuitionPartnerEnquiryRepository.cs
@@ -5,7 +5,5 @@ namespace Application.Common.Interfaces.Repositories;
 
 public interface ITuitionPartnerEnquiryRepository : IGenericRepository<TuitionPartnerEnquiry>
 {
-    Task<EnquirerViewAllResponsesModel> GetEnquirerViewAllResponses(int enquiryId, string baseServiceUrl);
-
     Task<EnquirerViewResponseModel?> GetEnquirerViewResponse(int enquiryId, int tuitionPartnerId);
 }

--- a/Application/Common/Models/Enquiry/Respond/EnquirerViewAllResponsesModel.cs
+++ b/Application/Common/Models/Enquiry/Respond/EnquirerViewAllResponsesModel.cs
@@ -12,6 +12,7 @@ public class EnquirerViewAllResponsesModel
 
     public string SupportReferenceNumber { get; set; } = null!;
 
+    public string TuitionTypeName { get; set; } = null!;
     public List<string> KeyStageSubjects { get; set; } = null!;
     public DateTime EnquiryCreatedDateTime { get; set; }
 

--- a/Application/Common/Models/Enquiry/Respond/EnquirerViewAllResponsesModel.cs
+++ b/Application/Common/Models/Enquiry/Respond/EnquirerViewAllResponsesModel.cs
@@ -10,5 +10,10 @@ public class EnquirerViewAllResponsesModel
 
     public int NumberOfTpEnquiryWasSent { get; set; }
 
+    public string SupportReferenceNumber { get; set; } = null!;
+
+    public List<string> KeyStageSubjects { get; set; } = null!;
+    public DateTime EnquiryCreatedDateTime { get; set; }
+
     public List<EnquirerViewResponseDto> EnquirerViewResponses { get; set; } = null!;
 }

--- a/Application/Constants/StringConstants.cs
+++ b/Application/Constants/StringConstants.cs
@@ -15,13 +15,13 @@
 
         public const string English = "English";
 
-        public const string Math = "Math";
+        public const string Maths = "Maths";
 
         public const string Science = "Science";
 
         public const string Humanities = "Humanities";
 
-        public const string ModernForeignLanguages = "ModernForeignLanguages";
+        public const string ModernForeignLanguages = "Modern foreign languages";
 
         public const string SessionCookieName = ".FindATuitionPartner.Session";
 

--- a/Application/Constants/StringConstants.cs
+++ b/Application/Constants/StringConstants.cs
@@ -13,9 +13,15 @@
         public const string UrlUnsafeCharacters = "[^a-zA-Z0-9_{}()\\-~/]";
         public const string MultipleUnderscores = @"[-]{2,}";
 
-        public const string PENDING = "PENDING";
+        public const string English = "English";
 
-        public const string RECEIVED = "RECEIVED";
+        public const string Math = "Math";
+
+        public const string Science = "Science";
+
+        public const string Humanities = "Humanities";
+
+        public const string ModernForeignLanguages = "ModernForeignLanguages";
 
         public const string SessionCookieName = ".FindATuitionPartner.Session";
 

--- a/Application/Extensions/KeyStageSubjectsIdMapExtensions.cs
+++ b/Application/Extensions/KeyStageSubjectsIdMapExtensions.cs
@@ -28,7 +28,7 @@ public static class KeyStageSubjectsIdMapExtensions
                 }
             },
             {
-                StringConstants.Math, new Dictionary<int, int>()
+                StringConstants.Maths, new Dictionary<int, int>()
                 {
                     { KeyStages.Id.One, Subjects.Id.KeyStage1Maths },
                     { KeyStages.Id.Two, Subjects.Id.KeyStage2Maths },

--- a/Application/Extensions/KeyStageSubjectsIdMapExtensions.cs
+++ b/Application/Extensions/KeyStageSubjectsIdMapExtensions.cs
@@ -1,0 +1,83 @@
+using Application.Common.Models;
+using Application.Constants;
+using Domain.Constants;
+
+namespace Application.Extensions;
+
+public static class KeyStageSubjectsIdMapExtensions
+{
+    public static IEnumerable<(int, int)> GetIdsForKeyStageSubjects(this KeyStageSubject[] keyStageSubjects)
+    {
+        var keyStagesMap = new Dictionary<int, int>()
+        {
+            { 1, KeyStages.Id.One },
+            { 2, KeyStages.Id.Two },
+            { 3, KeyStages.Id.Three },
+            { 4, KeyStages.Id.Four }
+        };
+
+        var subjectsMap = new Dictionary<string, Dictionary<int, int>>()
+        {
+            {
+                StringConstants.English, new Dictionary<int, int>()
+                {
+                    { KeyStages.Id.One, Subjects.Id.KeyStage1English },
+                    { KeyStages.Id.Two, Subjects.Id.KeyStage2English },
+                    { KeyStages.Id.Three, Subjects.Id.KeyStage3English },
+                    { KeyStages.Id.Four, Subjects.Id.KeyStage4English }
+                }
+            },
+            {
+                StringConstants.Math, new Dictionary<int, int>()
+                {
+                    { KeyStages.Id.One, Subjects.Id.KeyStage1Maths },
+                    { KeyStages.Id.Two, Subjects.Id.KeyStage2Maths },
+                    { KeyStages.Id.Three, Subjects.Id.KeyStage3Maths },
+                    { KeyStages.Id.Four, Subjects.Id.KeyStage4Maths }
+                }
+            },
+            {
+                StringConstants.Science, new Dictionary<int, int>()
+                {
+                    { KeyStages.Id.One, Subjects.Id.KeyStage1Science },
+                    { KeyStages.Id.Two, Subjects.Id.KeyStage2Science },
+                    { KeyStages.Id.Three, Subjects.Id.KeyStage3Science },
+                    { KeyStages.Id.Four, Subjects.Id.KeyStage4Science }
+                }
+            },
+            {
+                StringConstants.Humanities, new Dictionary<int, int>()
+                {
+                    { KeyStages.Id.Three, Subjects.Id.KeyStage3Humanities },
+                    { KeyStages.Id.Four, Subjects.Id.KeyStage4Humanities }
+                }
+            },
+            {
+                StringConstants.ModernForeignLanguages, new Dictionary<int, int>()
+                {
+                    { KeyStages.Id.Three, Subjects.Id.KeyStage3ModernForeignLanguages },
+                    { KeyStages.Id.Four, Subjects.Id.KeyStage4ModernForeignLanguages }
+                }
+            }
+        };
+
+        var result = new List<(int, int)>();
+
+        foreach (var keyStageSubject in keyStageSubjects)
+        {
+            var keyStageId = (int)keyStageSubject.KeyStage;
+
+            var subject = keyStageSubject.Subject;
+
+            if (!keyStagesMap.TryGetValue(keyStageId, out var keyStageIdValue)) continue;
+
+            if (subjectsMap.TryGetValue(subject, out var subjectMap)
+                && subjectMap.TryGetValue(keyStageId, out var subjectIdValue))
+            {
+                result.Add((keyStageIdValue, subjectIdValue));
+            }
+        }
+
+        return result;
+    }
+}

--- a/Application/Extensions/StringExtensions.cs
+++ b/Application/Extensions/StringExtensions.cs
@@ -58,4 +58,23 @@ public static class StringExtensions
 
         return commaSeparated.Remove(lastCommaIndex, 1).Insert(lastCommaIndex, " and");
     }
+
+    public static List<string> GroupByKeyAndConcatenateValues(this IEnumerable<string> keyValuePairs)
+    {
+        var groupedPairs = keyValuePairs.GroupBy(kv =>
+            kv.Substring(0, kv.IndexOf(":", StringComparison.Ordinal)).Trim());
+        return (from @group in groupedPairs
+                let key = @group.Key
+                let values = @group.Select(kv => kv.Substring(kv.IndexOf(":", StringComparison.Ordinal) + 1).Trim())
+                    .ToList()
+                let valuesCount = values.Count
+                let valueString = valuesCount switch
+                {
+                    1 => values[0],
+                    2 => $"{values[0]} and {values[1]}",
+                    _ => $"{string.Join(", ", values.Take(valuesCount - 1))} and {values.Last()}"
+                }
+                select $"{key}: {valueString}").ToList();
+    }
+
 }

--- a/Application/Handlers/GetTuitionPartnerQueryHandler.cs
+++ b/Application/Handlers/GetTuitionPartnerQueryHandler.cs
@@ -103,7 +103,7 @@ public class GetTuitionPartnerQueryHandler : IRequestHandler<GetTuitionPartnerQu
         if (tpResult is IErrorResult tpError)
             return tpError.Cast<TuitionPartnersResult>();
 
-        var result = new TuitionPartnersResult(tpResult.Data, location.LocalAuthority);
+        var result = new TuitionPartnersResult(tpResult.Data, location.LocalAuthority, location.LocalAuthorityDistrict);
 
         return Result.Success(result);
     }

--- a/Application/Queries/GetEnquirerViewAllResponsesQuery.cs
+++ b/Application/Queries/GetEnquirerViewAllResponsesQuery.cs
@@ -16,7 +16,7 @@ public class GetEnquirerViewAllResponsesQueryHandler : IRequestHandler<GetEnquir
 
     public async Task<EnquirerViewAllResponsesModel> Handle(GetEnquirerViewAllResponsesQuery request, CancellationToken cancellationToken)
     {
-        var result = await _unitOfWork.TuitionPartnerEnquiryRepository
+        var result = await _unitOfWork.EnquiryRepository
             .GetEnquirerViewAllResponses(request.EnquiryId, request.BaseServiceUrl);
         return result;
     }

--- a/Application/Queries/GetSearchResultsQuery.cs
+++ b/Application/Queries/GetSearchResultsQuery.cs
@@ -84,7 +84,7 @@ public class GetSearchResultsQueryHandler : IRequestHandler<GetSearchResultsQuer
             request,
             cancellationToken);
 
-        var result = new TuitionPartnersResult(results, location.Data.LocalAuthority);
+        var result = new TuitionPartnersResult(results, location.Data.LocalAuthority, location.Data.LocalAuthorityDistrict);
 
         return Result.Success(result);
     }

--- a/Domain/Enquiry.cs
+++ b/Domain/Enquiry.cs
@@ -14,4 +14,6 @@ public class Enquiry
     public ICollection<EnquiryResponse> EnquiryResponse { get; set; } = null!;
 
     public ICollection<MagicLink> MagicLinks { get; set; } = null!;
+
+    public ICollection<KeyStageSubjectEnquiry> KeyStageSubjectEnquiry { get; set; } = null!;
 }

--- a/Domain/Enquiry.cs
+++ b/Domain/Enquiry.cs
@@ -4,9 +4,13 @@ public class Enquiry
     public int Id { get; set; }
     public string EnquiryText { get; set; } = null!;
     public string Email { get; set; } = null!;
-
     public string SupportReferenceNumber { get; set; } = null!;
 
+    public string PostCode { get; set; } = null!;
+
+    public string LocalAuthorityDistrict { get; set; } = null!;
+
+    public int? TuitionTypeId { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     public ICollection<TuitionPartnerEnquiry> TuitionPartnerEnquiry { get; set; } = null!;

--- a/Domain/Enquiry.cs
+++ b/Domain/Enquiry.cs
@@ -13,6 +13,8 @@ public class Enquiry
     public int? TuitionTypeId { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+    public TuitionType TuitionType { get; set; } = null!;
+
     public ICollection<TuitionPartnerEnquiry> TuitionPartnerEnquiry { get; set; } = null!;
 
     public ICollection<EnquiryResponse> EnquiryResponse { get; set; } = null!;

--- a/Domain/KeyStageSubjectEnquiry.cs
+++ b/Domain/KeyStageSubjectEnquiry.cs
@@ -1,0 +1,18 @@
+namespace Domain;
+
+public class KeyStageSubjectEnquiry
+{
+    public int Id { get; set; }
+
+    public int EnquiryId { get; set; }
+
+    public int KeyStageId { get; set; }
+
+    public int SubjectId { get; set; }
+
+    public Enquiry Enquiry { get; set; } = null!;
+
+    public KeyStage KeyStage { get; set; } = null!;
+
+    public Subject Subject { get; set; } = null!;
+}

--- a/Domain/Search/TuitionPartnersResult.cs
+++ b/Domain/Search/TuitionPartnersResult.cs
@@ -2,23 +2,27 @@
 
 public class TuitionPartnersResult
 {
-    public TuitionPartnersResult(TuitionPartnerResult result, string? localAuthorityName)
+    public TuitionPartnersResult(TuitionPartnerResult result, string? localAuthorityName, string? localAuthorityDistrictName)
     {
         Results = new List<TuitionPartnerResult>() { result };
         Count = 1;
         LocalAuthorityName = localAuthorityName;
+        LocalAuthorityDistrictName = localAuthorityDistrictName;
     }
 
-    public TuitionPartnersResult(IEnumerable<TuitionPartnerResult> results, string? localAuthorityName)
+    public TuitionPartnersResult(IEnumerable<TuitionPartnerResult> results, string? localAuthorityName, string? localAuthorityDistrictName)
     {
         Results = results;
         Count = results.Count();
         LocalAuthorityName = localAuthorityName;
+        LocalAuthorityDistrictName = localAuthorityDistrictName;
     }
 
     public IEnumerable<TuitionPartnerResult> Results { get; set; }
     public int Count { get; set; }
     public string? LocalAuthorityName { get; set; }
+
+    public string? LocalAuthorityDistrictName { get; set; }
 
     public TuitionPartnerResult FirstResult => Results.Any() ? Results.First() : new TuitionPartnerResult();
 }

--- a/Infrastructure/EntityConfigurations/KeyStageSubjectEnquiryConfigurations.cs
+++ b/Infrastructure/EntityConfigurations/KeyStageSubjectEnquiryConfigurations.cs
@@ -1,0 +1,15 @@
+using Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.EntityConfigurations;
+
+public class KeyStageSubjectEnquiryConfigurations : IEntityTypeConfiguration<KeyStageSubjectEnquiry>
+{
+    public void Configure(EntityTypeBuilder<KeyStageSubjectEnquiry> builder)
+    {
+        builder.HasIndex(e => e.KeyStageId);
+
+        builder.HasIndex(e => e.SubjectId);
+    }
+}

--- a/Infrastructure/Migrations/20230308190912_KeyStageSubjectEnquiry.Designer.cs
+++ b/Infrastructure/Migrations/20230308190912_KeyStageSubjectEnquiry.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(NtpDbContext))]
-    partial class NtpDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230308190912_KeyStageSubjectEnquiry")]
+    partial class KeyStageSubjectEnquiry
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20230308190912_KeyStageSubjectEnquiry.cs
+++ b/Infrastructure/Migrations/20230308190912_KeyStageSubjectEnquiry.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    public partial class KeyStageSubjectEnquiry : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "KeyStageSubjectsEnquiry",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    EnquiryId = table.Column<int>(type: "integer", nullable: false),
+                    KeyStageId = table.Column<int>(type: "integer", nullable: false),
+                    SubjectId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_KeyStageSubjectsEnquiry", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_KeyStageSubjectsEnquiry_Enquiries_EnquiryId",
+                        column: x => x.EnquiryId,
+                        principalTable: "Enquiries",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_KeyStageSubjectsEnquiry_KeyStage_KeyStageId",
+                        column: x => x.KeyStageId,
+                        principalTable: "KeyStage",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_KeyStageSubjectsEnquiry_Subjects_SubjectId",
+                        column: x => x.SubjectId,
+                        principalTable: "Subjects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_KeyStageSubjectsEnquiry_EnquiryId",
+                table: "KeyStageSubjectsEnquiry",
+                column: "EnquiryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_KeyStageSubjectsEnquiry_KeyStageId",
+                table: "KeyStageSubjectsEnquiry",
+                column: "KeyStageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_KeyStageSubjectsEnquiry_SubjectId",
+                table: "KeyStageSubjectsEnquiry",
+                column: "SubjectId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "KeyStageSubjectsEnquiry");
+        }
+    }
+}

--- a/Infrastructure/Migrations/20230309145736_AddPostCodeLadAndTpTypeIdToEnquiry.Designer.cs
+++ b/Infrastructure/Migrations/20230309145736_AddPostCodeLadAndTpTypeIdToEnquiry.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(NtpDbContext))]
-    partial class NtpDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230309145736_AddPostCodeLadAndTpTypeIdToEnquiry")]
+    partial class AddPostCodeLadAndTpTypeIdToEnquiry
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20230309145736_AddPostCodeLadAndTpTypeIdToEnquiry.cs
+++ b/Infrastructure/Migrations/20230309145736_AddPostCodeLadAndTpTypeIdToEnquiry.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    public partial class AddPostCodeLadAndTpTypeIdToEnquiry : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LocalAuthorityDistrict",
+                table: "Enquiries",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "PostCode",
+                table: "Enquiries",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "TuitionTypeId",
+                table: "Enquiries",
+                type: "integer",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LocalAuthorityDistrict",
+                table: "Enquiries");
+
+            migrationBuilder.DropColumn(
+                name: "PostCode",
+                table: "Enquiries");
+
+            migrationBuilder.DropColumn(
+                name: "TuitionTypeId",
+                table: "Enquiries");
+        }
+    }
+}

--- a/Infrastructure/Migrations/20230310141910_AddTuitionTypeFkToEnquiry.Designer.cs
+++ b/Infrastructure/Migrations/20230310141910_AddTuitionTypeFkToEnquiry.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(NtpDbContext))]
-    partial class NtpDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230310141910_AddTuitionTypeFkToEnquiry")]
+    partial class AddTuitionTypeFkToEnquiry
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20230310141910_AddTuitionTypeFkToEnquiry.cs
+++ b/Infrastructure/Migrations/20230310141910_AddTuitionTypeFkToEnquiry.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    public partial class AddTuitionTypeFkToEnquiry : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Enquiries_TuitionTypeId",
+                table: "Enquiries",
+                column: "TuitionTypeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Enquiries_TuitionTypes_TuitionTypeId",
+                table: "Enquiries",
+                column: "TuitionTypeId",
+                principalTable: "TuitionTypes",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Enquiries_TuitionTypes_TuitionTypeId",
+                table: "Enquiries");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Enquiries_TuitionTypeId",
+                table: "Enquiries");
+        }
+    }
+}

--- a/Infrastructure/NtpDbContext.cs
+++ b/Infrastructure/NtpDbContext.cs
@@ -32,6 +32,7 @@ public class NtpDbContext : DbContext, INtpDbContext, IDataProtectionKeyContext
     public DbSet<OrganisationType> OrganisationType { get; set; } = null!;
 
     public DbSet<TuitionPartnerEnquiry> TuitionPartnersEnquiry { get; set; } = null!;
+    public DbSet<KeyStageSubjectEnquiry> KeyStageSubjectsEnquiry { get; set; } = null!;
 
     public Task<int> SaveChangesAsync()
     {

--- a/Infrastructure/Repositories/EnquiryRepository.cs
+++ b/Infrastructure/Repositories/EnquiryRepository.cs
@@ -1,5 +1,10 @@
+using Application.Common.DTO;
 using Application.Common.Interfaces.Repositories;
+using Application.Common.Models.Enquiry.Respond;
+using Application.Extensions;
 using Domain;
+using Microsoft.EntityFrameworkCore;
+using TuitionType = Domain.Enums.TuitionType;
 
 namespace Infrastructure.Repositories;
 
@@ -7,5 +12,76 @@ public class EnquiryRepository : GenericRepository<Enquiry>, IEnquiryRepository
 {
     public EnquiryRepository(NtpDbContext context) : base(context)
     {
+    }
+
+    public async Task<EnquirerViewAllResponsesModel> GetEnquirerViewAllResponses(int enquiryId, string baseServiceUrl)
+    {
+        var enquiry = await _context.Enquiries.AsNoTracking()
+            .Where(e => e.Id == enquiryId)
+            .Include(e => e.KeyStageSubjectEnquiry)
+            .ThenInclude(ks => ks.KeyStage)
+            .Include(e => e.KeyStageSubjectEnquiry)
+            .ThenInclude(s => s.Subject)
+            .Include(x => x.TuitionPartnerEnquiry)
+            .ThenInclude(x => x.EnquiryResponse)
+            .ThenInclude(e => e!.MagicLink)
+            .Include(x => x.TuitionPartnerEnquiry)
+            .ThenInclude(x => x.TuitionPartner)
+            .AsSplitQuery()
+            .SingleOrDefaultAsync();
+
+        if (enquiry == null)
+        {
+            return new EnquirerViewAllResponsesModel();
+        }
+
+        var tuitionPartnerEnquiriesWithResponses = enquiry.TuitionPartnerEnquiry.Where(x =>
+            x.EnquiryResponse != null && !string.IsNullOrEmpty(x.EnquiryResponse.EnquiryResponseText)).ToList();
+
+        var keyStageSubjects = enquiry
+            .KeyStageSubjectEnquiry
+            .Select(x => $"{x.KeyStage.Name}: {x.Subject.Name}")
+            .GroupByKeyAndConcatenateValues();
+
+        var tuitionTypeName = GetTuitionTypeName(enquiry.TuitionTypeId);
+
+        var result = new EnquirerViewAllResponsesModel
+        {
+            EnquiryText = enquiry.EnquiryText!,
+            SupportReferenceNumber = enquiry.SupportReferenceNumber,
+            NumberOfTpEnquiryWasSent = enquiry.TuitionPartnerEnquiry.Count,
+            KeyStageSubjects = keyStageSubjects,
+            TuitionTypeName = tuitionTypeName,
+            EnquiryCreatedDateTime = enquiry.CreatedAt,
+            EnquirerViewResponses = new List<EnquirerViewResponseDto>()
+        };
+
+        foreach (var er in tuitionPartnerEnquiriesWithResponses)
+        {
+            var responseModel = new EnquirerViewResponseDto
+            {
+                TuitionPartnerName = er.TuitionPartner.Name,
+                EnquiryResponseDate = er.EnquiryResponse?.CreatedAt!,
+                EnquirerEnquiryResponseLink =
+                    $"{baseServiceUrl}/enquiry/respond/enquirer-response?token={er.EnquiryResponse!.MagicLink!.Token}"
+            };
+            result.EnquirerViewResponses.Add(responseModel);
+        }
+
+        var orderByReceivedEnquirerViewResponses = result.EnquirerViewResponses
+            .OrderByDescending(x => x.EnquiryResponseDate).ToList();
+        result.EnquirerViewResponses = orderByReceivedEnquirerViewResponses;
+        return result;
+    }
+
+    private string GetTuitionTypeName(int? tuitionTypeId)
+    {
+        return tuitionTypeId switch
+        {
+            null => TuitionType.Any.ToString(),
+            (int)TuitionType.Online => TuitionType.Online.ToString(),
+            (int)TuitionType.InSchool => TuitionType.InSchool.ToString(),
+            _ => TuitionType.Any.ToString()
+        };
     }
 }

--- a/Infrastructure/Repositories/KeyStageSubjectEnquiryRepository.cs
+++ b/Infrastructure/Repositories/KeyStageSubjectEnquiryRepository.cs
@@ -1,0 +1,11 @@
+using Application.Common.Interfaces.Repositories;
+using Domain;
+
+namespace Infrastructure.Repositories;
+
+public class KeyStageSubjectEnquiryRepository : GenericRepository<KeyStageSubjectEnquiry>, IKeyStageSubjectEnquiryRepository
+{
+    public KeyStageSubjectEnquiryRepository(NtpDbContext context) : base(context)
+    {
+    }
+}

--- a/Infrastructure/Repositories/TuitionPartnerEnquiryRepository.cs
+++ b/Infrastructure/Repositories/TuitionPartnerEnquiryRepository.cs
@@ -5,6 +5,7 @@ using Application.Extensions;
 using Domain;
 using Microsoft.EntityFrameworkCore;
 using MagicLinkType = Domain.Enums.MagicLinkType;
+using TuitionType = Domain.Enums.TuitionType;
 
 namespace Infrastructure.Repositories;
 
@@ -42,12 +43,15 @@ public class TuitionPartnerEnquiryRepository : GenericRepository<TuitionPartnerE
             .Select(x => $"{x.KeyStage.Name}: {x.Subject.Name}")
             .GroupByKeyAndConcatenateValues();
 
+        var tuitionTypeName = GetTuitionTypeName(tuitionPartnerEnquiries.First().Enquiry.TuitionTypeId);
+
         var result = new EnquirerViewAllResponsesModel
         {
             EnquiryText = tuitionPartnerEnquiries.FirstOrDefault()?.Enquiry.EnquiryText!,
             SupportReferenceNumber = tuitionPartnerEnquiries.First().Enquiry.SupportReferenceNumber,
             NumberOfTpEnquiryWasSent = tuitionPartnerEnquiries.Count,
             KeyStageSubjects = keyStageSubjects,
+            TuitionTypeName = tuitionTypeName,
             EnquiryCreatedDateTime = tuitionPartnerEnquiries.First().Enquiry.CreatedAt,
             EnquirerViewResponses = new List<EnquirerViewResponseDto>()
         };
@@ -93,5 +97,16 @@ public class TuitionPartnerEnquiryRepository : GenericRepository<TuitionPartnerE
         };
 
         return result;
+    }
+
+    private string GetTuitionTypeName(int? tuitionTypeId)
+    {
+        return tuitionTypeId switch
+        {
+            null => TuitionType.Any.ToString(),
+            (int)TuitionType.Online => TuitionType.Online.ToString(),
+            (int)TuitionType.InSchool => TuitionType.InSchool.ToString(),
+            _ => TuitionType.Any.ToString()
+        };
     }
 }

--- a/Infrastructure/Repositories/TuitionPartnerEnquiryRepository.cs
+++ b/Infrastructure/Repositories/TuitionPartnerEnquiryRepository.cs
@@ -1,11 +1,8 @@
-using Application.Common.DTO;
 using Application.Common.Interfaces.Repositories;
 using Application.Common.Models.Enquiry.Respond;
-using Application.Extensions;
 using Domain;
 using Microsoft.EntityFrameworkCore;
 using MagicLinkType = Domain.Enums.MagicLinkType;
-using TuitionType = Domain.Enums.TuitionType;
 
 namespace Infrastructure.Repositories;
 
@@ -15,79 +12,22 @@ public class TuitionPartnerEnquiryRepository : GenericRepository<TuitionPartnerE
     {
     }
 
-    public async Task<EnquirerViewAllResponsesModel> GetEnquirerViewAllResponses(int enquiryId, string baseServiceUrl)
-    {
-        var tuitionPartnerEnquiries = await _context.TuitionPartnersEnquiry.AsNoTracking()
-            .Where(e => e.EnquiryId == enquiryId)
-            .Include(e => e.Enquiry)
-            .ThenInclude(e => e.KeyStageSubjectEnquiry)
-            .ThenInclude(ks => ks.KeyStage)
-            .Include(e => e.Enquiry)
-            .ThenInclude(e => e.KeyStageSubjectEnquiry)
-            .ThenInclude(s => s.Subject)
-            .Include(e => e.EnquiryResponse)
-            .ThenInclude(e => e!.MagicLink)
-            .Include(x => x.TuitionPartner)
-            .ToListAsync();
-
-        if (!tuitionPartnerEnquiries.Any())
-        {
-            return new EnquirerViewAllResponsesModel();
-        }
-
-        var tuitionPartnerEnquiriesWithResponses = tuitionPartnerEnquiries.Where(x =>
-            x.EnquiryResponse != null && !string.IsNullOrEmpty(x.EnquiryResponse.EnquiryResponseText)).ToList();
-
-        var keyStageSubjects = tuitionPartnerEnquiries.First().Enquiry
-            .KeyStageSubjectEnquiry
-            .Select(x => $"{x.KeyStage.Name}: {x.Subject.Name}")
-            .GroupByKeyAndConcatenateValues();
-
-        var tuitionTypeName = GetTuitionTypeName(tuitionPartnerEnquiries.First().Enquiry.TuitionTypeId);
-
-        var result = new EnquirerViewAllResponsesModel
-        {
-            EnquiryText = tuitionPartnerEnquiries.FirstOrDefault()?.Enquiry.EnquiryText!,
-            SupportReferenceNumber = tuitionPartnerEnquiries.First().Enquiry.SupportReferenceNumber,
-            NumberOfTpEnquiryWasSent = tuitionPartnerEnquiries.Count,
-            KeyStageSubjects = keyStageSubjects,
-            TuitionTypeName = tuitionTypeName,
-            EnquiryCreatedDateTime = tuitionPartnerEnquiries.First().Enquiry.CreatedAt,
-            EnquirerViewResponses = new List<EnquirerViewResponseDto>()
-        };
-
-        foreach (var er in tuitionPartnerEnquiriesWithResponses)
-        {
-            var responseModel = new EnquirerViewResponseDto
-            {
-                TuitionPartnerName = er.TuitionPartner.Name,
-                EnquiryResponseDate = er.EnquiryResponse?.CreatedAt!,
-                EnquirerEnquiryResponseLink =
-                    $"{baseServiceUrl}/enquiry/respond/enquirer-response?token={er.EnquiryResponse!.MagicLink!.Token}"
-            };
-            result.EnquirerViewResponses.Add(responseModel);
-        }
-
-        var orderByReceivedEnquirerViewResponses = result.EnquirerViewResponses
-            .OrderByDescending(x => x.EnquiryResponseDate).ToList();
-        result.EnquirerViewResponses = orderByReceivedEnquirerViewResponses;
-        return result;
-    }
-
     public async Task<EnquirerViewResponseModel?> GetEnquirerViewResponse(int enquiryId, int tuitionPartnerId)
     {
         var tuitionPartnerEnquiry = await _context.TuitionPartnersEnquiry.AsNoTracking()
             .Where(e => e.EnquiryId == enquiryId && e.TuitionPartnerId == tuitionPartnerId)
             .Include(e => e.Enquiry)
-            .ThenInclude(e => e.MagicLinks)
+            .ThenInclude(m => m.MagicLinks)
             .Include(e => e.EnquiryResponse)
-            .Include(x => x.TuitionPartner).SingleOrDefaultAsync();
+            .Include(x => x.TuitionPartner)
+            .SingleOrDefaultAsync();
 
         if (tuitionPartnerEnquiry == null) return null;
 
 
         var enquirerViewAllResponsesMagicLinkToken = tuitionPartnerEnquiry.Enquiry.MagicLinks
-            .SingleOrDefault(x => x.MagicLinkTypeId == (int)MagicLinkType.EnquirerViewAllResponses);
+            .SingleOrDefault(x => x.EnquiryId == enquiryId
+                                       && x.MagicLinkTypeId == (int)MagicLinkType.EnquirerViewAllResponses);
 
         var result = new EnquirerViewResponseModel()
         {
@@ -97,16 +37,5 @@ public class TuitionPartnerEnquiryRepository : GenericRepository<TuitionPartnerE
         };
 
         return result;
-    }
-
-    private string GetTuitionTypeName(int? tuitionTypeId)
-    {
-        return tuitionTypeId switch
-        {
-            null => TuitionType.Any.ToString(),
-            (int)TuitionType.Online => TuitionType.Online.ToString(),
-            (int)TuitionType.InSchool => TuitionType.InSchool.ToString(),
-            _ => TuitionType.Any.ToString()
-        };
     }
 }

--- a/Infrastructure/UnitOfWorks/UnitOfWork.cs
+++ b/Infrastructure/UnitOfWorks/UnitOfWork.cs
@@ -19,6 +19,7 @@ public class UnitOfWork : IUnitOfWork
         SchoolRepository = new SchoolRepository(_context);
         MagicLinkRepository = new MagicLinkRepository(_context);
         TuitionPartnerEnquiryRepository = new TuitionPartnerEnquiryRepository(_context);
+        KeyStageSubjectEnquiryRepository = new KeyStageSubjectEnquiryRepository(_context);
     }
     public IEnquiryRepository EnquiryRepository { get; private set; }
     public IEnquiryResponseRepository EnquiryResponseRepository { get; private set; }
@@ -30,6 +31,8 @@ public class UnitOfWork : IUnitOfWork
     public IMagicLinkRepository MagicLinkRepository { get; private set; }
 
     public ITuitionPartnerEnquiryRepository TuitionPartnerEnquiryRepository { get; private set; }
+
+    public IKeyStageSubjectEnquiryRepository KeyStageSubjectEnquiryRepository { get; private set; }
 
     public async Task<bool> Complete()
     {

--- a/Tests/SearchForSubjects.cs
+++ b/Tests/SearchForSubjects.cs
@@ -147,4 +147,15 @@ public class SearchForSubjects : CleanSliceFixture
         var parsed = new[] { keyStageSubject }.ParseKeyStageSubjects();
         parsed.Should().BeEmpty();
     }
+
+    [Theory]
+    [InlineData("KeyStage1-English")]
+    [InlineData("KeyStage1-Maths")]
+    [InlineData("KeyStage2-Science")]
+    [InlineData("KeyStage4-Humanities")]
+    public void Parses_valid_KeyStageSubject_without_error(string keyStageSubject)
+    {
+        var parsed = new[] { keyStageSubject }.ParseKeyStageSubjects();
+        parsed.Should().NotBeEmpty();
+    }
 }

--- a/UI/Pages/AllTuitionPartners.cshtml.cs
+++ b/UI/Pages/AllTuitionPartners.cshtml.cs
@@ -22,7 +22,7 @@ public class AllTuitionPartners : PageModel
 
         var tuitionPartners = await FindTuitionPartners(Data, cancellationToken);
 
-        Results = new TuitionPartnersResult(tuitionPartners, null);
+        Results = new TuitionPartnersResult(tuitionPartners, null, null);
     }
 
     private async Task<IEnumerable<TuitionPartnerResult>> FindTuitionPartners(SearchModel data, CancellationToken cancellationToken)

--- a/UI/Pages/CompareList.cshtml.cs
+++ b/UI/Pages/CompareList.cshtml.cs
@@ -273,7 +273,7 @@ public class CompareList : PageModel
                         },
                         cancellationToken);
 
-            var result = new TuitionPartnersResult(results, location.Data.LocalAuthority);
+            var result = new TuitionPartnersResult(results, location.Data.LocalAuthority, location.Data.LocalAuthorityDistrict);
 
             return Result.Success(result);
         }

--- a/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
+++ b/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
@@ -5,6 +5,9 @@
     ViewData["Title"] = "Enquirer View All Responses";
     ViewData["BackLinkHref"] = "/";
     ViewData["IncludePrintPage"] = true;
+
+    var numberOfTpEnquiryResponseReceived = !Model.Data.EnquirerViewResponses.Any()
+        ? 0 : Model.Data.EnquirerViewResponses.Count;
 }
 
 <div class="govuk-grid-row app-print-hide">
@@ -15,12 +18,20 @@
         </govuk-error-summary>
 
 
-        <h2 class="govuk-heading-m">
+        <p class="govuk-body">
             <span>@Model.Data.SupportReferenceNumber</span>
-        </h2>
+        </p>
         <h1 class="govuk-heading-l">
             <span>View responses to your tuition enquiry</span>
         </h1>
+        <div class="govuk-inset-text">
+            You should bookmark this page for your future reference and quicker access to your enquiry.
+        </div>
+
+        <h3 class="govuk-heading-s">
+            <span>Your tuition enquiry summary</span>
+        </h3>
+        <p class="govuk-body">Created on <span>@Model.Data.EnquiryCreatedDateTime.ToString("h:mm tt dddd, MMMM dd, yyyy")</span></p>
 
         <govuk-details open="false">
             <govuk-details-summary>
@@ -36,7 +47,10 @@
                         </li>
                     }
                     <li>
-                        @Model.Data?.EnquiryText
+                        Enquiry: @Model.Data?.EnquiryText
+                    </li>
+                    <li>
+                        Tuition type: @Model.Data?.TuitionTypeName
                     </li>
                 </ul>
             </govuk-details-text>
@@ -45,16 +59,15 @@
     </div>
 </div>
 
-<h1 class="govuk-heading-l">
+<h3 class="govuk-heading-s">
     <span>All tuition partner responses</span>
-</h1>
+</h3>
 
-@if (!Model.Data.EnquirerViewResponses.Any())
-{
-    <div class="govuk-inset-text">
-        You have 0 out of @Model.Data.NumberOfTpEnquiryWasSent responses at the moment.
-    </div>
-}
+<div class="govuk-inset-text">
+    <p class="govuk-body"><strong> @numberOfTpEnquiryResponseReceived out of @Model.Data.NumberOfTpEnquiryWasSent tuition partners </strong> have responded at the moment.</p>
+    <p class="govuk-body">We have asked tuition partners to respond within 5 days of creating this enquiry.</p>
+    <p class="govuk-body">You should <strong>contact up to 3 tuition partners</strong> to discuss your budget and tuition needs.</p>
+</div>
 
 @if (Model.Data.EnquirerViewResponses.Any())
 {

--- a/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
+++ b/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
@@ -14,16 +14,31 @@
             <govuk-error-summary-item asp-for="Data.ErrorMessage"/>
         </govuk-error-summary>
 
+
+        <h2 class="govuk-heading-m">
+            <span>@Model.Data.SupportReferenceNumber</span>
+        </h2>
         <h1 class="govuk-heading-l">
             <span>View responses to your tuition enquiry</span>
         </h1>
 
         <govuk-details open="false">
             <govuk-details-summary>
-                Reveal your enquiry
+                Your tuition requirements
             </govuk-details-summary>
             <govuk-details-text>
-                @Model.Data?.EnquiryText
+                This is the tuition requirements you asked for:
+                <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
+                    @foreach (var item in Model.Data.KeyStageSubjects)
+                    {
+                        <li>
+                            @item
+                        </li>
+                    }
+                    <li>
+                        @Model.Data?.EnquiryText
+                    </li>
+                </ul>
             </govuk-details-text>
         </govuk-details>
 

--- a/UI/Pages/WhichTuitionTypes.cshtml
+++ b/UI/Pages/WhichTuitionTypes.cshtml
@@ -1,8 +1,9 @@
 ﻿@page
 @model WhichTuitionTypes
 @{
+    var backLink = Model.Data.From == ReferrerList.CheckYourAnswers ? "/enquiry/build/check-your-answers" : "/which-subjects";
     ViewData["Title"] = "What type of tuition do you need?";
-    ViewData["BackLinkHref"] = "/which-subjects?" + Model.Data.ToQueryString();
+    ViewData["BackLinkHref"] = $"{backLink}?{Model.Data.ToQueryString()}";
 }
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
- Add the ability to store KeyStage, Subjects, Tuition Type, Postcode and LAD to the Enquiry record.
- Add functionality to the enquirer view all responses page, including displaying tuition type, enquiry created date, time format and content based on the design.
- Add relevant unit tests.
- Refactor the query to get the enquirer to view all responses faster.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

[https://dfedigital.atlassian.net/browse/NTP-1008](https://dfedigital.atlassian.net/browse/NTP-1008)

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**