### PR TITLE
NTP-1040: UI changes and tidy up CYA page

### DIFF
--- a/Application/Common/Models/Enquiry/Build/CheckYourAnswersModel.cs
+++ b/Application/Common/Models/Enquiry/Build/CheckYourAnswersModel.cs
@@ -5,6 +5,7 @@ namespace Application.Common.Models.Enquiry.Build;
 public record CheckYourAnswersModel : EnquiryBuildModel
 {
     public Dictionary<KeyStage, List<Subject>>? KeyStageSubjects { get; set; }
+    public bool HasKeyStageSubjects { get; set; }
     public string? LocalAuthorityDistrictName { get; set; }
     public bool ConfirmTermsAndConditions { get; set; }
 }

--- a/Application/Constants/StringConstants.cs
+++ b/Application/Constants/StringConstants.cs
@@ -29,6 +29,8 @@
 
         public const string NotSpecified = "Not specified";
 
+        public const string IsRequiredLabel = "This field is required";
+
         public const string EnquirerEmail = "EnquirerEmail";
 
         public const string EnquiryTuitionType = "EnquiryTuitionType";

--- a/Application/Validators/Enquiry/Build/CheckYourAnswersModelValidator.cs
+++ b/Application/Validators/Enquiry/Build/CheckYourAnswersModelValidator.cs
@@ -13,18 +13,13 @@ public class CheckYourAnswersModelValidator : AbstractValidator<CheckYourAnswers
             .NotEmpty()
             .WithMessage("Enter a postcode");
 
-        //TODO - Key stages and subjects can be cleared on the search pages - how does that flow work?
-        RuleFor(m => m.KeyStages)
-            .NotEmpty()
-            .WithMessage("Select at least one key stage");
-
-        RuleFor(m => m.Subjects)
-            .NotEmpty()
-            .WithMessage("Select the subject or subjects");
+        RuleFor(m => m.HasKeyStageSubjects)
+            .NotEqual(false)
+            .WithMessage("Select at least one key stage and related subject");
 
         RuleFor(m => m.TuitionType)
             .NotEmpty()
-            .WithMessage("Enter a type of tuition");
+            .WithMessage("Select a tuition type option");
 
         RuleFor(request => request.Email).NotEmpty().WithMessage("Enter an email address")
             .Matches(StringConstants.EmailRegExp).WithMessage("You must enter an email address in the correct format");

--- a/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml
+++ b/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml
@@ -1,138 +1,143 @@
 @page
 @model UI.Pages.Enquiry.Build.CheckYourAnswers
 @{ 
-    ViewData["Title"] = "Check your answers";
-    ViewData["BackLinkHref"] = $"/enquiry/build/additional-information?{((Model.Data with { From = null }).ToQueryString())}";
+  ViewData["Title"] = "Check your answers";
+  ViewData["BackLinkHref"] = $"/enquiry/build/additional-information?{((Model.Data with { From = null }).ToQueryString())}";
+  ViewData["IncludePrintPage"] = true;
 }
-
-<div class="govuk-grid-row app-print-hide">
-    <div class="govuk-grid-column-full">
-
-        <govuk-error-summary>
-            <govuk-error-summary-item asp-for="Data.KeyStages" />
-            <govuk-error-summary-item asp-for="Data.Subjects" />
-            <govuk-error-summary-item asp-for="Data.TuitionType" />
-            <govuk-error-summary-item asp-for="Data.Email" />
-            <govuk-error-summary-item asp-for="Data.TutoringLogistics" />
-            <govuk-error-summary-item asp-for="Data.SENDRequirements" />
-            <govuk-error-summary-item asp-for="Data.AdditionalInformation" />
-            <govuk-error-summary-item asp-for="Data.ConfirmTermsAndConditions" />
-        </govuk-error-summary>
-
-        <span show-if="!string.IsNullOrWhiteSpace(Model.Data.LocalAuthorityDistrictName)" class="govuk-caption-l">Enquiry for <strong>@Model.Data.LocalAuthorityDistrictName</strong></span>
-        <h1 class="govuk-heading-l">
-            <span>Check your answers</span>
-        </h1>
-    </div>
-</div>
-
-<div class="govuk-width-container">
+<form method="post">
+  <govuk-error-summary show-if="!Model.ModelState.IsValid && Model.Data.ConfirmTermsAndConditions">
+    <govuk-error-summary-item asp-for="Data.HasKeyStageSubjects" />
+    <govuk-error-summary-item asp-for="Data.TuitionType" />
+    <govuk-error-summary-item asp-for="Data.Email" />
+    <govuk-error-summary-item asp-for="Data.TutoringLogistics" />
+    <govuk-error-summary-item asp-for="Data.SENDRequirements" />
+    <govuk-error-summary-item asp-for="Data.AdditionalInformation" />
+  </govuk-error-summary>
   <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <span show-if="!string.IsNullOrWhiteSpace(Model.Data.LocalAuthorityDistrictName)" class="govuk-caption-l">Enquiry for <strong>@Model.Data.LocalAuthorityDistrictName</strong></span>
