### PR TITLE
NTP-1125: Amend routing for the enquiry build feature

### DIFF
--- a/Application/Commands/AddEnquiryCommand.cs
+++ b/Application/Commands/AddEnquiryCommand.cs
@@ -136,7 +136,7 @@ public class AddEnquiryCommandHandler : IRequestHandler<AddEnquiryCommand, Submi
         _logger.LogInformation("Enquiry successfully created with magic links. EnquiryId: {enquiryId}", enquiry.Id);
 
         var enquirerViewAllResponsesPageLink =
-            $"{request.Data?.BaseServiceUrl}/enquiry/{enquiry.SupportReferenceNumber}/respond/all-enquirer-responses?Token={enquirerMagicLink.Token}";
+            $"{request.Data?.BaseServiceUrl}/enquiry/{enquiry.SupportReferenceNumber}?Token={enquirerMagicLink.Token}";
 
         getEnquirySubmittedConfirmationToEnquirerNotificationsRecipient.Personalisation = GetGetEnquirySubmittedConfirmationToEnquirerPersonalisation(
                     request.Data!.TuitionPartnersForEnquiry!.Results!.Count(), enquirerViewAllResponsesPageLink);
@@ -147,7 +147,7 @@ public class AddEnquiryCommandHandler : IRequestHandler<AddEnquiryCommand, Submi
 
         getEnquirySubmittedToTpNotificationsRecipients.ForEach(x =>
             x.Personalisation = GetEnquirySubmittedToTpPersonalisation(x.TuitionPartnerName!,
-                $"{request.Data!.BaseServiceUrl}/enquiry/{enquiry.SupportReferenceNumber}/respond/response/{x.TuitionPartnerName.ToSeoUrl()}?Token={x.Token}",
+                $"{request.Data!.BaseServiceUrl}/enquiry-response/{x.TuitionPartnerName.ToSeoUrl()}/{enquiry.SupportReferenceNumber}?Token={x.Token}",
                 request!.Data!.TuitionPartnersForEnquiry!.LocalAuthorityDistrictName!
                 ));
 

--- a/Application/Commands/AddEnquiryResponseCommand.cs
+++ b/Application/Commands/AddEnquiryResponseCommand.cs
@@ -132,7 +132,7 @@ public class AddEnquiryResponseCommandHandler : IRequestHandler<AddEnquiryRespon
     private NotificationsRecipientDto GetEnquiryResponseReceivedConfirmationToEnquirerNotificationsRecipient(AddEnquiryResponseCommand request,
         string tpName, string supportRefNumber, string contactusLink)
     {
-        var pageLink = $"{request.Data?.BaseServiceUrl}/enquiry/{supportRefNumber}/respond/all-enquirer-responses?token={request.Data?.Token}";
+        var pageLink = $"{request.Data?.BaseServiceUrl}/enquiry/{supportRefNumber}?Token={request.Data?.Token}";
 
         var result = new NotificationsRecipientDto()
         {

--- a/Infrastructure/Repositories/EnquiryRepository.cs
+++ b/Infrastructure/Repositories/EnquiryRepository.cs
@@ -81,7 +81,7 @@ public class EnquiryRepository : GenericRepository<Enquiry>, IEnquiryRepository
                 TuitionPartnerName = er.TuitionPartner.Name,
                 EnquiryResponseDate = er.EnquiryResponse?.CreatedAt!,
                 EnquirerEnquiryResponseLink =
-                    $"{baseServiceUrl}/enquiry/{supportReferenceNumber}/respond/enquirer-response/{er.TuitionPartner.Name.ToSeoUrl()}?Token={er.MagicLink!.Token}"
+                    $"{baseServiceUrl}/enquiry/{supportReferenceNumber}/{er.TuitionPartner.Name.ToSeoUrl()}?Token={er.MagicLink!.Token}"
             };
             result.EnquirerViewResponses.Add(responseModel);
         }

--- a/UI/Pages/Enquiry/Build/SubmittedConfirmation.cshtml
+++ b/UI/Pages/Enquiry/Build/SubmittedConfirmation.cshtml
@@ -4,7 +4,7 @@
   ViewData["Title"] = "Enquiry submitted confirmation";
   ViewData["IncludePrintPage"] = true;
   var supportReferenceNumber = Model.Data.SupportReferenceNumber ?? string.Empty;
