### PR TITLE
NTP-1037: View a response

### DIFF
--- a/Application/Common/Models/Enquiry/Respond/EnquirerViewResponseModel.cs
+++ b/Application/Common/Models/Enquiry/Respond/EnquirerViewResponseModel.cs
@@ -1,11 +1,7 @@
 namespace Application.Common.Models.Enquiry.Respond;
 
-public record EnquirerViewResponseModel
+public record EnquirerViewResponseModel : EnquiryResponseModel
 {
-    public string TuitionPartnerName { get; set; } = null!;
-
-    public string EnquiryResponseText { get; set; } = null!;
-
     public string EnquirerViewAllResponsesToken { get; set; } = null!;
 
 }

--- a/Application/Extensions/IntExtensions.cs
+++ b/Application/Extensions/IntExtensions.cs
@@ -1,0 +1,16 @@
+namespace Application.Extensions;
+using TuitionType = Domain.Enums.TuitionType;
+
+public static class IntExtensions
+{
+    public static string GetTuitionTypeName(this int? tuitionTypeId)
+    {
+        return tuitionTypeId switch
+        {
+            null => TuitionType.Any.DisplayName(),
+            (int)TuitionType.Online => TuitionType.Online.DisplayName(),
+            (int)TuitionType.InSchool => TuitionType.InSchool.DisplayName(),
+            _ => TuitionType.Any.DisplayName()
+        };
+    }
+}

--- a/Infrastructure/Repositories/EnquiryRepository.cs
+++ b/Infrastructure/Repositories/EnquiryRepository.cs
@@ -43,7 +43,7 @@ public class EnquiryRepository : GenericRepository<Enquiry>, IEnquiryRepository
             .Select(x => $"{x.KeyStage.Name}: {x.Subject.Name}")
             .GroupByKeyAndConcatenateValues();
 
-        var tuitionTypeName = GetTuitionTypeName(enquiry.TuitionTypeId);
+
 
         var result = new EnquirerViewAllResponsesModel
         {
@@ -52,7 +52,7 @@ public class EnquiryRepository : GenericRepository<Enquiry>, IEnquiryRepository
             SupportReferenceNumber = enquiry.SupportReferenceNumber,
             NumberOfTpEnquiryWasSent = enquiry.TuitionPartnerEnquiry.Count,
             KeyStageSubjects = keyStageSubjects,
-            TuitionTypeName = tuitionTypeName,
+            TuitionTypeName = enquiry.TuitionTypeId.GetTuitionTypeName(),
             SENDRequirements = enquiry.SENDRequirements ?? string.Empty,
             AdditionalInformation = enquiry.AdditionalInformation ?? string.Empty,
             EnquiryCreatedDateTime = enquiry.CreatedAt,
@@ -75,16 +75,5 @@ public class EnquiryRepository : GenericRepository<Enquiry>, IEnquiryRepository
             .OrderByDescending(x => x.EnquiryResponseDate).ToList();
         result.EnquirerViewResponses = orderByReceivedEnquirerViewResponses;
         return result;
-    }
-
-    private string GetTuitionTypeName(int? tuitionTypeId)
-    {
-        return tuitionTypeId switch
-        {
-            null => TuitionType.Any.DisplayName(),
-            (int)TuitionType.Online => TuitionType.Online.DisplayName(),
-            (int)TuitionType.InSchool => TuitionType.InSchool.DisplayName(),
-            _ => TuitionType.Any.DisplayName()
-        };
     }
 }

--- a/Infrastructure/Repositories/EnquiryRepository.cs
+++ b/Infrastructure/Repositories/EnquiryRepository.cs
@@ -4,7 +4,6 @@ using Application.Common.Models.Enquiry.Respond;
 using Application.Extensions;
 using Domain;
 using Microsoft.EntityFrameworkCore;
-using TuitionType = Domain.Enums.TuitionType;
 
 namespace Infrastructure.Repositories;
 