+      <h1 class="govuk-heading-l">
+        <span>Check your answers</span>
+      </h1>
+    </div>
+  </div>
+
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
         <p class="govuk-body">
           Your email will not be shared with tuition partners
         </p>
-        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Key stages and subjects
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <ul class="govuk-list govuk-list-bullets-mobile-view">
-              @foreach (var item in @Model.Data?.KeyStageSubjects!)
+        <govuk-summary-list class="govuk-!-margin-bottom-9">
+          <govuk-summary-list-row>
+            <govuk-summary-list-row-key>
+              <div asp-validation-group-for="Data.HasKeyStageSubjects">
+                Key stages and subjects
+              </div>
+            </govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>
+              @if (!@Model.Data!.HasKeyStageSubjects)
               {
-                <li>@(item.Key.DisplayName()) - @(item.Value.Select(x => x.DisplayName()).OrderBy(x => x).DisplayList())</li>
+                <span>@StringConstants.IsRequiredLabel</span>
               }
+              else
+              {
+              <ul class="govuk-list govuk-list-bullets-mobile-view">
+                @foreach (var item in @Model.Data?.KeyStageSubjects!)
+                {
+                  <li>@(item.Key.DisplayName()) - @(item.Value.Select(x => x.DisplayName()).OrderBy(x => x).DisplayList())</li>
+                }
               </ul>
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/which-key-stages?@((Model.Data with { From = ReferrerList.CheckYourAnswers }).ToQueryString())">
-                Change<span class="govuk-visually-hidden"> key stage and subjects</span>
-              </a>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Type of tuition
-            </dt>
-            <dd class="govuk-summary-list__value">
-              @Model.Data!.TuitionType?.DisplayName()
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/which-tuition-types?@((Model.Data with { From = ReferrerList.CheckYourAnswers }).ToQueryString())">
-                Change<span class="govuk-visually-hidden"> type of tuition</span>
-              </a>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Email address
-            </dt>
-            <dd class="govuk-summary-list__value">
+              }
+            </govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+              <govuk-summary-list-row-action asp-page="/WhichKeyStages" asp-all-route-data="@(Model.Data with { From = ReferrerList.CheckYourAnswers }).ToRouteData()" visually-hidden-text="key stage and subjects">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+          </govuk-summary-list-row>
+          <govuk-summary-list-row>
+            <govuk-summary-list-row-key>
+              <div asp-validation-group-for="Data.TuitionType">
+                Type of tuition
+              </div>
+            </govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>
+              @if (@Model.Data!.TuitionType == null)
+              {
+                <span>@StringConstants.IsRequiredLabel</span>
+              }
+              else
+              {
+                @Model.Data!.TuitionType?.DisplayName()
+              }
+            </govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+              <govuk-summary-list-row-action asp-page="/WhichTuitionTypes" asp-all-route-data="@(Model.Data with { From = ReferrerList.CheckYourAnswers }).ToRouteData()" visually-hidden-text="type of tuition">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+          </govuk-summary-list-row>
+          <govuk-summary-list-row>
+            <govuk-summary-list-row-key>
+              <div asp-validation-group-for="Data.Email">
+                Email address
+              </div>
+            </govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>
               @Model.Data.Email
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/enquiry/build/enquirer-email?@((Model.Data with { From = ReferrerList.CheckYourAnswers }).ToQueryString())#Data_Email">
-                Change<span class="govuk-visually-hidden"> email address</span>
-              </a>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Tuition plan
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <span class="display-pre-wrap">@Model.Data!.TutoringLogistics</span>
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/enquiry/build/tutoring-logistics?@((Model.Data with { From = ReferrerList.CheckYourAnswers }).ToQueryString())#Data_TutoringLogistics">
-                Change<span class="govuk-visually-hidden"> what type of tuition plan do you need</span>
-              </a>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-                SEND
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <span class="display-pre-wrap">@(string.IsNullOrWhiteSpace(Model.Data.SENDRequirements) ? StringConstants.NotSpecified : Model.Data.SENDRequirements)</span>
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/enquiry/build/send-requirements?@((Model.Data with { From = ReferrerList.CheckYourAnswers }).ToQueryString())#Data_SENDRequirements">
-                Change<span class="govuk-visually-hidden"> if you need tuition partners who can support pupils with SEND</span>
-              </a>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Other
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <span class="display-pre-wrap">@(string.IsNullOrWhiteSpace(Model.Data.AdditionalInformation) ? StringConstants.NotSpecified : Model.Data.AdditionalInformation)</span>
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/enquiry/build/additional-information?@((Model.Data with { From = ReferrerList.CheckYourAnswers }).ToQueryString())#Data_AdditionalInformation">
-                Change<span class="govuk-visually-hidden"> anything else that you want tuition partners to consider</span>
-              </a>
-            </dd>
-          </div>
-        </dl> 
-        <form method="post" class="cya-form">
-          <govuk-checkboxes asp-for="Data.ConfirmTermsAndConditions" class="t-and-c-checkbox">
-            <govuk-checkboxes-item id="Data_ConfirmTermsAndConditions" value="True" checked="@Model.Data.ConfirmTermsAndConditions">
-              I confirm that I have not included any information that would allow anyone to identify pupils, such as names or specific characteristics.
-            </govuk-checkboxes-item>
-          </govuk-checkboxes>
-          <button class="govuk-button" data-module="govuk-button">
-            Send enquiry
-          </button>
-          <input asp-for="Data.LocalAuthorityDistrictName" type="hidden" />
-          <input asp-for="Data.Email" type="hidden" />
-          <input asp-for="Data.TutoringLogistics" type="hidden" />
-          <input asp-for="Data.SENDRequirements" type="hidden" />
-          <input asp-for="Data.AdditionalInformation" type="hidden" />
-          <partial name="_SearchModelHiddenInputs" model="@Model.Data" />
-        </form>
+            </govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+              <govuk-summary-list-row-action asp-page="EnquirerEmail" asp-all-route-data="@(Model.Data with { From = ReferrerList.CheckYourAnswers }).ToRouteData()" asp-fragment="Data_Email" visually-hidden-text="email address">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+          </govuk-summary-list-row>
+          <govuk-summary-list-row>
+            <govuk-summary-list-row-key>
+              <div asp-validation-group-for="Data.TutoringLogistics">
+                Tuition plan
+              </div>
+            </govuk-summary-list-row-key>
+            <govuk-summary-list-row-value class="display-pre-wrap">@Model.Data!.TutoringLogistics</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+              <govuk-summary-list-row-action asp-page="TutoringLogistics" asp-all-route-data="@(Model.Data with { From = ReferrerList.CheckYourAnswers }).ToRouteData()" asp-fragment="Data_TutoringLogistics" visually-hidden-text="what type of tuition plan do you need">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+          </govuk-summary-list-row>
+          <govuk-summary-list-row>
+            <govuk-summary-list-row-key>
+              <div asp-validation-group-for="Data.SENDRequirements">
+                SEND requirements
+              </div>
+            </govuk-summary-list-row-key>
+            <govuk-summary-list-row-value class="display-pre-wrap">@(string.IsNullOrWhiteSpace(Model.Data.SENDRequirements) ? StringConstants.NotSpecified : Model.Data.SENDRequirements)</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+              <govuk-summary-list-row-action asp-page="SENDRequirements" asp-all-route-data="@(Model.Data with { From = ReferrerList.CheckYourAnswers }).ToRouteData()" asp-fragment="Data_SENDRequirements" visually-hidden-text="if you need tuition partners who can support pupils with SEND">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+          </govuk-summary-list-row>
+          <govuk-summary-list-row>
+            <govuk-summary-list-row-key>
+              <div asp-validation-group-for="Data.AdditionalInformation">
+                Other tuition requirements
+              </div>
+            </govuk-summary-list-row-key>
+            <govuk-summary-list-row-value class="display-pre-wrap">@(string.IsNullOrWhiteSpace(Model.Data.AdditionalInformation) ? StringConstants.NotSpecified : Model.Data.AdditionalInformation)</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+              <govuk-summary-list-row-action asp-page="AdditionalInformation" asp-all-route-data="@(Model.Data with { From = ReferrerList.CheckYourAnswers }).ToRouteData()" asp-fragment="Data_AdditionalInformation" visually-hidden-text="anything else that you want tuition partners to consider">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+          </govuk-summary-list-row>
+        </govuk-summary-list>
+        <govuk-checkboxes asp-for="Data.ConfirmTermsAndConditions" class="t-and-c-checkbox">
+          <govuk-checkboxes-item id="Data_ConfirmTermsAndConditions" value="True" checked="@Model.Data.ConfirmTermsAndConditions">
+            I confirm that I have not included any information that would allow anyone to identify pupils, such as names or specific characteristics.
+          </govuk-checkboxes-item>
+        </govuk-checkboxes>
+        <button class="govuk-button" data-module="govuk-button">
+          Send enquiry
+        </button>
+        <input asp-for="Data.LocalAuthorityDistrictName" type="hidden" />
+        <input asp-for="Data.HasKeyStageSubjects" type="hidden" />
+        <input asp-for="Data.Email" type="hidden" />
+        <input asp-for="Data.TutoringLogistics" type="hidden" />
+        <input asp-for="Data.SENDRequirements" type="hidden" />
+        <input asp-for="Data.AdditionalInformation" type="hidden" />
+        <partial name="_SearchModelHiddenInputs" model="@Model.Data" />        
       </div>
