### PR TITLE
NTP-1134: Issue with text area count mismatch when using carriage returns

### DIFF
--- a/Application/Validators/Enquiry/Build/AdditionalInformationModelValidator.cs
+++ b/Application/Validators/Enquiry/Build/AdditionalInformationModelValidator.cs
@@ -9,7 +9,7 @@ public class AdditionalInformationModelValidator : AbstractValidator<AdditionalI
     public AdditionalInformationModelValidator()
     {
         RuleFor(request => request.AdditionalInformation)
-             .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-             .WithMessage($"Any other considerations for tuition partners to consider must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
+            .Must(x => string.IsNullOrEmpty(x) || (!string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize))
+            .WithMessage($"Any other considerations for tuition partners to consider must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
     }
 }

--- a/Application/Validators/Enquiry/Build/CheckYourAnswersModelValidator.cs
+++ b/Application/Validators/Enquiry/Build/CheckYourAnswersModelValidator.cs
@@ -33,22 +33,22 @@ public class CheckYourAnswersModelValidator : AbstractValidator<CheckYourAnswers
             .WithMessage("You must enter an email address in the correct format");
 
         RuleFor(request => request.TutoringLogistics)
-             .NotEmpty()
-             .When(m => m.ConfirmTermsAndConditions)
-             .WithMessage("Enter the type of tuition plan that you need")
-             .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-             .When(m => m.ConfirmTermsAndConditions)
-             .WithMessage($"The type of tuition plan must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
+            .NotEmpty()
+            .When(m => m.ConfirmTermsAndConditions)
+            .WithMessage("Enter the type of tuition plan that you need")
+            .Must(x => !string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize)
+            .When(m => m.ConfirmTermsAndConditions)
+            .WithMessage($"The type of tuition plan must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
 
         RuleFor(request => request.SENDRequirements)
-             .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-             .When(m => m.ConfirmTermsAndConditions)
-             .WithMessage($"SEND requirements must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
+            .Must(x => string.IsNullOrEmpty(x) || (!string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize))
+            .When(m => m.ConfirmTermsAndConditions)
+            .WithMessage($"SEND requirements must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
 
         RuleFor(request => request.AdditionalInformation)
-             .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-             .When(m => m.ConfirmTermsAndConditions)
-             .WithMessage($"Any other considerations for tuition partners to consider must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
+            .Must(x => string.IsNullOrEmpty(x) || (!string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize))
+            .When(m => m.ConfirmTermsAndConditions)
+            .WithMessage($"Any other considerations for tuition partners to consider must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
 
         RuleFor(m => m.ConfirmTermsAndConditions)
             .NotEqual(false)

--- a/Application/Validators/Enquiry/Build/SENDRequirementsModelValidator.cs
+++ b/Application/Validators/Enquiry/Build/SENDRequirementsModelValidator.cs
@@ -9,7 +9,7 @@ public class SENDRequirementsModelValidator : AbstractValidator<SENDRequirements
     public SENDRequirementsModelValidator()
     {
         RuleFor(request => request.SENDRequirements)
-             .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-             .WithMessage($"SEND requirements must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
+            .Must(x => string.IsNullOrEmpty(x) || (!string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize))
+            .WithMessage($"SEND requirements must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
     }
 }

--- a/Application/Validators/Enquiry/Build/TutoringLogisticsModelValidator.cs
+++ b/Application/Validators/Enquiry/Build/TutoringLogisticsModelValidator.cs
@@ -9,9 +9,9 @@ public class TutoringLogisticsModelValidator : AbstractValidator<TutoringLogisti
     public TutoringLogisticsModelValidator()
     {
         RuleFor(request => request.TutoringLogistics)
-             .NotEmpty()
-             .WithMessage("Enter the type of tuition plan that you need")
-             .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-             .WithMessage($"The type of tuition plan must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
+            .NotEmpty()
+            .WithMessage("Enter the type of tuition plan that you need")
+            .Must(x => !string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize)
+            .WithMessage($"The type of tuition plan must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
     }
 }

--- a/Application/Validators/Enquiry/Respond/CheckYourAnswersModelValidator.cs
+++ b/Application/Validators/Enquiry/Respond/CheckYourAnswersModelValidator.cs
@@ -11,33 +11,33 @@ public class CheckYourAnswersModelValidator : AbstractValidator<CheckYourAnswers
         RuleFor(request => request.KeyStageAndSubjectsText)
             .NotEmpty()
             .WithMessage("Enter can you support those key stages and subjects")
-            .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-            .WithMessage($"Key stages and subjects must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize} characters or less");
+            .Must(x => !string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize)
+            .WithMessage($"Key stages and subjects must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
 
         RuleFor(request => request.TuitionTypeText)
             .NotEmpty()
             .WithMessage("Enter to what extent can you support that type of tuition")
-            .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-            .WithMessage($"Type of tuition must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize} characters or less");
+            .Must(x => !string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize)
+            .WithMessage($"Type of tuition must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
 
         RuleFor(request => request.TutoringLogisticsText)
             .NotEmpty()
             .WithMessage("Enter can you support that tuition plan")
-            .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-            .WithMessage($"Tuition plan must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize} characters or less");
+            .Must(x => !string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize)
+            .WithMessage($"Tuition plan must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
 
         RuleFor(request => request.SENDRequirementsText)
             .NotEmpty()
             .When(m => !string.IsNullOrWhiteSpace(m.EnquirySENDRequirements))
             .WithMessage("Enter can you support the SEND requirements")
-            .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-            .WithMessage($"SEND requirements must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize} characters or less");
+            .Must(x => string.IsNullOrEmpty(x) || (!string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize))
+            .WithMessage($"SEND requirements must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
 
         RuleFor(request => request.AdditionalInformationText)
             .NotEmpty()
             .When(m => !string.IsNullOrWhiteSpace(m.EnquiryAdditionalInformation))
             .WithMessage("Enter can you support the other school considerations")
-            .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-            .WithMessage($"Other school considerations must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize} characters or less");
+            .Must(x => string.IsNullOrEmpty(x) || (!string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize))
+            .WithMessage($"Other school considerations must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
     }
 }

--- a/Application/Validators/Enquiry/Respond/ViewAndCaptureEnquiryResponseModelValidator.cs
+++ b/Application/Validators/Enquiry/Respond/ViewAndCaptureEnquiryResponseModelValidator.cs
@@ -11,33 +11,33 @@ public class ViewAndCaptureEnquiryResponseModelValidator : AbstractValidator<Vie
         RuleFor(request => request.KeyStageAndSubjectsText)
             .NotEmpty()
             .WithMessage("Enter can you support those key stages and subjects")
-            .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-            .WithMessage($"Key stages and subjects must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize} characters or less");
+            .Must(x => !string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize)
+            .WithMessage($"Key stages and subjects must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
 
         RuleFor(request => request.TuitionTypeText)
             .NotEmpty()
             .WithMessage("Enter to what extent can you support that type of tuition")
-            .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-            .WithMessage($"Type of tuition must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize} characters or less");
+            .Must(x => !string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize)
+            .WithMessage($"Type of tuition must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
 
         RuleFor(request => request.TutoringLogisticsText)
             .NotEmpty()
             .WithMessage("Enter can you support that tuition plan")
-            .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-            .WithMessage($"Tuition plan must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize} characters or less");
+            .Must(x => !string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize)
+            .WithMessage($"Tuition plan must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
 
         RuleFor(request => request.SENDRequirementsText)
             .NotEmpty()
             .When(m => !string.IsNullOrWhiteSpace(m.EnquirySENDRequirements))
             .WithMessage("Enter can you support the SEND requirements")
-            .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-            .WithMessage($"SEND requirements must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize} characters or less");
+            .Must(x => string.IsNullOrEmpty(x) || (!string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize))
+            .WithMessage($"SEND requirements must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
 
         RuleFor(request => request.AdditionalInformationText)
             .NotEmpty()
             .When(m => !string.IsNullOrWhiteSpace(m.EnquiryAdditionalInformation))
             .WithMessage("Enter can you support the other school considerations")
-            .MaximumLength(IntegerConstants.EnquiryQuestionsMaxCharacterSize)
-            .WithMessage($"Other school considerations must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize} characters or less");
+            .Must(x => string.IsNullOrEmpty(x) || (!string.IsNullOrEmpty(x) && x.Replace(Environment.NewLine, " ").Length <= IntegerConstants.EnquiryQuestionsMaxCharacterSize))
+            .WithMessage($"Other school considerations must be {IntegerConstants.EnquiryQuestionsMaxCharacterSize:N0} characters or less");
     }
 }


### PR DESCRIPTION
…atch

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1134

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**