### PR TITLE
NTP-1142: Stop alert from being sent when TP clicks on a responded en…

### DIFF
--- a/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
+++ b/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
@@ -90,14 +90,13 @@ public class CheckYourAnswers : PageModel
 
         if (!submittedConfirmationModel.IsValid && submittedConfirmationModel.ErrorStatus == HttpStatusCode.NotFound.ToString())
         {
-            TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage("/ErrorModel");
+            return NotFound();
         }
 
         if (!submittedConfirmationModel.IsValid && submittedConfirmationModel.ErrorStatus == HttpStatusCode.InternalServerError.ToString())
         {
             TempData["Status"] = HttpStatusCode.InternalServerError;
-            return RedirectToPage("/ErrorModel");
+            return RedirectToPage(nameof(ErrorModel));
         }
 
         if (!string.IsNullOrEmpty(enquirerEmailSentStatus))
@@ -117,7 +116,7 @@ public class CheckYourAnswers : PageModel
             if (enquirerEmailSentStatus == StringConstants.EnquirerEmailSentStatus5xxErrorValue)
             {
                 TempData["Status"] = HttpStatusCode.InternalServerError;
-                return RedirectToPage("/ErrorModel");
+                return RedirectToPage(nameof(ErrorModel));
             }
         }
 

--- a/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
+++ b/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
@@ -91,13 +91,13 @@ public class CheckYourAnswers : PageModel
         if (!submittedConfirmationModel.IsValid && submittedConfirmationModel.ErrorStatus == HttpStatusCode.NotFound.ToString())
         {
             TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage(nameof(ErrorModel));
+            return RedirectToPage("/ErrorModel");
         }
 
         if (!submittedConfirmationModel.IsValid && submittedConfirmationModel.ErrorStatus == HttpStatusCode.InternalServerError.ToString())
         {
             TempData["Status"] = HttpStatusCode.InternalServerError;
-            return RedirectToPage(nameof(ErrorModel));
+            return RedirectToPage("/ErrorModel");
         }
 
         if (!string.IsNullOrEmpty(enquirerEmailSentStatus))
@@ -117,7 +117,7 @@ public class CheckYourAnswers : PageModel
             if (enquirerEmailSentStatus == StringConstants.EnquirerEmailSentStatus5xxErrorValue)
             {
                 TempData["Status"] = HttpStatusCode.InternalServerError;
-                return RedirectToPage(nameof(ErrorModel));
+                return RedirectToPage("/ErrorModel");
             }
         }
 

--- a/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml.cs
@@ -23,8 +23,7 @@ namespace UI.Pages.Enquiry.Respond
 
             if (string.IsNullOrEmpty(SupportReferenceNumber) || string.IsNullOrEmpty(queryToken))
             {
-                TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage("/ErrorModel");
+                return NotFound();
             }
 
             Data.SupportReferenceNumber = SupportReferenceNumber;
@@ -38,15 +37,13 @@ namespace UI.Pages.Enquiry.Respond
 
                 if (!isValidMagicLink)
                 {
-                    TempData["Status"] = HttpStatusCode.NotFound;
-                    return RedirectToPage("/ErrorModel");
+                    return NotFound();
                 }
 
                 var data = await _mediator.Send(new GetEnquirerViewAllResponsesQuery(baseServiceUrl, SupportReferenceNumber));
                 if (data == null)
                 {
-                    TempData["Status"] = HttpStatusCode.NotFound;
-                    return RedirectToPage("/ErrorModel");
+                    return NotFound();
                 }
 
                 Data = data;

--- a/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/AllEnquirerResponses.cshtml.cs
@@ -24,7 +24,7 @@ namespace UI.Pages.Enquiry.Respond
             if (string.IsNullOrEmpty(SupportReferenceNumber) || string.IsNullOrEmpty(queryToken))
             {
                 TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage(nameof(ErrorModel));
+                return RedirectToPage("/ErrorModel");
             }
 
             Data.SupportReferenceNumber = SupportReferenceNumber;
@@ -39,14 +39,14 @@ namespace UI.Pages.Enquiry.Respond
                 if (!isValidMagicLink)
                 {
                     TempData["Status"] = HttpStatusCode.NotFound;
-                    return RedirectToPage(nameof(ErrorModel));
+                    return RedirectToPage("/ErrorModel");
                 }
 
                 var data = await _mediator.Send(new GetEnquirerViewAllResponsesQuery(baseServiceUrl, SupportReferenceNumber));
                 if (data == null)
                 {
                     TempData["Status"] = HttpStatusCode.NotFound;
-                    return RedirectToPage(nameof(ErrorModel));
+                    return RedirectToPage("/ErrorModel");
                 }
 
                 Data = data;

--- a/UI/Pages/Enquiry/Respond/CheckYourAnswers.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/CheckYourAnswers.cshtml.cs
@@ -39,7 +39,7 @@ public class CheckYourAnswers : ResponsePageModel<CheckYourAnswers>
         if (!isValidMagicLink)
         {
             TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage(nameof(ErrorModel));
+            return RedirectToPage("/ErrorModel");
         }
 
         ModelState.Clear();
