### PR TITLE
NTP-1043: feature flag to turn off enquiry builder

### DIFF
--- a/Infrastructure/Configuration/FeatureFlags.cs
+++ b/Infrastructure/Configuration/FeatureFlags.cs
@@ -1,0 +1,9 @@
+﻿namespace Infrastructure.Configuration;
+
+public class FeatureFlags
+{
+    public const string FeatureFlagsConfigName = "FeatureFlags";
+
+    public bool EnquiryBuilder { get; set; } = true;
+
+}

--- a/Infrastructure/Extensions/ServiceCollectionFeatureFlagExtensions.cs
+++ b/Infrastructure/Extensions/ServiceCollectionFeatureFlagExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Infrastructure.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.Extensions;
+
+public static class ServiceCollectionFeatureFlagExtensions
+{
+    public static IServiceCollection AddFeatureFlagConfig(
+        this IServiceCollection services, IConfiguration config)
+    {
+        services.Configure<FeatureFlags>(
+            config.GetSection(FeatureFlags.FeatureFlagsConfigName));
+
+        return services;
+    }
+}

--- a/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
+++ b/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
@@ -13,13 +13,13 @@ public class CheckYourAnswers : PageModel
     private readonly IHostEnvironment _hostEnvironment;
     private readonly FeatureFlags _featureFlagsConfig;
 
-  public CheckYourAnswers(IMediator mediator, ISessionService sessionService, IHostEnvironment hostEnvironment, IOptions<FeatureFlags> featureFlagsConfig)
+    public CheckYourAnswers(IMediator mediator, ISessionService sessionService, IHostEnvironment hostEnvironment, IOptions<FeatureFlags> featureFlagsConfig)
     {
         _mediator = mediator;
         _sessionService = sessionService;
         _hostEnvironment = hostEnvironment;
         _featureFlagsConfig = featureFlagsConfig.Value;
-  }
+    }
 
     [BindProperty] public CheckYourAnswersModel Data { get; set; } = new();
 

--- a/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
+++ b/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
@@ -1,6 +1,8 @@
 using Application.Common.Interfaces;
 using Application.Common.Models;
 using Application.Common.Models.Enquiry.Build;
+using Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace UI.Pages.Enquiry.Build;
 