+    </div>
   </div>
-</div>
+</form>

--- a/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
+++ b/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
@@ -40,6 +40,7 @@ public class CheckYourAnswers : PageModel
         //  errors when calling _mediator
 
         Data.KeyStageSubjects = GetKeyStageSubject(Data.Subjects);
+        Data.HasKeyStageSubjects = Data.KeyStageSubjects.Any();
 
         if (!string.IsNullOrWhiteSpace(Data.Postcode))
         {

--- a/UI/Pages/Shared/_CookiesOptionBanner.cshtml
+++ b/UI/Pages/Shared/_CookiesOptionBanner.cshtml
@@ -31,15 +31,15 @@
 
             <div class="govuk-button-group">
                 <a data-testid="accept-cookies" value="accept" type="button" name="cookies" class="govuk-button"
-               data-module="govuk-button" asp-page="@nameof(Cookies)" asp-route-consent="true">
+               data-module="govuk-button" asp-page="\Cookies" asp-route-consent="true">
                     Accept analytics cookies
 
                 </a>
                 <a button value="reject" data-testid="reject-cookies" type="button" name="cookies" class="govuk-button"
-               data-module="govuk-button" asp-page="@nameof(Cookies)" asp-route-consent="false">
+               data-module="govuk-button" asp-page="\Cookies" asp-route-consent="false">
                     Reject analytics cookies
                 </a>
-                <a class="govuk-link" data-testid="view-cookies" a asp-page="@nameof(Cookies)">View cookies</a>
+                <a class="govuk-link" data-testid="view-cookies" a asp-page="\Cookies">View cookies</a>
             </div>
         </div>
     </div>

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -201,7 +201,7 @@ height="0" width="0" class="govuk-!-display-none"></iframe></noscript>
         <div class="govuk-breadcrumbs">
           <ol class="govuk-breadcrumbs__list">
             <li class="govuk-breadcrumbs__list-item">
-              <a asp-page="@nameof(Index)" class="govuk-breadcrumbs__link" data-testid="home-link" >Home</a>
+              <a asp-page="\" class="govuk-breadcrumbs__link" data-testid="home-link" >Home</a>
             </li>
           </ol>
         </div>
@@ -246,7 +246,7 @@ height="0" width="0" class="govuk-!-display-none"></iframe></noscript>
                                data-testid="accessibility-link">Accessibility</a>
                         </li>
                         <li class="govuk-footer__inline-list-item">
-                            <a asp-page="@nameof(Cookies)" asp-route-consent="" class="govuk-footer__link"
+                            <a asp-page="\Cookies" asp-route-consent="" class="govuk-footer__link"
                                data-testid="view-footer-cookies">Cookies</a>
                         </li>
                         <li class="govuk-footer__inline-list-item">

--- a/UI/src/sass/enquiry-build.scss
+++ b/UI/src/sass/enquiry-build.scss
@@ -1,7 +1,3 @@
 ﻿.t-and-c-checkbox label {
   padding-top: 0px;
 }
-
-.cya-form .govuk-error-summary {
-  display: none;
-}

--- a/UI/src/sass/enquiry-build.scss
+++ b/UI/src/sass/enquiry-build.scss
@@ -1,3 +1,7 @@
 ﻿.t-and-c-checkbox label {
   padding-top: 0px;
 }
+
+.cya-form .govuk-error-summary {
+    display: none;
+}


### PR DESCRIPTION
UI changes in CYA as in ticket - label renames, show new label names, show new error messages for missing key stage, subjects and tuition type and show message in place of missing data.
Code tidy up on CYA page to use gov components
Ensure that only 1 error summary shown at a time on UI due to a11y issues

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1040

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**