@@ -60,7 +60,7 @@ public class CheckYourAnswers : ResponsePageModel<CheckYourAnswers>
         if (!isValidMagicLink)
         {
             TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage(nameof(ErrorModel));
+            return RedirectToPage("/ErrorModel");
         }
 
         Data.BaseServiceUrl = Request.GetBaseServiceUrl();
@@ -75,13 +75,13 @@ public class CheckYourAnswers : ResponsePageModel<CheckYourAnswers>
         if (!submittedConfirmationModel.IsValid && submittedConfirmationModel.ErrorStatus == HttpStatusCode.NotFound.ToString())
         {
             TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage(nameof(ErrorModel));
+            return RedirectToPage("/ErrorModel");
         }
 
         if (!submittedConfirmationModel.IsValid && submittedConfirmationModel.ErrorStatus == HttpStatusCode.InternalServerError.ToString())
         {
             TempData["Status"] = HttpStatusCode.InternalServerError;
-            return RedirectToPage(nameof(ErrorModel));
+            return RedirectToPage("/ErrorModel");
         }
 
         if (!string.IsNullOrEmpty(submittedConfirmationModel.SupportReferenceNumber))

--- a/UI/Pages/Enquiry/Respond/CheckYourAnswers.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/CheckYourAnswers.cshtml.cs
@@ -38,8 +38,7 @@ public class CheckYourAnswers : ResponsePageModel<CheckYourAnswers>
 
         if (!isValidMagicLink)
         {
-            TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage("/ErrorModel");
+            return NotFound();
         }
 
         ModelState.Clear();
@@ -59,8 +58,7 @@ public class CheckYourAnswers : ResponsePageModel<CheckYourAnswers>
 
         if (!isValidMagicLink)
         {
-            TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage("/ErrorModel");
+            return NotFound();
         }
 
         Data.BaseServiceUrl = Request.GetBaseServiceUrl();
@@ -74,14 +72,13 @@ public class CheckYourAnswers : ResponsePageModel<CheckYourAnswers>
 
         if (!submittedConfirmationModel.IsValid && submittedConfirmationModel.ErrorStatus == HttpStatusCode.NotFound.ToString())
         {
-            TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage("/ErrorModel");
+            return NotFound();
         }
 
         if (!submittedConfirmationModel.IsValid && submittedConfirmationModel.ErrorStatus == HttpStatusCode.InternalServerError.ToString())
         {
             TempData["Status"] = HttpStatusCode.InternalServerError;
-            return RedirectToPage("/ErrorModel");
+            return RedirectToPage(nameof(ErrorModel));
         }
 
         if (!string.IsNullOrEmpty(submittedConfirmationModel.SupportReferenceNumber))

--- a/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml.cs
@@ -24,7 +24,7 @@ public class EnquirerResponse : PageModel
         if (string.IsNullOrEmpty(SupportReferenceNumber) || string.IsNullOrEmpty(queryToken) || string.IsNullOrEmpty(TuitionPartnerSeoUrl))
         {
             TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage(nameof(ErrorModel));
+            return RedirectToPage("/ErrorModel");
         }
 
         if (!string.IsNullOrEmpty(SupportReferenceNumber))
@@ -42,7 +42,7 @@ public class EnquirerResponse : PageModel
         if (!isValidMagicLink)
         {
             TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage(nameof(ErrorModel));
+            return RedirectToPage("/ErrorModel");
         }
 
         try

--- a/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/EnquirerResponse.cshtml.cs
@@ -23,8 +23,7 @@ public class EnquirerResponse : PageModel
 
         if (string.IsNullOrEmpty(SupportReferenceNumber) || string.IsNullOrEmpty(queryToken) || string.IsNullOrEmpty(TuitionPartnerSeoUrl))
         {
-            TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage("/ErrorModel");
+            return NotFound();
         }
 
         if (!string.IsNullOrEmpty(SupportReferenceNumber))
@@ -41,8 +40,7 @@ public class EnquirerResponse : PageModel
 
         if (!isValidMagicLink)
         {
-            TempData["Status"] = HttpStatusCode.NotFound;
-            return RedirectToPage("/ErrorModel");
+            return NotFound();
         }
 
         try

--- a/UI/Pages/Enquiry/Respond/EnquirerViewTuitionPartnerDetails.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/EnquirerViewTuitionPartnerDetails.cshtml.cs
@@ -24,7 +24,7 @@ namespace UI.Pages.Enquiry.Respond
             if (string.IsNullOrEmpty(SupportReferenceNumber) || string.IsNullOrEmpty(queryToken) || string.IsNullOrEmpty(TuitionPartnerSeoUrl))
             {
                 TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage(nameof(ErrorModel));
+                return RedirectToPage("/ErrorModel");
             }
 
             if (!string.IsNullOrEmpty(SupportReferenceNumber))
@@ -42,7 +42,7 @@ namespace UI.Pages.Enquiry.Respond
             if (!isValidMagicLink)
             {
                 TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage(nameof(ErrorModel));
+                return RedirectToPage("/ErrorModel");
             }
 
             try

