### PR TITLE
NTP-1123: On tp respond page the time to respond is set to somewhere near jesus 1st birthday if a validation error is shown

### DIFF
--- a/Application/Common/Models/Enquiry/Respond/ViewAndCaptureEnquiryResponseModel.cs
+++ b/Application/Common/Models/Enquiry/Respond/ViewAndCaptureEnquiryResponseModel.cs
@@ -2,5 +2,5 @@ namespace Application.Common.Models.Enquiry.Respond;
 
 public record ViewAndCaptureEnquiryResponseModel : EnquiryResponseModel
 {
-    public DateTime EnquiryResponseCloseDate { get; set; }
+    public string EnquiryResponseCloseDateFormatted { get; set; } = string.Empty;
 }

--- a/UI/Pages/Enquiry/Respond/Response.cshtml
+++ b/UI/Pages/Enquiry/Respond/Response.cshtml
@@ -36,7 +36,7 @@
         </ul>
       </p>
       <div class="govuk-inset-text">
-        You have until <strong>@Model.Data.EnquiryResponseCloseDate.ToString("h:mmtt 'on' dddd d MMMM yyyy")</strong> to respond to this enquiry
+        You have until <strong>@Model.Data.EnquiryResponseCloseDateFormatted</strong> to respond to this enquiry
       </div>
     </div>
   </div>
@@ -183,5 +183,6 @@
   <input asp-for="Data.EnquiryTutoringLogistics" type="hidden" />
   <input asp-for="Data.EnquirySENDRequirements" type="hidden" />
   <input asp-for="Data.EnquiryAdditionalInformation" type="hidden" />
+  <input asp-for="Data.EnquiryResponseCloseDateFormatted" type="hidden" />
   <govuk-button prevent-double-click="true" type="submit" data-testid="call-to-action" class="app-print-hide">Continue</govuk-button>
 </form>

--- a/UI/Pages/Enquiry/Respond/Response.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/Response.cshtml.cs
@@ -50,7 +50,7 @@ namespace UI.Pages.Enquiry.Respond
                 return RedirectToPage(nameof(ErrorModel));
             }
 
-            Data.EnquiryResponseCloseDate = enquiryData.EnquiryCreatedDateTime.AddDays(IntegerConstants.EnquiryDaysToRespond);
+            Data.EnquiryResponseCloseDateFormatted = enquiryData.EnquiryCreatedDateTime.AddDays(IntegerConstants.EnquiryDaysToRespond).ToString("h:mmtt 'on' dddd d MMMM yyyy");
 
             var sessionValues = await _sessionService.RetrieveDataAsync(GetSessionKey(Data.TuitionPartnerSeoUrl!, Data.SupportReferenceNumber));
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1123

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**