### PR TITLE
NTP-1201: 2023-2024 guidance links

### DIFF
--- a/UI/Pages/AllTuitionPartners.cshtml
+++ b/UI/Pages/AllTuitionPartners.cshtml
@@ -102,6 +102,9 @@
       <p class="govuk-body">
         <a class="govuk-link" href="https://www.gov.uk/government/publications/national-tutoring-programme-guidance-for-schools-2022-to-2023/national-tutoring-programme-guidance-for-schools-2022-to-2023">NTP guidance for schools 2022 to 2023</a>.
       </p>
+      <p class="govuk-body">
+        <a class="govuk-link" href="https://www.gov.uk/government/publications/national-tutoring-programme-guidance-for-schools-academic-year-202324/national-tutoring-programme-guidance-for-schools-academic-year-202324">NTP guidance for schools 2023 to 2024</a>.
+      </p>
     </div>
   </form>
 </div>

--- a/UI/Pages/Index.cshtml
+++ b/UI/Pages/Index.cshtml
@@ -68,6 +68,9 @@
     <p class="govuk-body">
       <a class="govuk-link" href="https://www.gov.uk/government/publications/national-tutoring-programme-guidance-for-schools-2022-to-2023/national-tutoring-programme-guidance-for-schools-2022-to-2023">NTP guidance for schools 2022 to 2023</a>.
     </p>
+    <p class="govuk-body">
+      <a class="govuk-link" href="https://www.gov.uk/government/publications/national-tutoring-programme-guidance-for-schools-academic-year-202324/national-tutoring-programme-guidance-for-schools-academic-year-202324">NTP guidance for schools 2023 to 2024</a>.
+    </p>
     <h2 class="govuk-heading-m" data-testid="check-your-tp-quality-assured">Check your tuition partner is quality assured</h2>
     <p class="govuk-body">You can only use your NTP funding with quality-assured tuition partners.</p>
     <p class="govuk-body"><a asp-page="@nameof(AllTuitionPartners)" class="govuk-link" data-testid="full-list-link">Check the full list of quality-assured tuition partners</a>.</p>

--- a/UI/Pages/TuitionPartner.cshtml
+++ b/UI/Pages/TuitionPartner.cshtml
@@ -98,8 +98,12 @@
         <h2 class="govuk-heading-m">Tuition cost information</h2>
 
         <p class="govuk-body">
-          For help understanding your funding, you can find out more on: <a class="govuk-link" href="https://www.gov.uk/government/publications/national-tutoring-programme-guidance-for-schools-2022-to-2023/national-tutoring-programme-guidance-for-schools-2022-to-2023">NTP guidance for schools 2022 to 2023</a>
+          For help understanding your funding, you can find out more on:
         </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li><a class="govuk-link" href="https://www.gov.uk/government/publications/national-tutoring-programme-guidance-for-schools-2022-to-2023/national-tutoring-programme-guidance-for-schools-2022-to-2023">NTP guidance for schools 2022 to 2023</a></li>
+          <li><a class="govuk-link" href="https://www.gov.uk/government/publications/national-tutoring-programme-guidance-for-schools-academic-year-202324/national-tutoring-programme-guidance-for-schools-academic-year-202324">NTP guidance for schools 2023 to 2024</a></li>
+        </ul>
       </div>
 
       <h2 class="govuk-heading-m">Tuition prices</h2>


### PR DESCRIPTION
## Context

Add in new links to the 2023-24 guidance website pages

## Changes proposed in this pull request

Add another link for the 2023-24 year guidance where the 22-23 guidance has been placed.

The new year guidance should always appear below the 22-23 guidance

Start Page - in the ‘related links’ section as a new line below 22-23 guidance

NTP guidance for schools 2022 to 2023 (existing)

NTP guidance for schools 2023 to 2024 (NEW)

Search TPs page - in the ‘related links’ section as a new line below 22-23 guidance

NTP guidance for schools 2022 to 2023 (existing)

NTP guidance for schools 2023 to 2024 (NEW)

TP details page - in the ‘tuition cost information’ section as a new line below 22-23 guidance - they should both be bullet points here rather than in-line with the other text as they are now. So we should have:

Line of existing copy (not bullet point) “For help understanding your funding, you can find out more on”: (add colon)

Bullet point: NTP guidance for schools 2022 to 2023 [Link and URL already in place]

bullet point: NTP guidance for schools 2023 to 2024 [USE URL at top of ticket]

## Guidance to review

Review all content changes as detailed above

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1201

## Things to check

- [ ] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**