-  var enquirerLink = string.IsNullOrWhiteSpace(Model.Data.EnquirerMagicLink) ? string.Empty : $"/enquiry/{Model.Data.SupportReferenceNumber}/respond/all-enquirer-responses?Token={Model.Data.EnquirerMagicLink}";
+  var enquirerLink = string.IsNullOrWhiteSpace(Model.Data.EnquirerMagicLink) ? string.Empty : $"/enquiry/{Model.Data.SupportReferenceNumber}?Token={Model.Data.EnquirerMagicLink}";
 }
 
 <div class="govuk-width-container">
@@ -46,7 +46,7 @@
                 foreach (var tpLink in Model.Data.TuitionPartnerMagicLinks)
                 {
                     var dataTestId = $"tp-response-magic-link{tpLink.Email}";
-                    var tpHref = $"/enquiry/{Model.Data.SupportReferenceNumber}/respond/response/{tpLink.TuitionPartnerSeoUrl}?Token={tpLink.MagicLinkToken}";
+                    var tpHref = $"/enquiry-response/{tpLink.TuitionPartnerSeoUrl}/{Model.Data.SupportReferenceNumber}?Token={tpLink.MagicLinkToken}";
                 <p class="govuk-body">
                     @tpLink.Email: <a href="@tpHref" data-testid="@dataTestId">Response link</a>
                 </p>

--- a/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
+++ b/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml
@@ -1,4 +1,4 @@
-@page "/enquiry/{supportReferenceNumber}/respond/all-enquirer-responses"
+@page "/enquiry/{supportReferenceNumber}"
 @model UI.Pages.Enquiry.Respond.AllEnquirerResponses
 @using GovUk.Frontend.AspNetCore.TagHelpers
 @{

--- a/UI/Pages/Enquiry/Respond/CheckYourAnswers.cshtml
+++ b/UI/Pages/Enquiry/Respond/CheckYourAnswers.cshtml
@@ -2,7 +2,7 @@
 @model UI.Pages.Enquiry.Respond.CheckYourAnswers
 
 @{
-  var backUrl = $"/enquiry/{Model.Data.SupportReferenceNumber}/respond/response/{Model.Data.TuitionPartnerSeoUrl}?token={@Model.Data.Token}";
+  var backUrl = $"/enquiry-response/{Model.Data.TuitionPartnerSeoUrl}/{Model.Data.SupportReferenceNumber}?Token={@Model.Data.Token}";
   ViewData["Title"] = "Check your answers";
   ViewData["BackLinkHref"] = backUrl;
   ViewData["IncludePrintPage"] = true;

--- a/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml
+++ b/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml
@@ -1,9 +1,9 @@
-@page "/enquiry/{supportReferenceNumber}/respond/enquirer-response/{tuitionPartnerSeoUrl}"
+@page "/enquiry/{supportReferenceNumber}/{tuitionPartnerSeoUrl}"
 @model UI.Pages.Enquiry.Respond.EnquirerResponse
 @{
   var baseServiceUrl = Request.GetBaseServiceUrl();
-  var backLink = $"{baseServiceUrl}/enquiry/{Model.SupportReferenceNumber}/respond/all-enquirer-responses?Token={Model.Data.EnquirerViewAllResponsesToken}";
-  var tpDetails = $"{baseServiceUrl}/enquiry/{Model.SupportReferenceNumber}/respond/enquirer-view-tuition-partner-details/{Model.TuitionPartnerSeoUrl}?Token={Model.Data.EnquirerViewResponseToken}";
+  var backLink = $"{baseServiceUrl}/enquiry/{Model.SupportReferenceNumber}?Token={Model.Data.EnquirerViewAllResponsesToken}";
+  var tpDetails = $"{baseServiceUrl}/enquiry/{Model.SupportReferenceNumber}/{Model.TuitionPartnerSeoUrl}/contact-details?Token={Model.Data.EnquirerViewResponseToken}";
 
   ViewData["Title"] = "View a response";
   ViewData["BackLinkText"] = "Back to view all your responses";

--- a/UI/Pages/Enquiry/Respond/EnquirerViewTuitionPartnerDetails.cshtml
+++ b/UI/Pages/Enquiry/Respond/EnquirerViewTuitionPartnerDetails.cshtml
@@ -1,9 +1,9 @@
-﻿@page "/enquiry/{supportReferenceNumber}/respond/enquirer-view-tuition-partner-details/{tuitionPartnerSeoUrl}"
+﻿@page "/enquiry/{supportReferenceNumber}/{tuitionPartnerSeoUrl}/contact-details"
 @model UI.Pages.Enquiry.Respond.EnquirerViewTuitionPartnerDetails
 @{
   var baseServiceUrl = Request.GetBaseServiceUrl();
-  var backLink = $"{baseServiceUrl}/enquiry/{Model.SupportReferenceNumber}/respond/enquirer-response/{Model.TuitionPartnerSeoUrl}?Token={@Model.Data.EnquirerViewResponseToken}";
-  var allList = $"{baseServiceUrl}/enquiry/{Model.SupportReferenceNumber}/respond/all-enquirer-responses?Token={@Model.Data.EnquirerViewAllResponsesToken}";
+  var backLink = $"{baseServiceUrl}/enquiry/{Model.SupportReferenceNumber}/{Model.TuitionPartnerSeoUrl}?Token={@Model.Data.EnquirerViewResponseToken}";
+  var allList = $"{baseServiceUrl}/enquiry/{Model.SupportReferenceNumber}?Token={@Model.Data.EnquirerViewAllResponsesToken}";
 
   ViewData["Title"] = "Contact " + Model.Data.TuitionPartnerName;
   ViewData["BackLinkHref"] = backLink;

--- a/UI/Pages/Enquiry/Respond/Response.cshtml
+++ b/UI/Pages/Enquiry/Respond/Response.cshtml
@@ -1,4 +1,4 @@
-﻿@page "/enquiry/{supportReferenceNumber}/respond/response/{tuitionPartnerSeoUrl}"
+﻿@page "/enquiry-response/{tuitionPartnerSeoUrl}/{supportReferenceNumber}"
 @model UI.Pages.Enquiry.Respond.Response
 @using GovUk.Frontend.AspNetCore.TagHelpers
 @{

--- a/UI/Pages/Enquiry/Respond/ResponseConfirmation.cshtml
+++ b/UI/Pages/Enquiry/Respond/ResponseConfirmation.cshtml
@@ -4,7 +4,7 @@
   ViewData["Title"] = "Response sent confirmation";
   ViewData["IncludePrintPage"] = true;
   var supportReferenceNumber = @Model.Data.SupportReferenceNumber ?? string.Empty;
-  var enquirerLink = string.IsNullOrWhiteSpace(Model.Data.EnquirerMagicLink) ? string.Empty : $"/enquiry/{Model.Data.SupportReferenceNumber}/respond/all-enquirer-responses?Token={Model.Data.EnquirerMagicLink}";
+  var enquirerLink = string.IsNullOrWhiteSpace(Model.Data.EnquirerMagicLink) ? string.Empty : $"/enquiry/{Model.Data.SupportReferenceNumber}?Token={Model.Data.EnquirerMagicLink}";
 }
 
 <div class="govuk-width-container">

--- a/UI/wwwroot/robots.txt
+++ b/UI/wwwroot/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Disallow: /enquiry/build/*
 Disallow: /enquiry/*
+Disallow: /enquiry-response/*


### PR DESCRIPTION
## Context

The dev team has decided on the below ACs for amending the routing of the enquiry build feature, particularly for the MVP.

ACs:

Enquirer View all:

`/enquiry/{ref_num}?Token=...`
 

Enquirer view specific:

`/enquiry/{ref_num}/{tp_name}?Token=...`
 

Enquirer TP reveal:

`/enquiry/{ref_num}/{tp_name}/contact-details?Token=...`
 

TP response:

`/enquiry-response/{tp_name}/{ref_num}?Token=...`

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

[https://dfedigital.atlassian.net/browse/NTP-1125](https://dfedigital.atlassian.net/browse/NTP-1125)

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**