### PR TITLE
NTP-1164: Restructure the code folders to align with the enquiry routes

### DIFF
--- a/Application/Commands/Enquiry/Build/AddEnquiryCommand.cs
+++ b/Application/Commands/Enquiry/Build/AddEnquiryCommand.cs
@@ -11,7 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using TuitionType = Domain.Enums.TuitionType;
 
-namespace Application.Commands;
+namespace Application.Commands.Enquiry.Build;
 
 public record AddEnquiryCommand : IRequest<SubmittedConfirmationModel>
 {
@@ -80,7 +80,7 @@ public class AddEnquiryCommandHandler : IRequestHandler<AddEnquiryCommand, Submi
 
         var tuitionTypeId = GetTuitionTypeId(request.Data!.TuitionType);
 
-        var enquiry = new Enquiry()
+        var enquiry = new Domain.Enquiry()
         {
             Email = request.Data?.Email!,
             TutoringLogistics = request.Data?.TutoringLogistics!,
@@ -293,7 +293,7 @@ public class AddEnquiryCommandHandler : IRequestHandler<AddEnquiryCommand, Submi
         return null;
     }
 
-    private async Task HandleDbUpdateException(DbUpdateException ex, Enquiry enquiry)
+    private async Task HandleDbUpdateException(DbUpdateException ex, Domain.Enquiry enquiry)
     {
         var dataSaved = false;
         var retryAttempt = 0;
@@ -337,7 +337,7 @@ public class AddEnquiryCommandHandler : IRequestHandler<AddEnquiryCommand, Submi
         }
     }
 
-    private async Task TrySendEnquirySubmittedConfirmationToEnquirerEmail(Enquiry enquiry,
+    private async Task TrySendEnquirySubmittedConfirmationToEnquirerEmail(Domain.Enquiry enquiry,
         NotificationsRecipientDto getEnquirySubmittedConfirmationToEnquirerNotificationsRecipient)
     {
         try
@@ -353,7 +353,7 @@ public class AddEnquiryCommandHandler : IRequestHandler<AddEnquiryCommand, Submi
         }
     }
 