@@ -53,8 +52,8 @@ public class EnquiryRepository : GenericRepository<Enquiry>, IEnquiryRepository
             NumberOfTpEnquiryWasSent = enquiry.TuitionPartnerEnquiry.Count,
             KeyStageSubjects = keyStageSubjects,
             TuitionTypeName = enquiry.TuitionTypeId.GetTuitionTypeName(),
-            SENDRequirements = enquiry.SENDRequirements ?? string.Empty,
-            AdditionalInformation = enquiry.AdditionalInformation ?? string.Empty,
+            SENDRequirements = enquiry.SENDRequirements,
+            AdditionalInformation = enquiry.AdditionalInformation,
             EnquiryCreatedDateTime = enquiry.CreatedAt,
             EnquirerViewResponses = new List<EnquirerViewResponseDto>()
         };

--- a/Infrastructure/Repositories/TuitionPartnerEnquiryRepository.cs
+++ b/Infrastructure/Repositories/TuitionPartnerEnquiryRepository.cs
@@ -1,5 +1,6 @@
 using Application.Common.Interfaces.Repositories;
 using Application.Common.Models.Enquiry.Respond;
+using Application.Extensions;
 using Domain;
 using Microsoft.EntityFrameworkCore;
 using MagicLinkType = Domain.Enums.MagicLinkType;
@@ -20,6 +21,11 @@ public class TuitionPartnerEnquiryRepository : GenericRepository<TuitionPartnerE
             .ThenInclude(m => m.MagicLinks)
             .Include(e => e.EnquiryResponse)
             .Include(x => x.TuitionPartner)
+            .Include(e => e.Enquiry.KeyStageSubjectEnquiry)
+            .ThenInclude(ks => ks.KeyStage)
+            .Include(e => e.Enquiry.KeyStageSubjectEnquiry)
+            .ThenInclude(s => s.Subject)
+            .AsSplitQuery()
             .SingleOrDefaultAsync();
 
         if (tuitionPartnerEnquiry == null) return null;
@@ -29,10 +35,27 @@ public class TuitionPartnerEnquiryRepository : GenericRepository<TuitionPartnerE
             .SingleOrDefault(x => x.EnquiryId == enquiryId
                                        && x.MagicLinkTypeId == (int)MagicLinkType.EnquirerViewAllResponses);
 
-        var result = new EnquirerViewResponseModel()
+        var enquiry = tuitionPartnerEnquiry.Enquiry;
+        var enquiryResponse = tuitionPartnerEnquiry.EnquiryResponse!;
+
+        var keyStageSubjects = enquiry
+            .KeyStageSubjectEnquiry
+            .Select(x => $"{x.KeyStage.Name}: {x.Subject.Name}")
+            .GroupByKeyAndConcatenateValues();
+
+        var result = new EnquirerViewResponseModel
         {
             TuitionPartnerName = tuitionPartnerEnquiry.TuitionPartner.Name,
-            EnquiryResponseText = tuitionPartnerEnquiry.EnquiryResponse!.TutoringLogisticsText,
+            EnquiryKeyStageSubjects = keyStageSubjects,
+            KeyStageAndSubjectsText = enquiryResponse.KeyStageAndSubjectsText!,
+            EnquiryTuitionType = enquiry.TuitionTypeId.GetTuitionTypeName(),
+            TuitionTypeText = enquiryResponse.TuitionTypeText,
+            EnquiryTutoringLogistics = enquiry.TutoringLogistics,
+            TutoringLogisticsText = enquiryResponse.TutoringLogisticsText,
+            EnquirySENDRequirements = enquiry.SENDRequirements,
+            SENDRequirementsText = enquiryResponse.SENDRequirementsText,
+            EnquiryAdditionalInformation = enquiry.AdditionalInformation,
+            AdditionalInformationText = enquiryResponse.AdditionalInformationText,
             EnquirerViewAllResponsesToken = enquirerViewAllResponsesMagicLinkToken!.Token
         };
 