@@ -8,11 +10,13 @@ public class CheckYourAnswers : PageModel
 {
     private readonly IMediator _mediator;
     private readonly ISessionService _sessionService;
+    private readonly FeatureFlags _featureFlagsConfig;
 
-    public CheckYourAnswers(IMediator mediator, ISessionService sessionService)
+    public CheckYourAnswers(IMediator mediator, ISessionService sessionService, IOptions<FeatureFlags> featureFlagsConfig)
     {
         _mediator = mediator;
         _sessionService = sessionService;
+        _featureFlagsConfig = featureFlagsConfig.Value;
     }
 
     [BindProperty] public CheckYourAnswersModel Data { get; set; } = new();
@@ -55,6 +59,9 @@ public class CheckYourAnswers : PageModel
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (!_featureFlagsConfig.EnquiryBuilder)
+            throw new InvalidOperationException("User is trying to submit an enquiry when the feature is disabled");
+
         if (!await _sessionService.SessionDataExistsAsync())
             return RedirectToPage("/Session/Timeout");
 

--- a/UI/Pages/Index.cshtml
+++ b/UI/Pages/Index.cshtml
@@ -7,8 +7,27 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+    @if (!Model.IncludeEnquiryBuilder)
+    {
+      <div class="govuk-notification-banner govuk-notification-banner--blue" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        <div class="govuk-body">
+            <p class="govuk-notification-banner__heading">Enquiry builder is temporally unavailable.</p>
+            <p class="govuk-body">You will be able to use this feature later.</p>
+            <p class="govuk-body">You can still contact tuition partners in your area or compare prices.</p>
+        </div>
+      </div>
+    </div>
+    }
         <form method="get">
             <h1 class="govuk-heading-l">Find a tuition partner</h1>
+            @if(Model.IncludeEnquiryBuilder)
+            {
             <p class="govuk-body">
                 Use this service to:
             </p>
@@ -19,13 +38,11 @@
                 <li>
                     compare prices
                 </li>
-                @if(Model.IncludeEnquiryBuilder)
-                {
                 <li>
                     send an enquiry to tuition partners
                 </li>
-                }
             </ul>
+            }
 
             <p class="govuk-body">
                 All tuition partners in the service are quality assured.

--- a/UI/Pages/Index.cshtml
+++ b/UI/Pages/Index.cshtml
@@ -19,9 +19,12 @@
                 <li>
                     compare prices
                 </li>
+                @if(Model.IncludeEnquiryBuilder)
+                {
                 <li>
                     send an enquiry to tuition partners
                 </li>
+                }
             </ul>
 
             <p class="govuk-body">

--- a/UI/Pages/Index.cshtml.cs
+++ b/UI/Pages/Index.cshtml.cs
@@ -1,6 +1,8 @@
 using Application.Common.Interfaces;
 using Application.Common.Models;
 using Domain;
+using Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace UI.Pages;
 
@@ -8,15 +10,18 @@ public partial class Index : PageModel
 {
     private readonly ILogger<Index> _logger;
     private readonly IMediator _mediator;
+    private readonly FeatureFlags _featureFlagsConfig;
 
-    public Index(ILogger<Index> logger, IMediator mediator)
+    public Index(ILogger<Index> logger, IMediator mediator, IOptions<FeatureFlags> featureFlagsConfig)
     {
         _logger = logger;
         _mediator = mediator;
+        _featureFlagsConfig = featureFlagsConfig.Value;
     }
 
     [BindProperty(SupportsGet = true)]
     public Command Data { get; set; } = new Command();
+    public bool IncludeEnquiryBuilder { get; set; } = true;
 
     public record Command : SearchModel, IRequest<Domain.IResult> { }
 
@@ -26,6 +31,8 @@ public partial class Index : PageModel
         // This is not appropriate for this page either when first arriving on this page or using a back link.
         // Therefore clear any model state validation errors
         ModelState.Clear();
+
+        IncludeEnquiryBuilder = _featureFlagsConfig.EnquiryBuilder;
 
         return Page();
     }

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -47,9 +47,12 @@
             You can either:
         </p>
         <ol class="govuk-list govuk-list--number govuk-!-margin-left-4">
+            @if(Model.IncludeEnquiryBuilder)
+            {
             <li>
                 Send a tailored enquiry to tuition partners anonymously.
             </li>
+            }
             <li>
                 Use the search results on this page to contact tuition partners yourself.
             </li>
@@ -57,6 +60,8 @@
                 Select tuition partners and compare prices between them.
             </li>
         </ol>
+        @if(Model.IncludeEnquiryBuilder)
+        {
         <div class="app-print-hide enquire-nudge">
             <h2 class="govuk-heading-m">Send an enquiry to tuition partners</h2>
             <p class="govuk-body">
@@ -64,6 +69,7 @@
             </p>
             <a class="govuk-button" data-module="govuk-button" draggable="false" href="/enquiry/build/guidance?@Model.Data.ToQueryString()" role="button">Start now</a>
         </div>
+        }
     </div>
 </div>
 

--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -25,6 +25,23 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
+    @if (!Model.IncludeEnquiryBuilder)
+    {
+      <div class="govuk-notification-banner govuk-notification-banner--blue" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <div class="govuk-body">
+            <p class="govuk-notification-banner__heading">Enquiry builder is temporally unavailable.</p>
+            <p class="govuk-body">You will be able to use this feature later.</p>
+          </div>
+        </div>
+      </div>
+    }
+
         <govuk-error-summary show-if="!Model.ModelState.IsValid" class="app-print-hide">
             <govuk-error-summary-item show-if="!Model.ModelState.IsValid" class="error-summary-filter-prompt">Use the filters section below to update the following details:</govuk-error-summary-item>
             <govuk-error-summary-item asp-for="Data.Postcode"/>

--- a/UI/Pages/SearchResults.cshtml.cs
+++ b/UI/Pages/SearchResults.cshtml.cs
@@ -1,5 +1,7 @@
 using Application.Common.Models;
 using Application.Validators;
+using Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
 using TuitionType = Domain.Enums.TuitionType;
 
 namespace UI.Pages;
@@ -7,13 +9,20 @@ namespace UI.Pages;
 public class SearchResults : PageModel
 {
     private readonly IMediator _mediator;
-    public SearchResults(IMediator mediator) => _mediator = mediator;
+    private readonly FeatureFlags _featureFlagsConfig;
+    public SearchResults(IMediator mediator, IOptions<FeatureFlags> featureFlagsConfig)
+    {
+        _mediator = mediator;
+        _featureFlagsConfig = featureFlagsConfig.Value;
+    }
 
     public SearchResultsModel Data { get; set; } = new();
     [BindProperty(SupportsGet = true)] public List<string> CompareListedTuitionPartners { get; set; } = new();
     public List<SelectableTuitionPartnerModel> SelectableTuitionPartners { get; set; } = new();
     public int TotalCompareListedTuitionPartners { get; set; }
     [BindProperty(SupportsGet = true)] public string? UpdateMyCompareList { get; set; }
+
+    public bool IncludeEnquiryBuilder { get; set; } = true;
 
     // Name keys : Tps => TuitionPartners,Tp => TuitionPartner
 
@@ -34,6 +43,8 @@ public class SearchResults : PageModel
 
     private async Task<IActionResult> CommonOnGetPostLogic(GetSearchResultsQuery data)
     {
+        IncludeEnquiryBuilder = _featureFlagsConfig.EnquiryBuilder;
+
         data.TuitionType ??= TuitionType.Any;
         data.KeyStages = data.KeyStages.UpdateFromSubjects(data.Subjects);
 

--- a/UI/Program.cs
+++ b/UI/Program.cs
@@ -62,6 +62,7 @@ builder.Services.AddNotificationConfig(builder.Configuration)
     .AddNotificationClientServiceConfiguration(builder.Configuration);
 builder.Services.AddEmailSettingsConfig(builder.Configuration);
 builder.Services.AddAesEncryption(builder.Configuration);
+builder.Services.AddFeatureFlagConfig(builder.Configuration);
 builder.Services.AddRepositories();
 builder.Services.AddCqrs();
 builder.Services.LogKeyMetrics();

--- a/manifest.yml
+++ b/manifest.yml
@@ -32,3 +32,4 @@ applications:
     EmailSettings:AllSentToEnquirer: ((email-all-sent-to-enquirer))
     AesEncryption:Key: ((magiclink-aes-encryption-key))
     AesEncryption:IV: ((magiclink-aes-encryption-iv))
+    FeatureFlags:EnquiryBuilder: ((feature-flag-enquiry-builder))

--- a/vars-pr.yml
+++ b/vars-pr.yml
@@ -14,3 +14,4 @@ govuk-notify-enquiry-response-submitted-confirmation-to-tp-template-id: 0aad4d76
 override-email-address: 
 email-amalgamate-responses: true
 email-all-sent-to-enquirer: true
+feature-flag-enquiry-builder: true

--- a/vars-production.yml
+++ b/vars-production.yml
@@ -14,3 +14,4 @@ govuk-notify-enquiry-response-submitted-confirmation-to-tp-template-id: 0aad4d76
 override-email-address: 
 email-amalgamate-responses: false
 email-all-sent-to-enquirer: false
+feature-flag-enquiry-builder: true

--- a/vars-qa.yml
+++ b/vars-qa.yml
@@ -14,3 +14,4 @@ govuk-notify-enquiry-response-submitted-confirmation-to-tp-template-id: 0aad4d76
 override-email-address: 
 email-amalgamate-responses: true
 email-all-sent-to-enquirer: true
+feature-flag-enquiry-builder: true

--- a/vars-research.yml
+++ b/vars-research.yml
@@ -14,3 +14,4 @@ govuk-notify-enquiry-response-submitted-confirmation-to-tp-template-id: 0aad4d76
 override-email-address: 
 email-amalgamate-responses: true
 email-all-sent-to-enquirer: true
+feature-flag-enquiry-builder: true

--- a/vars-staging.yml
+++ b/vars-staging.yml
@@ -14,3 +14,4 @@ govuk-notify-enquiry-response-submitted-confirmation-to-tp-template-id: 0aad4d76
 override-email-address: 
 email-amalgamate-responses: false
 email-all-sent-to-enquirer: true
+feature-flag-enquiry-builder: true


### PR DESCRIPTION
## Context

Via the .vars files add a config bool flag to ensure that the enquiry builder can be switched off - remove the enquiry content & button from the search results and have an extra check on the CYA enquiry post action to ensure that enquiries are not submitted.  Allow the responses to still to be created and viewed.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1043

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**