### PR TITLE
NTP-1183: Change CF CLI binary back to the CF URL

### DIFF
--- a/.github/workflows/deploy-to-gpaas.yml
+++ b/.github/workflows/deploy-to-gpaas.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install the CF CLI
         run: |
-          wget -v -O cf.tar.gz "https://s177d01corec7afkt3qxq7ie.blob.core.windows.net/ash-temp-cloudfoundry-cli/cf8-cli_8.6.1_linux_x86-64.tgz"
+          wget -v -O cf.tar.gz "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v8"
           sudo tar xzf cf.tar.gz --wildcards --directory /usr/local/bin/ "cf*"
 
       - name: Authenticate

--- a/.github/workflows/import-data.yml
+++ b/.github/workflows/import-data.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Install the CF CLI
         run: |
-          wget -v -O cf.tar.gz "https://s177d01corec7afkt3qxq7ie.blob.core.windows.net/ash-temp-cloudfoundry-cli/cf8-cli_8.6.1_linux_x86-64.tgz"
+          wget -v -O cf.tar.gz "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v8"
           sudo tar xzf cf.tar.gz --wildcards --directory /usr/local/bin/ "cf*"
 
       - name: Authenticate

--- a/.github/workflows/pull-request-teardown.yml
+++ b/.github/workflows/pull-request-teardown.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - name: Install the CF CLI
       run: |
-        wget -v -O cf.tar.gz "https://s177d01corec7afkt3qxq7ie.blob.core.windows.net/ash-temp-cloudfoundry-cli/cf8-cli_8.6.1_linux_x86-64.tgz"
+        wget -v -O cf.tar.gz "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v8"
         sudo tar xzf cf.tar.gz --wildcards --directory /usr/local/bin/ "cf*"
 
     - name: Authenticate

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Install the CF CLI
       run: |
-        wget -v -O cf.tar.gz "https://s177d01corec7afkt3qxq7ie.blob.core.windows.net/ash-temp-cloudfoundry-cli/cf8-cli_8.6.1_linux_x86-64.tgz"
+        wget -v -O cf.tar.gz "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v8"
         sudo tar xzf cf.tar.gz --wildcards --directory /usr/local/bin/ "cf*"
 
     - name: Authenticate


### PR DESCRIPTION
## Changes proposed in this pull request

Undoes the temporary change where the CF CLI binaries were copied to a BLOB store as the CF CDN was broken for a time.

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1183

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code