--- a/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
+++ b/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
@@ -2,7 +2,7 @@
 @model UI.Pages.Enquiry.Respond.AllEnquirerResponses
 @using GovUk.Frontend.AspNetCore.TagHelpers
 @{
-    ViewData["Title"] = "Enquirer View All Responses";
+    ViewData["Title"] = "View all responses";
     ViewData["IncludePrintPage"] = true;
 
     var numberOfTpEnquiryResponseReceived = !Model.Data.EnquirerViewResponses.Any()

--- a/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
+++ b/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
@@ -3,7 +3,6 @@
 @using GovUk.Frontend.AspNetCore.TagHelpers
 @{
     ViewData["Title"] = "Enquirer View All Responses";
-    ViewData["BackLinkHref"] = "/";
     ViewData["IncludePrintPage"] = true;
 
     var numberOfTpEnquiryResponseReceived = !Model.Data.EnquirerViewResponses.Any()
@@ -18,10 +17,10 @@
         </govuk-error-summary>
 
 
-        <p class="govuk-body">
-            <span>@Model.Data.SupportReferenceNumber</span>
+        <p class="govuk-body govuk-!-margin-bottom-0">
+            <span class="govuk-caption-l">@Model.Data.SupportReferenceNumber</span>
         </p>
-        <h1 class="govuk-heading-l">
+        <h1 class="govuk-heading-l govuk-!-padding-top-0">
             <span>View responses to your tuition enquiry</span>
         </h1>
         <div class="govuk-inset-text">
@@ -31,7 +30,7 @@
         <h3 class="govuk-heading-s">
             <span>Your tuition enquiry summary</span>
         </h3>
-        <p class="govuk-body">Created on <span>@Model.Data.EnquiryCreatedDateTime.ToString("h:mm tt dddd, MMMM dd, yyyy")</span></p>
+        <p class="govuk-body">Created on <span>@Model.Data.EnquiryCreatedDateTime.ToString("h:mmtt 'on' dddd d MMMM")</span></p>
 
         <govuk-details open="false">
             <govuk-details-summary>
@@ -47,11 +46,26 @@
                         </li>
                     }
                     <li>
-                        The type of tuition plan needed: @Model.Data?.TutoringLogistics
+                        @Model.Data.TuitionTypeName
                     </li>
                     <li>
-                        Tuition type: @Model.Data?.TuitionTypeName
+                        <span class="display-pre-wrap">@Model.Data.TutoringLogistics</span>
                     </li>
+                    
+                    @if (!string.IsNullOrWhiteSpace(Model.Data.SENDRequirements))
+                    {
+                        <li>
+                            <span class="display-pre-wrap">@Model.Data.SENDRequirements</span>
+                        </li>
+                    }
+
+                    @if (!string.IsNullOrWhiteSpace(Model.Data.AdditionalInformation))
+                    {
+                        <li>
+                            <span class="display-pre-wrap">@Model.Data.AdditionalInformation</span>
+                        </li>
+                    }
+                    
                 </ul>
             </govuk-details-text>
         </govuk-details>
@@ -65,7 +79,7 @@
 
 <div class="govuk-inset-text">
     <p class="govuk-body"><strong> @numberOfTpEnquiryResponseReceived out of @Model.Data.NumberOfTpEnquiryWasSent tuition partners </strong> have responded at the moment.</p>
-    <p class="govuk-body">We have asked tuition partners to respond within 5 days of creating this enquiry.</p>
+    <p class="govuk-body">We have asked tuition partners to respond within 7 days of creating this enquiry.</p>
     <p class="govuk-body">You should <strong>contact up to 3 tuition partners</strong> to discuss your budget and tuition needs.</p>
 </div>
 
@@ -76,8 +90,8 @@
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col"> Date </th>
-            <th class="govuk-table__header" scope="col"> Tuition Partner </th>
-            <th class="govuk-table__header" scope="col"> Their Response </th>
+            <th class="govuk-table__header" scope="col"> Tuition partner </th>
+            <th class="govuk-table__header" scope="col"> Their response </th>
         </tr>
         </thead>
         <tbody class="govuk-table__body">

--- a/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
+++ b/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
@@ -27,9 +27,9 @@
             You should bookmark this page for your future reference and quicker access to your enquiry.
         </div>
 
-        <h3 class="govuk-heading-s">
+        <h2 class="govuk-heading-s">
             <span>Your tuition enquiry summary</span>
-        </h3>
+        </h2>
         <p class="govuk-body">Created on <span>@Model.Data.EnquiryCreatedDateTime.ToString("h:mmtt 'on' dddd d MMMM")</span></p>
 
         <govuk-details open="false">
@@ -73,9 +73,9 @@
     </div>
 </div>
 
-<h3 class="govuk-heading-s">
+<h2 class="govuk-heading-s">
     <span>All tuition partner responses</span>
-</h3>
+</h2>
 
 <div class="govuk-inset-text">
     <p class="govuk-body"><strong> @numberOfTpEnquiryResponseReceived out of @Model.Data.NumberOfTpEnquiryWasSent tuition partners </strong> have responded at the moment.</p>

--- a/UI/Pages/Enquiry/Respond/CheckYourAnswers.cshtml
+++ b/UI/Pages/Enquiry/Respond/CheckYourAnswers.cshtml
@@ -79,45 +79,44 @@
               </a>
             </dd>
           </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              SEND requirements:                
-              <p class="govuk-body">
-              <span class="display-pre-wrap">@(string.IsNullOrWhiteSpace(Model.Data.EnquirySENDRequirements) 
-                                               ? StringConstants.NotSpecified : Model.Data.EnquirySENDRequirements)</span></p>
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <span class="display-pre-wrap">@(string.IsNullOrWhiteSpace(Model.Data.SENDRequirementsText) ? StringConstants.NotSpecified : Model.Data.SENDRequirementsText)</span>
-            </dd>
-            @if (!string.IsNullOrWhiteSpace(Model.Data.EnquirySENDRequirements))
-            {
+          @if (!string.IsNullOrWhiteSpace(Model.Data.EnquirySENDRequirements))
+          {
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                SEND requirements:                
+                <p class="govuk-body">
+                  <span class="display-pre-wrap">@Model.Data.EnquirySENDRequirements</span></p>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <span class="display-pre-wrap">@(string.IsNullOrWhiteSpace(Model.Data.SENDRequirementsText) 
+                                                 ? StringConstants.NotSpecified : Model.Data.SENDRequirementsText)</span>
+              </dd>
               <dd class="govuk-summary-list__actions">
                 <a class="govuk-link" href=@backUrl>
                   Change<span class="govuk-visually-hidden"> SEND requirements</span>
                 </a>
               </dd>
-            }
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Other school considerations:
-              <p class="govuk-body">
-                <span class="display-pre-wrap">@(string.IsNullOrWhiteSpace(Model.Data.EnquiryAdditionalInformation)
-                    ? StringConstants.NotSpecified : Model.Data.EnquiryAdditionalInformation)</span></p>
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <p class="govuk-body"> <span class="display-pre-wrap">@(string.IsNullOrWhiteSpace(Model.Data.AdditionalInformationText) 
-                                                                      ? StringConstants.NotSpecified : Model.Data.AdditionalInformationText)</span></p>
-            </dd>
-            @if (!string.IsNullOrWhiteSpace(Model.Data.EnquiryAdditionalInformation))
-            {
+            </div>
+          }
+          @if (!string.IsNullOrWhiteSpace(Model.Data.EnquiryAdditionalInformation))
+          {
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Other school considerations:
+                <p class="govuk-body">
+                  <span class="display-pre-wrap">@Model.Data.EnquiryAdditionalInformation</span></p>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <span class="display-pre-wrap">@(string.IsNullOrWhiteSpace(Model.Data.AdditionalInformationText) 
+                                                                        ? StringConstants.NotSpecified : Model.Data.AdditionalInformationText)</span>
+              </dd>
               <dd class="govuk-summary-list__actions">
                 <a class="govuk-link" href=@backUrl>
                   Change<span class="govuk-visually-hidden"> other school considerations</span>
                 </a>
               </dd>
-            }
-          </div>
+            </div>
+          }
         </dl>
         <form method="post">
           <input type="hidden" name="answers-checked" value="true">

--- a/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml
+++ b/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml
@@ -4,13 +4,14 @@
     var baseServiceUrl = Request.GetBaseServiceUrl();
     var backLink = $"{baseServiceUrl}/enquiry/respond/all-enquirer-responses?token={@Model.Data.EnquirerViewAllResponsesToken}";
     
-    ViewData["Title"] = "Enquirer View Response";
+    ViewData["Title"] = "View a response";
+    ViewData["BackLinkText"] = "Back to view all your responses";
     ViewData["BackLinkHref"] = backLink;
     ViewData["IncludePrintPage"] = true;
 }
 
 
