### PR TITLE
NTP-1130: Change mobile version of search heading to match desktop

### DIFF
--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -50,10 +50,7 @@
     </govuk-error-summary>
 
     <span show-if="@validResults" class="govuk-caption-l"><strong data-testid="result-count">@count</strong> tuition @partnersPlural for <strong>@Model.Data!.Results!.LocalAuthorityDistrictName</strong></span>
-    <h1 class="govuk-heading-l app-print-hide">
-      <span class="app-results-filter--desktop">Your options for choosing a tuition partner</span>
-      <span class="app-results-filter--non-desktop">Your options now</span>
-    </h1>
+    <h1 class="govuk-heading-l app-print-hide">Your options for choosing a tuition partner</h1>
 
   </div>
 </div>

--- a/UI/cypress/e2e/mobile.feature
+++ b/UI/cypress/e2e/mobile.feature
@@ -22,12 +22,12 @@ Feature: Tuition partner details mobile view page tests
   Scenario: Search results page heading is 'Find a tuition partner' in tablet and above view
     Given a user has arrived on the 'Search results' page
     And a user is using a 'tablet'
-    Then the search results page heading is 'Your options for choosing a tuition partner'
+    Then the heading of the page has text 'Your options for choosing a tuition partner'
 
   Scenario: Search results page heading is 'Search results' in mobile phone view
     Given a user has arrived on the 'Search results' page
     And a user is using a 'phone'
-    Then the search results page heading is 'Your options now'
+    Then heading of the page has text 'Your options for choosing a tuition partner'
 
   Scenario: Search results filter heading is 'Filter results' in tablet and above view
     Given a user has arrived on the 'Search results' page

--- a/UI/cypress/e2e/mobile.feature
+++ b/UI/cypress/e2e/mobile.feature
@@ -27,7 +27,7 @@ Feature: Tuition partner details mobile view page tests
   Scenario: Search results page heading is 'Search results' in mobile phone view
     Given a user has arrived on the 'Search results' page
     And a user is using a 'phone'
-    Then heading of the page has text 'Your options for choosing a tuition partner'
+    Then the heading of the page has text 'Your options for choosing a tuition partner'
 
   Scenario: Search results filter heading is 'Filter results' in tablet and above view
     Given a user has arrived on the 'Search results' page

--- a/UI/src/sass/print-this-page.scss
+++ b/UI/src/sass/print-this-page.scss
@@ -115,7 +115,6 @@
     display: none;
   }
 
-  .app-results-filter--non-desktop,
   .app-results-filter-overlay--visible,
   .app-results-filter-overlay--show-filters,
   .app-form-group-inline {

--- a/UI/src/sass/results-filter.scss
+++ b/UI/src/sass/results-filter.scss
@@ -1,20 +1,4 @@
 @media not print {
-  .js-enabled .app-results-filter--desktop {
-    @include govuk-media-query($until: tablet) {
-      display: none;
-    }
-  }
-
-  .app-results-filter--non-desktop {
-    display: none;
-  }
-
-  .js-enabled .app-results-filter--non-desktop {
-    @include govuk-media-query($until: tablet) {
-      display: block;
-    }
-  }
-
   .app-results-filter {
     padding: govuk-spacing(3);
     background-color: govuk-colour("light-grey");


### PR DESCRIPTION
## Context

Change mobile version of search heading to match desktop

## Changes proposed in this pull request

Change mobile version of search heading to match desktop

## Guidance to review

Run cypress test

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1130

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [x] **PR deployment has been signed off by wider team**