-    private async Task CleanUpData(Enquiry enquiry)
+    private async Task CleanUpData(Domain.Enquiry enquiry)
     {
         _unitOfWork.EnquiryRepository.Remove(enquiry);
         var tpMagicLinks = await _unitOfWork.TuitionPartnerEnquiryRepository

--- a/Application/Commands/Enquiry/Respond/AddEnquiryResponseCommand.cs
+++ b/Application/Commands/Enquiry/Respond/AddEnquiryResponseCommand.cs
@@ -1,6 +1,6 @@
-using System.Net;
 using Application.Common.DTO;
 using Application.Common.Interfaces;
+using Application.Common.Models.Enquiry;
 using Application.Common.Models.Enquiry.Respond;
 using Application.Constants;
 using Application.Extensions;
@@ -8,11 +8,11 @@ using Domain;
 using Domain.Enums;
 using Microsoft.Extensions.Logging;
 
-namespace Application.Commands;
+namespace Application.Commands.Enquiry.Respond;
 
 public record AddEnquiryResponseCommand : IRequest<ResponseConfirmationModel>
 {
-    public EnquiryResponseModel Data { get; set; } = null!;
+    public EnquiryResponseBaseModel Data { get; set; } = null!;
 }
 
 public class AddEnquiryResponseCommandHandler : IRequestHandler<AddEnquiryResponseCommand, ResponseConfirmationModel>

--- a/Application/Common/Interfaces/Repositories/IEnquiryRepository.cs
+++ b/Application/Common/Interfaces/Repositories/IEnquiryRepository.cs
@@ -1,4 +1,4 @@
-using Application.Common.Models.Enquiry.Respond;
+using Application.Common.Models.Enquiry.Manage;
 using Domain;
 
 namespace Application.Common.Interfaces.Repositories;

--- a/Application/Common/Interfaces/Repositories/ITuitionPartnerEnquiryRepository.cs
+++ b/Application/Common/Interfaces/Repositories/ITuitionPartnerEnquiryRepository.cs
@@ -1,4 +1,4 @@
-using Application.Common.Models.Enquiry.Respond;
+using Application.Common.Models.Enquiry.Manage;
 using Domain;
 
 namespace Application.Common.Interfaces.Repositories;

--- a/Application/Common/Models/Enquiry/EnquiryBaseModel.cs
+++ b/Application/Common/Models/Enquiry/EnquiryBaseModel.cs
@@ -1,4 +1,4 @@
-namespace Application.Common.Models.Enquiry.Build;
+namespace Application.Common.Models.Enquiry;
 
 public record EnquiryBaseModel : SearchModel
 {

--- a/Application/Common/Models/Enquiry/EnquiryResponseBaseModel.cs
+++ b/Application/Common/Models/Enquiry/EnquiryResponseBaseModel.cs
@@ -1,8 +1,6 @@
-using Application.Common.Models.Enquiry.Build;
+namespace Application.Common.Models.Enquiry;
 
-namespace Application.Common.Models.Enquiry.Respond;
-
-public record EnquiryResponseModel : EnquiryBaseModel
+public record EnquiryResponseBaseModel : EnquiryBaseModel
 {
     public string TuitionPartnerName { get; set; } = string.Empty;
 

--- a/Application/Common/Models/Enquiry/Manage/EnquirerViewAllResponsesModel.cs
+++ b/Application/Common/Models/Enquiry/Manage/EnquirerViewAllResponsesModel.cs
@@ -1,6 +1,6 @@
 using Application.Common.DTO;
 
-namespace Application.Common.Models.Enquiry.Respond;
+namespace Application.Common.Models.Enquiry.Manage;
 
 public class EnquirerViewAllResponsesModel
 {

--- a/Application/Common/Models/Enquiry/Manage/EnquirerViewResponseModel.cs
+++ b/Application/Common/Models/Enquiry/Manage/EnquirerViewResponseModel.cs
@@ -1,0 +1,3 @@
+namespace Application.Common.Models.Enquiry.Manage;
+
+public record EnquirerViewResponseModel : EnquiryResponseBaseModel;

--- a/Application/Common/Models/Enquiry/Manage/EnquirerViewTuitionPartnerDetailsModel.cs
+++ b/Application/Common/Models/Enquiry/Manage/EnquirerViewTuitionPartnerDetailsModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Application.Common.Models.Enquiry.Respond;
+﻿namespace Application.Common.Models.Enquiry.Manage;
 
 public record EnquirerViewTuitionPartnerDetailsModel
 {

--- a/Application/Common/Models/Enquiry/Respond/CheckYourAnswersModel.cs
+++ b/Application/Common/Models/Enquiry/Respond/CheckYourAnswersModel.cs
@@ -1,3 +1,3 @@
 namespace Application.Common.Models.Enquiry.Respond;
 
-public record CheckYourAnswersModel : EnquiryResponseModel;
+public record CheckYourAnswersModel : EnquiryResponseBaseModel;

--- a/Application/Common/Models/Enquiry/Respond/EnquirerViewResponseModel.cs
+++ b/Application/Common/Models/Enquiry/Respond/EnquirerViewResponseModel.cs
@@ -1,3 +1,0 @@
-namespace Application.Common.Models.Enquiry.Respond;
-
-public record EnquirerViewResponseModel : EnquiryResponseModel;

--- a/Application/Common/Models/Enquiry/Respond/ViewAndCaptureEnquiryResponseModel.cs
+++ b/Application/Common/Models/Enquiry/Respond/ViewAndCaptureEnquiryResponseModel.cs
@@ -1,6 +1,6 @@
 namespace Application.Common.Models.Enquiry.Respond;
 
-public record ViewAndCaptureEnquiryResponseModel : EnquiryResponseModel
+public record ViewAndCaptureEnquiryResponseModel : EnquiryResponseBaseModel
 {
     public string EnquiryResponseCloseDateFormatted { get; set; } = string.Empty;
 }

--- a/Application/Queries/Enquiry/GetEnquirerViewAllResponsesQuery.cs
+++ b/Application/Queries/Enquiry/GetEnquirerViewAllResponsesQuery.cs
@@ -1,7 +1,7 @@
 using Application.Common.Interfaces;
-using Application.Common.Models.Enquiry.Respond;
+using Application.Common.Models.Enquiry.Manage;
 
-namespace Application.Queries;
+namespace Application.Queries.Enquiry;
 
 public record GetEnquirerViewAllResponsesQuery(string SupportReferenceNumber) : IRequest<EnquirerViewAllResponsesModel>;
 

--- a/Application/Queries/Enquiry/IsValidMagicLinkTokenQuery.cs
+++ b/Application/Queries/Enquiry/IsValidMagicLinkTokenQuery.cs
@@ -1,7 +1,7 @@
 using Application.Common.Interfaces;
 using Microsoft.Extensions.Logging;
 
-namespace Application.Queries;
+namespace Application.Queries.Enquiry;
 
 public record IsValidMagicLinkTokenQuery(string Token, string SupportReferenceNumber, string? TuitionPartnerSeoUrl = null, bool IsTuitionPartnerResponse = false) : IRequest<bool>;
 

--- a/Application/Queries/Enquiry/Manage/GetEnquirerViewResponseQuery.cs
+++ b/Application/Queries/Enquiry/Manage/GetEnquirerViewResponseQuery.cs
@@ -1,8 +1,8 @@
 using Application.Common.Interfaces;
-using Application.Common.Models.Enquiry.Respond;
+using Application.Common.Models.Enquiry.Manage;
 using Microsoft.Extensions.Logging;
 
-namespace Application.Queries;
+namespace Application.Queries.Enquiry.Manage;
 
 public record GetEnquirerViewResponseQuery(string SupportReferenceNumber, string TuitionPartnerSeoUrl) : IRequest<EnquirerViewResponseModel?>;
 

--- a/Application/Queries/Enquiry/Manage/GetEnquirerViewTuitionPartnerDetailsQuery.cs
+++ b/Application/Queries/Enquiry/Manage/GetEnquirerViewTuitionPartnerDetailsQuery.cs
@@ -1,8 +1,8 @@
 ﻿using Application.Common.Interfaces;
-using Application.Common.Models.Enquiry.Respond;
+using Application.Common.Models.Enquiry.Manage;
 using Microsoft.Extensions.Logging;
 
-namespace Application.Queries;
+namespace Application.Queries.Enquiry.Manage;
 
 public record GetEnquirerViewTuitionPartnerDetailsQuery(string SupportReferenceNumber, string TuitionPartnerSeoUrl) : IRequest<EnquirerViewTuitionPartnerDetailsModel?>;
 

--- a/Infrastructure/Repositories/EnquiryRepository.cs
+++ b/Infrastructure/Repositories/EnquiryRepository.cs
@@ -1,6 +1,6 @@
 using Application.Common.DTO;
 using Application.Common.Interfaces.Repositories;
-using Application.Common.Models.Enquiry.Respond;
+using Application.Common.Models.Enquiry.Manage;
 using Application.Extensions;
 using Domain;
 using Microsoft.EntityFrameworkCore;

--- a/Infrastructure/Repositories/TuitionPartnerEnquiryRepository.cs
+++ b/Infrastructure/Repositories/TuitionPartnerEnquiryRepository.cs
@@ -1,5 +1,5 @@
 using Application.Common.Interfaces.Repositories;
-using Application.Common.Models.Enquiry.Respond;
+using Application.Common.Models.Enquiry.Manage;
 using Application.Extensions;
 using Domain;
 using Microsoft.EntityFrameworkCore;

--- a/UI/Extensions/EnquiryResponseModelExtensions.cs
+++ b/UI/Extensions/EnquiryResponseModelExtensions.cs
@@ -1,10 +1,10 @@
-using Application.Common.Models.Enquiry.Respond;
+using Application.Common.Models.Enquiry;
 
 namespace UI.Extensions;
 
 public static class EnquiryResponseModelExtensions
 {
-    public static void EnquiryResponseParseSessionValues(this EnquiryResponseModel data, string key, string value)
+    public static void EnquiryResponseParseSessionValues(this EnquiryResponseBaseModel data, string key, string value)
     {
         switch (key)
         {

--- a/UI/Models/ResponsePageModel.cs
+++ b/UI/Models/ResponsePageModel.cs
@@ -1,6 +1,6 @@
 ﻿using Application.Common.Interfaces;
 
-namespace UI.Pages.Enquiry.Respond
+namespace UI.Models
 {
     public class ResponsePageModel<T> : PageModel where T : PageModel
     {

--- a/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
+++ b/UI/Pages/Enquiry/Build/CheckYourAnswers.cshtml.cs
@@ -1,3 +1,4 @@
+using Application.Commands.Enquiry.Build;
 using Application.Common.Interfaces;
 using Application.Common.Models;
 using Application.Common.Models.Enquiry.Build;

--- a/UI/Pages/Enquiry/Manage/AllEnquirerResponses.cshtml
+++ b/UI/Pages/Enquiry/Manage/AllEnquirerResponses.cshtml
@@ -1,5 +1,5 @@
 @page "/enquiry/{supportReferenceNumber}"
-@model UI.Pages.Enquiry.Respond.AllEnquirerResponses
+@model UI.Pages.Enquiry.Manage.AllEnquirerResponses
 @using GovUk.Frontend.AspNetCore.TagHelpers
 @{
   ViewData["Title"] = "View all responses";

--- a/UI/Pages/Enquiry/Manage/AllEnquirerResponses.cshtml.cs
+++ b/UI/Pages/Enquiry/Manage/AllEnquirerResponses.cshtml.cs
@@ -1,7 +1,7 @@
-using Application.Common.Models.Enquiry.Respond;
+using Application.Common.Models.Enquiry.Manage;
+using Application.Queries.Enquiry;
 
-
-namespace UI.Pages.Enquiry.Respond
+namespace UI.Pages.Enquiry.Manage
 {
     public class AllEnquirerResponses : PageModel
     {

--- a/UI/Pages/Enquiry/Manage/EnquirerResponse.cshtml
+++ b/UI/Pages/Enquiry/Manage/EnquirerResponse.cshtml
@@ -1,5 +1,5 @@
 @page "/enquiry/{supportReferenceNumber}/{tuitionPartnerSeoUrl}"
-@model UI.Pages.Enquiry.Respond.EnquirerResponse
+@model UI.Pages.Enquiry.Manage.EnquirerResponse
 @{
   var baseServiceUrl = Request.GetBaseServiceUrl();
   var backLink = $"{baseServiceUrl}/enquiry/{Model.SupportReferenceNumber}?Token={Model.Data.Token}";

--- a/UI/Pages/Enquiry/Manage/EnquirerResponse.cshtml.cs
+++ b/UI/Pages/Enquiry/Manage/EnquirerResponse.cshtml.cs
@@ -1,6 +1,8 @@
-using Application.Common.Models.Enquiry.Respond;
+using Application.Common.Models.Enquiry.Manage;
+using Application.Queries.Enquiry;
+using Application.Queries.Enquiry.Manage;
 
-namespace UI.Pages.Enquiry.Respond;
+namespace UI.Pages.Enquiry.Manage;
 
 public class EnquirerResponse : PageModel
 {

--- a/UI/Pages/Enquiry/Manage/EnquirerViewTuitionPartnerDetails.cshtml
+++ b/UI/Pages/Enquiry/Manage/EnquirerViewTuitionPartnerDetails.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/enquiry/{supportReferenceNumber}/{tuitionPartnerSeoUrl}/contact-details"
-@model UI.Pages.Enquiry.Respond.EnquirerViewTuitionPartnerDetails
+@model UI.Pages.Enquiry.Manage.EnquirerViewTuitionPartnerDetails
 @{
   var baseServiceUrl = Request.GetBaseServiceUrl();
   var backLink = $"{baseServiceUrl}/enquiry/{Model.SupportReferenceNumber}/{Model.TuitionPartnerSeoUrl}?Token={@Model.Data.Token}";

--- a/UI/Pages/Enquiry/Manage/EnquirerViewTuitionPartnerDetails.cshtml.cs
+++ b/UI/Pages/Enquiry/Manage/EnquirerViewTuitionPartnerDetails.cshtml.cs
@@ -1,6 +1,8 @@
-using Application.Common.Models.Enquiry.Respond;
+using Application.Common.Models.Enquiry.Manage;
+using Application.Queries.Enquiry;
+using Application.Queries.Enquiry.Manage;
 
-namespace UI.Pages.Enquiry.Respond
+namespace UI.Pages.Enquiry.Manage
 {
     public class EnquirerViewTuitionPartnerDetails : PageModel
     {

--- a/UI/Pages/Enquiry/Respond/CheckYourAnswers.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/CheckYourAnswers.cshtml.cs
@@ -1,5 +1,8 @@
+using Application.Commands.Enquiry.Respond;
 using Application.Common.Interfaces;
 using Application.Common.Models.Enquiry.Respond;
+using Application.Queries.Enquiry;
+using UI.Models;
 
 namespace UI.Pages.Enquiry.Respond;
 

--- a/UI/Pages/Enquiry/Respond/Response.cshtml.cs
+++ b/UI/Pages/Enquiry/Respond/Response.cshtml.cs
@@ -1,5 +1,7 @@
 using Application.Common.Interfaces;
 using Application.Common.Models.Enquiry.Respond;
+using Application.Queries.Enquiry;
+using UI.Models;
 
 namespace UI.Pages.Enquiry.Respond
 {


### PR DESCRIPTION
## Context

Restructure the code folders to align with the enquiry routes

## Changes proposed in this pull request

Should the .NET code folder structure be restructured slightly - e.g. update “UI\Pages\Enquiry\Respond“ so that it is “UI\Pages\Enquiry\Respond“ and “UI\Pages\Enquiry\Manage“, so that the TP and enquirer pages and code are separated in a similar way to the routes.

## Guidance to review

Only changes are files being moved and namespaces updated - test that all correct

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1164

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**