-<div class="govuk-grid-row app-print-hide">
+<div class="govuk-grid-row app-print-hide" xmlns="http://www.w3.org/1999/html">
     <div class="govuk-grid-column-full">
 
         <govuk-error-summary>
@@ -18,19 +19,182 @@
         </govuk-error-summary>
         
         <h1 class="govuk-heading-l">
-            <span>View response from @Model.Data.TuitionPartnerName</span>
+            <span>View @Model.Data.TuitionPartnerName’s <br/> response</span>
         </h1>
 
+        <p class="govuk-body">
+            You can view and compare their response to your tuition requirements.
+            This will help you decide if its a good match to <br/> your pupils' needs.
+        </p>
+        
+        <p class="govuk-body">
+            After you’ve viewed their response, you can either:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+
+            <li>
+                contact them to discuss your enquiry such as budget, funding, alternative arrangements and tutors available.
+            </li>
+
+            <li>
+                return to your enquiry list to view other tuition partner’s responses
+            </li>
+        </ul>
     </div>
 </div>
 
-<dl class="govuk-summary-list">
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Enquiry Response
-    </dt>
-    <dd class="govuk-summary-list__value">
-      @Model.Data.EnquiryResponseText
-    </dd>
-  </div>
-</dl>
+<hr class="govuk-section-break govuk-section-break--visible govuk-!-padding-bottom-0 govuk-!-margin-top-0 govuk-!-margin-bottom-7">
+
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <h2 class="govuk-heading-l govuk-!-padding-top-0">
+                Their response to your enquiry
+            </h2>
+
+            <h3 class="govuk-heading-m">
+                <span>Key stage and subjects:</span>
+            </h3>
+        
+            <p class="govuk-body govuk-!-margin-bottom-0">
+                <strong>Your requirement</strong>
+            </p>
+
+            <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
+                @foreach (var item in Model.Data.EnquiryKeyStageSubjects)
+                {
+                    <li>
+                        @item
+                    </li>
+                }
+            </ul>
+
+            <p class="govuk-body govuk-!-margin-bottom-0">
+                <strong>@Model.Data.TuitionPartnerName’s response</strong>
+            </p>
+            <p class="govuk-body">
+                <span class="display-pre-wrap">@Model.Data.KeyStageAndSubjectsText</span>
+            </p>
+
+            <h3 class="govuk-heading-m">
+                <span>Tuition type:</span>
+            </h3>
+
+            <p class="govuk-body govuk-!-margin-bottom-0">
+                <strong>Your requirement</strong>
+            </p>
+            <p class="govuk-body">
+                @Model.Data.EnquiryTuitionType
+            </p>
+
+            <p class="govuk-body govuk-!-margin-bottom-0">
+                <strong>@Model.Data.TuitionPartnerName’s response</strong>
+            </p>
+            <p class="govuk-body">
+                <span class="display-pre-wrap">@Model.Data.TuitionTypeText</span>
+            </p>
+
+            <h3 class="govuk-heading-m">
+                <span>Tuition plan:</span>
+            </h3>
+            <p class="govuk-body govuk-!-margin-bottom-0">
+                <strong>Your requirement</strong>
+            </p>
+            <govuk-details open="false">
+                <govuk-details-summary>
+                    View your tuition requirement
+                </govuk-details-summary>
+                <govuk-details-text>
+                    <span class="display-pre-wrap">@Model.Data.EnquiryTutoringLogistics</span>
+                </govuk-details-text>
+            </govuk-details>
+            <p class="govuk-body govuk-!-margin-bottom-0">
+                <strong>@Model.Data.TuitionPartnerName’s response</strong>
+            </p>
+            <p class="govuk-body">
+                <span class="display-pre-wrap">@Model.Data.TutoringLogisticsText</span>
+            </p>
+
+            @if (!string.IsNullOrWhiteSpace(Model.Data.EnquirySENDRequirements))
+            {
+                <h3 class="govuk-heading-m">
+                    <span>Can you support the following SEND requirements:</span>
+                </h3>
+                <p class="govuk-body govuk-!-margin-bottom-0">
+                    <strong>Your requirement</strong>
+                </p>
+                <govuk-details open="false">
+                    <govuk-details-summary>
+                        View your tuition requirement
+                    </govuk-details-summary>
+                    <govuk-details-text>
+                        <span class="display-pre-wrap">@Model.Data.EnquirySENDRequirements</span>
+                    </govuk-details-text>
+                </govuk-details>
+                <p class="govuk-body govuk-!-margin-bottom-0">
+                    <strong>@Model.Data.TuitionPartnerName’s response</strong>
+                </p>
+                <p class="govuk-body">
+                    <span class="display-pre-wrap">@Model.Data.SENDRequirementsText</span>
+                </p>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(Model.Data.EnquiryAdditionalInformation))
+            {
+                <h3 class="govuk-heading-m">
+                    <span>Other tuition considerations?:</span>
+                </h3>
+                <p class="govuk-body govuk-!-margin-bottom-0">
+                    <strong>Your requirement</strong>
+                </p>
+                <govuk-details open="false">
+                    <govuk-details-summary>
+                        View your tuition requirement
+                    </govuk-details-summary>
+                    <govuk-details-text>
+                        <span class="display-pre-wrap">@Model.Data.EnquiryAdditionalInformation</span>
+                    </govuk-details-text>
+                </govuk-details>
+                <p class="govuk-body govuk-!-margin-bottom-0">
+                    <strong>@Model.Data.TuitionPartnerName’s response</strong>
+                </p>
+                <p class="govuk-body">
+                    <span class="display-pre-wrap">@Model.Data.AdditionalInformationText</span>
+                </p>
+            }
+        </div>
+    </div>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-!-padding-bottom-0 govuk-!-margin-top-0 govuk-!-margin-bottom-7">
+
+<div class="govuk-width-container">
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h2 class="govuk-heading-l govuk-!-padding-top-0">
+            What you can do next
+        </h2>
+        <p class="govuk-body">
+            <strong>If you are interested in working with this tuition partner</strong>
+        </p>
+        <p class="govuk-body">
+            You can contact them to further discuss your pupils' needs. <br/>
+            We will also give you guidance about what information you should give to them. <br/>
+            Even if the tuition partner can’t fully meet all of your tuition requirements, you can still discuss any flexibility.
+        </p>
+        <govuk-button-link href="/">View tuition partner’s contact details</govuk-button-link>
+
+        <p class="govuk-body">
+            <strong>If you do not want to contact this tuition partner</strong>
+        </p>
+
+        <p class="govuk-body">
+            Select ‘cancel’ to return to the enquiry list. <br/>
+            This will let you view responses from other tuition partners. <br/>
+            We will not inform [tuition_partner_name] that you have chosen not to contact them. <br/>
+        </p>
+        
+        <a href="@backLink" class="govuk-button govuk-button--secondary" data-module="govuk-button">Cancel</a>
+    </div>
+</div>
+</div>

