### PR TITLE
NTP-1124: Display date time in UI with the current local date time (UK).

### DIFF
--- a/Application.Tests/Extensions/DateTimeExtensionsTests.cs
+++ b/Application.Tests/Extensions/DateTimeExtensionsTests.cs
@@ -14,6 +14,13 @@ public class DateTimeExtensionsTests
         var utcTime = new DateTime(2023, 03, 28, 10, 0, 0); // 10:00 AM UTC
         var expectedUkTime = new DateTime(2023, 03, 28, 11, 0, 0); // 11:00 AM UK local time
 
+        var offset = DateTimeOffset.Now;
+
+        if (offset.Offset == TimeSpan.Zero)
+        {
+            expectedUkTime = utcTime;
+        }
+
         // Act
         var actualUkTime = utcTime.ToLocalDateTime("GMT Standard Time");
 

--- a/Application.Tests/Extensions/DateTimeExtensionsTests.cs
+++ b/Application.Tests/Extensions/DateTimeExtensionsTests.cs
@@ -1,0 +1,23 @@
+using System;
+using Application.Extensions;
+using Xunit;
+
+namespace Application.Tests.Extensions;
+
+public class DateTimeExtensionsTests
+{
+
+    [Fact]
+    public void ConvertUtcToUk_LocalDateTimeReturned()
+    {
+        // Arrange
+        var utcTime = new DateTime(2023, 03, 28, 10, 0, 0); // 10:00 AM UTC
+        var expectedUkTime = new DateTime(2023, 03, 28, 11, 0, 0); // 11:00 AM UK local time
+
+        // Act
+        var actualUkTime = utcTime.ToLocalDateTime("GMT Standard Time");
+
+        // Assert
+        Assert.Equal(expectedUkTime, actualUkTime);
+    }
+}

--- a/Application/Commands/AddEnquiryResponseCommand.cs
+++ b/Application/Commands/AddEnquiryResponseCommand.cs
@@ -166,7 +166,7 @@ public class AddEnquiryResponseCommandHandler : IRequestHandler<AddEnquiryRespon
             TpName = tpName,
             SupportRefNumber = supportRefNumber,
             LocalAreaDistrict = request.Data.LocalAuthorityDistrict,
-            ResponseCreatedOnDateTime = responseCreateDateTime.ToString(StringConstants.DateFormatGDS),
+            ResponseCreatedOnDateTime = responseCreateDateTime.ToLocalDateTime().ToString(StringConstants.DateFormatGDS),
             EnquiryKeyStageSubjects = string.Join(Environment.NewLine, request.Data.EnquiryKeyStageSubjects!),
             EnquiryResponseKeyStageSubjects = request.Data.KeyStageAndSubjectsText.EscapeNotifyText(true),
             EnquiryTuitionType = request.Data.EnquiryTuitionType,

--- a/Application/Extensions/DateTimeExtensions.cs
+++ b/Application/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,11 @@
+namespace Application.Extensions;
+
+public static class DateTimeExtensions
+{
+    public static DateTime ToLocalDateTime(this DateTime dateTime, string? timeZoneId = null)
+    {
+        if (string.IsNullOrEmpty(timeZoneId)) timeZoneId = "GMT Standard Time";
+        var timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        return TimeZoneInfo.ConvertTimeFromUtc(dateTime, timeZoneInfo);
+    }
+}

--- a/Application/Extensions/DictionaryExtensions.cs
+++ b/Application/Extensions/DictionaryExtensions.cs
@@ -14,7 +14,7 @@ public static class DictionaryExtensions
         if (personalisation != null)
         {
             personalisation.Add(EnquiryRefKeyKey, enquiryRef);
-            personalisation.Add(EnquiryDateTimeKey, dateTime.ToString(StringConstants.DateFormatGDS));
+            personalisation.Add(EnquiryDateTimeKey, dateTime.ToLocalDateTime().ToString(StringConstants.DateFormatGDS));
             personalisation.Add(EnquiryContactUsKey, $"{baseUrl}/contact-us");
         }
 

--- a/Infrastructure/Repositories/EnquiryRepository.cs
+++ b/Infrastructure/Repositories/EnquiryRepository.cs
@@ -70,7 +70,7 @@ public class EnquiryRepository : GenericRepository<Enquiry>, IEnquiryRepository
             TuitionTypeName = enquiry.TuitionTypeId.GetTuitionTypeName(),
             SENDRequirements = enquiry.SENDRequirements,
             AdditionalInformation = enquiry.AdditionalInformation,
-            EnquiryCreatedDateTime = enquiry.CreatedAt,
+            EnquiryCreatedDateTime = enquiry.CreatedAt.ToLocalDateTime(),
             EnquirerViewResponses = new List<EnquirerViewResponseDto>()
         };
 


### PR DESCRIPTION
## Context

With this PR, we show the local date time for the enquiry build feature instead of displaying the UTC date time in the UI.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

[https://dfedigital.atlassian.net/browse/NTP-1124](https://dfedigital.atlassian.net/browse/NTP-1124)

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**