--- a/UI/Pages/Enquiry/Respond/EnquirerViewTuitionPartnerDetails.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/EnquirerViewTuitionPartnerDetails.cshtml.cs
@@ -23,8 +23,7 @@ namespace UI.Pages.Enquiry.Respond
 
             if (string.IsNullOrEmpty(SupportReferenceNumber) || string.IsNullOrEmpty(queryToken) || string.IsNullOrEmpty(TuitionPartnerSeoUrl))
             {
-                TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage("/ErrorModel");
+                return NotFound();
             }
 
             if (!string.IsNullOrEmpty(SupportReferenceNumber))
@@ -41,8 +40,7 @@ namespace UI.Pages.Enquiry.Respond
 
             if (!isValidMagicLink)
             {
-                TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage("/ErrorModel");
+                return NotFound();
             }
 
             try

--- a/UI/Pages/Enquiry/Respond/Response.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/Response.cshtml.cs
@@ -22,8 +22,7 @@ namespace UI.Pages.Enquiry.Respond
 
             if (string.IsNullOrEmpty(SupportReferenceNumber) || string.IsNullOrEmpty(queryToken) || string.IsNullOrEmpty(TuitionPartnerSeoUrl))
             {
-                TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage("/ErrorModel");
+                return NotFound();
             }
 
             Data.SupportReferenceNumber = SupportReferenceNumber;
@@ -35,8 +34,7 @@ namespace UI.Pages.Enquiry.Respond
 
             if (!isValidMagicLink)
             {
-                TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage("/ErrorModel");
+                return NotFound();
             }
 
             Data.BaseServiceUrl = Request.GetBaseServiceUrl();
@@ -46,8 +44,7 @@ namespace UI.Pages.Enquiry.Respond
 
             if (enquiryData == null)
             {
-                TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage("/ErrorModel");
+                return NotFound();
             }
 
             Data.EnquiryResponseCloseDateFormatted = enquiryData.EnquiryCreatedDateTime.AddDays(IntegerConstants.EnquiryDaysToRespond).ToString("h:mmtt 'on' dddd d MMMM yyyy");
@@ -90,8 +87,7 @@ namespace UI.Pages.Enquiry.Respond
 
                 if (!isValidMagicLink)
                 {
-                    TempData["Status"] = HttpStatusCode.NotFound;
-                    return RedirectToPage("/ErrorModel");
+                    return NotFound();
                 }
 
                 Data.BaseServiceUrl = Request.GetBaseServiceUrl();

--- a/UI/Pages/Enquiry/Respond/Response.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/Response.cshtml.cs
@@ -23,7 +23,7 @@ namespace UI.Pages.Enquiry.Respond
             if (string.IsNullOrEmpty(SupportReferenceNumber) || string.IsNullOrEmpty(queryToken) || string.IsNullOrEmpty(TuitionPartnerSeoUrl))
             {
                 TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage(nameof(ErrorModel));
+                return RedirectToPage("/ErrorModel");
             }
 
             Data.SupportReferenceNumber = SupportReferenceNumber;
@@ -36,7 +36,7 @@ namespace UI.Pages.Enquiry.Respond
             if (!isValidMagicLink)
             {
                 TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage(nameof(ErrorModel));
+                return RedirectToPage("/ErrorModel");
             }
 
             Data.BaseServiceUrl = Request.GetBaseServiceUrl();
@@ -47,7 +47,7 @@ namespace UI.Pages.Enquiry.Respond
             if (enquiryData == null)
             {
                 TempData["Status"] = HttpStatusCode.NotFound;
-                return RedirectToPage(nameof(ErrorModel));
+                return RedirectToPage("/ErrorModel");
             }
 
             Data.EnquiryResponseCloseDateFormatted = enquiryData.EnquiryCreatedDateTime.AddDays(IntegerConstants.EnquiryDaysToRespond).ToString("h:mmtt 'on' dddd d MMMM yyyy");
@@ -91,7 +91,7 @@ namespace UI.Pages.Enquiry.Respond
                 if (!isValidMagicLink)
                 {
                     TempData["Status"] = HttpStatusCode.NotFound;
-                    return RedirectToPage(nameof(ErrorModel));
+                    return RedirectToPage("/ErrorModel");
                 }
 
                 Data.BaseServiceUrl = Request.GetBaseServiceUrl();


### PR DESCRIPTION
After a TP has responded, if they click on the response link they are sent to a 404 page, by design.

But there is a [logit.io](http://logit.io/) error that should not happen
NOTE: This does not impact the user in any way

The fixes against this PR are for 404 errors, other errors will be dealt with as part of https://dfedigital.atlassian.net/browse/NTP-1044

## Context

Stop errors being thrown, even if no impact on user

## Changes proposed in this pull request

Change the redirect so that it uses text to link rather than `nameof()`

## Guidance to review

Create an enquiry, complete a response, then use the same response link again.  Check that the user goes to a 404, but that no errors are logged in logit.io

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1142

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [x] **PR deployment has been signed off by wider team**