--- a/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml
+++ b/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml
@@ -191,7 +191,7 @@
         <p class="govuk-body">
             Select ‘cancel’ to return to the enquiry list. <br/>
             This will let you view responses from other tuition partners. <br/>
-            We will not inform [tuition_partner_name] that you have chosen not to contact them. <br/>
+            We will not inform @Model.Data.TuitionPartnerName that you have chosen not to contact them. <br/>
         </p>
         
         <a href="@backLink" class="govuk-button govuk-button--secondary" data-module="govuk-button">Cancel</a>

--- a/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml
+++ b/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml
@@ -194,7 +194,9 @@
             We will not inform @Model.Data.TuitionPartnerName that you have chosen not to contact them. <br/>
         </p>
         
-        <a href="@backLink" class="govuk-button govuk-button--secondary" data-module="govuk-button">Cancel</a>
+        <a href="@backLink" class="govuk-link">
+            Cancel
+        </a>
     </div>
 </div>
 </div>

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -10,9 +10,10 @@
     var includeHomeLink = ViewData["IncludeHomeLink"] as bool? == true; 
     var backLinkHref = ViewData["BackLinkHref"] as string; 
     var backLinkText = ViewData["BackLinkText"] as string;
-    backLinkText = backLinkText ?? "Back";
     var includeBackLink = !string.IsNullOrEmpty(backLinkHref);
