### PR TITLE
NTP-1035: navigating to the contact us page form email enquiry has a redundant back button

### DIFF
--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -11,7 +11,7 @@
     var backLinkHref = ViewData["BackLinkHref"] as string; 
     var backLinkText = ViewData["BackLinkText"] as string;
     backLinkText = backLinkText ?? "Back";
-    var includeBackLink = backLinkHref is not null;
+    var includeBackLink = !string.IsNullOrEmpty(backLinkHref);
     var includePrintPage = includeBackLink && ViewData["IncludePrintPage"] as bool? == true; 
 
     var containerId = Configuration["GoogleTagManager:ContainerId"];


### PR DESCRIPTION
## Context

Make sure that the back link is not shown if there is no link set

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1035

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**