-    var includePrintPage = includeBackLink && ViewData["IncludePrintPage"] as bool? == true; 
+    backLinkText = backLinkText ?? "Back";
+    
+    var includePrintPage = ViewData["IncludePrintPage"] as bool? == true; 
 
     var containerId = Configuration["GoogleTagManager:ContainerId"];
     var enableGoogleTagManager = !string.IsNullOrWhiteSpace(containerId);
@@ -210,10 +211,12 @@ height="0" width="0" class="govuk-!-display-none"></iframe></noscript>
         @if (includePrintPage)
         {
             <div class="app-print-this-page--container">
-                <div class="app-print-this-page--container-left">
-                    <a href="@backLinkHref" data-testid="back-link" class="govuk-back-link">@backLinkText</a>
-                </div>
-
+                @if (includeBackLink)
+                {
+                    <div class="app-print-this-page--container-left">
+                        <a href="@backLinkHref" data-testid="back-link" class="govuk-back-link">@backLinkText</a>
+                    </div>
+                }
                 <div class="govuk-body app-print-this-page--container-right">
                     <a href="#" class="govuk-link app-print-this-page--link" data-module="print-this-page-link" data-testid="print-this-page-link">Print this page</a>
                 </div>


### PR DESCRIPTION
## Context

With this PR, I have covered the below  tickets:

[https://dfedigital.atlassian.net/browse/NTP-1037](https://dfedigital.atlassian.net/browse/NTP-1037)

[https://dfedigital.atlassian.net/browse/NTP-1036](https://dfedigital.atlassian.net/browse/NTP-1036)

[https://dfedigital.atlassian.net/browse/NTP-1051](https://dfedigital.atlassian.net/browse/NTP-1051)

I have made separate commits to this PR against each ticket work above.

Regarding the NTP-1037 **AC_12_d** "View tuition partner’s contact details" when selected, the button takes the user to the TP contact details page is yet to be implemented, so once the work for the [https://dfedigital.atlassian.net/browse/NTP-1039](https://dfedigital.atlassian.net/browse/NTP-1039) is complete the button needs to be updated accordingly.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

[https://dfedigital.atlassian.net/browse/NTP-1037](https://dfedigital.atlassian.net/browse/NTP-1037)

[https://dfedigital.atlassian.net/browse/NTP-1036](https://dfedigital.atlassian.net/browse/NTP-1036)

[https://dfedigital.atlassian.net/browse/NTP-1051](https://dfedigital.atlassian.net/browse/NTP-1051)

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**