### PR TITLE
NTP-1222: Add use of Clarity to Privacy Statement

### DIFF
--- a/UI/Pages/Privacy.cshtml
+++ b/UI/Pages/Privacy.cshtml
@@ -1,337 +1,339 @@
 ﻿@page
 @{
-    ViewData["Title"] = "Privacy notice";
-    ViewData["UseFromReturnUrlElseHome"] = true;
+  ViewData["Title"] = "Privacy notice";
+  ViewData["UseFromReturnUrlElseHome"] = true;
 }
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l" data-testid="privacy-header">Find a tuition partner privacy notice</h1>
-        <p class="govuk-body">
-            This privacy notice explains how the Department for Education (DfE) uses (processes) any
-            personal data you give to us, or any that we may collect about you. This privacy notice should be read
-            alongside the <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter"
-                             data-testid="personal-information-link" class="govuk-link">
-                DfE Personal Information
-            </a>.
-        </p>
-        <p class="govuk-body">
-            For the purposes of relevant data protection legislation, DfE is the data controller for personal
-            information processed in this service.
-            The data processing activity we do is:
-        </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-            <li>
-                getting in contact with you to respond to your enquiry
-            </li>
-            <li>
-                getting in contact with you to request your support in user research
-            </li>
-            <li>
-                analysing service usage data
-            </li>
-        </ul>
-        <p class="govuk-body">
-            When we ask you for personal data, we will:
-        </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-            <li>
-                tell you the reasons we’re asking for it
-            </li>
-            <li>
-                only ask for the information we need
-            </li>
-            <li>
-                make sure we don’t keep it for longer than necessary
-            </li>
-            <li>
-                protect it and make sure only the appropriate people have access to it
-            </li>
-            <li>
-                let you know if we’ll share it with other organisations
-            </li>
-            <li>
-                keep it up to date where necessary
-            </li>
-            <li>
-                consider privacy risks when we’re planning to change the way we use or hold it
-            </li>
-            <li>
-                train our staff to ensure we use and protect it properly
-            </li>
-        </ul>
-        <p class="govuk-body">
-            In return, we ask you to:
-        </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-            <li>
-                give us accurate information
-            </li>
-        </ul>
-        <h2 class="govuk-heading-m">
-            We may process the following types of personal data about you
-        </h2>
-        <p class="govuk-body">
-            We may process:
-        </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-            <li>
-                your first name and last name
-            </li>
-            <li>
-                the email address you provide
-            </li>
-        </ul>
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l" data-testid="privacy-header">Find a tuition partner privacy notice</h1>
+    <p class="govuk-body">
+      This privacy notice explains how the Department for Education (DfE) uses (processes) any
+      personal data you give to us, or any that we may collect about you. This privacy notice should be read
+      alongside the <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter"
+                       data-testid="personal-information-link" class="govuk-link">
+        DfE Personal Information
+      </a>.
+    </p>
+    <p class="govuk-body">
+      For the purposes of relevant data protection legislation, DfE is the data controller for personal
+      information processed in this service.
+      The data processing activity we do is:
+    </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
+      <li>
+        getting in contact with you to respond to your enquiry
+      </li>
+      <li>
+        getting in contact with you to request your support in user research
+      </li>
+      <li>
+        analysing service usage data
+      </li>
+    </ul>
+    <p class="govuk-body">
+      When we ask you for personal data, we will:
+    </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
+      <li>
+        tell you the reasons we’re asking for it
+      </li>
+      <li>
+        only ask for the information we need
+      </li>
+      <li>
+        make sure we don’t keep it for longer than necessary
+      </li>
+      <li>
+        protect it and make sure only the appropriate people have access to it
+      </li>
+      <li>
+        let you know if we’ll share it with other organisations
+      </li>
+      <li>
+        keep it up to date where necessary
+      </li>
+      <li>
+        consider privacy risks when we’re planning to change the way we use or hold it
+      </li>
+      <li>
+        train our staff to ensure we use and protect it properly
+      </li>
+    </ul>
+    <p class="govuk-body">
+      In return, we ask you to give us accurate information.
+    </p>
+    <h2 class="govuk-heading-m">
+      We may process the following types of personal data about you
+    </h2>
+    <p class="govuk-body">
+      We may process:
+    </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
+      <li>
+        your first name and last name
+      </li>
+      <li>
+        the email address you provide
+      </li>
+    </ul>
 
-        <h2 class="govuk-heading-m">
-            What data we collect if you participate in user research
-        </h2>
-        <p class="govuk-body">
-            If you consent to participate in user research we will ask for a consent form to be completed. We may
-            collect the following information about you:
-        </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-            <li>
-                your name
-            </li>
-            <li>
-                the email address you provide
-            </li>
-        </ul>
+    <h2 class="govuk-heading-m">
+      What data we collect if you participate in user research
+    </h2>
+    <p class="govuk-body">
+      If you consent to participate in user research we will ask for a consent form to be completed. We may
+      collect the following information about you:
+    </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
+      <li>
+        your name
+      </li>
+      <li>
+        the email address you provide
+      </li>
+    </ul>
 
-        <h2 class="govuk-heading-m">
-            What data we collect if you submit a feedback form
-        </h2>
-        <p class="govuk-body">
-            If you submit a feedback form we may collect the following information about you:
-        </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-            <li>
-                the email address you provide
-            </li>
-        </ul>
+    <h2 class="govuk-heading-m">
+      What data we collect if you submit a feedback form
+    </h2>
+    <p class="govuk-body">
+      If you submit a feedback form we may collect the email address you provide.
+    </p>
 
-        <h2 class="govuk-heading-m">
-            What data we collect if you submit a tuition partner enquiry
-        </h2>
-        <p class="govuk-body">
-            If you submit a tuition partner enquiry we may collect the following information about you:
-        </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-            <li>
-                the email address you provide
-            </li>
-        </ul>
+    <h2 class="govuk-heading-m">
+      What data we collect if you submit a tuition partner enquiry
+    </h2>
+    <p class="govuk-body">
+      If you submit a tuition partner enquiry we may collect the email address you provide.
+    </p>
 
-        <h2 class="govuk-heading-m">
-            What data we collect and process to improve our service
-        </h2>
-        <p class="govuk-body">
-            We collect and use anonymised data to understand generalised service usage and to allow us to improve the service. Anonymised data is information that has been stripped of any identifying details that would link it to a particular individual or device.
-        </p>
-        <p class="govuk-body">
-            Where you provide your consent, we also use <a href="https://support.google.com/analytics/topic/2919631" class="govuk-link">Google Analytics</a> cookies to collect information about how you use the service. This includes IP addresses.
-        </p>
-        <p class="govuk-body">
-            Google Analytics processes information about:
-        </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-            <li>
-                the pages you visit on the service
-            </li>
-            <li>
-                how long you spend on each page
-            </li>
+    <h2 class="govuk-heading-m">
+      What data we collect and process to improve our service
+    </h2>
+    <p class="govuk-body">
+      We collect and use anonymised data to understand generalised service usage and to allow us to improve the service. Anonymised data is information that has been stripped of any identifying details that would link it to a particular individual or device.
+    </p>
+    <p class="govuk-body">
+      Where you provide your consent, we also use <a href="https://support.google.com/analytics/topic/2919631" class="govuk-link">Google Analytics</a> and <a href="https://privacy.microsoft.com/en-GB/privacystatement" class="govuk-link">Microsoft Clarity</a> cookies to collect information about how you use the service. This includes IP addresses.
+    </p>
+    <p class="govuk-body">
+      Google Analytics processes information about:
+    </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
+      <li>
+        the pages you visit on the service
+      </li>
+      <li>
+        how long you spend on each page
+      </li>
 
-            <li>
-                how you got to the site
-            </li>
-            <li>
-                what you click on while you’re visiting the site
-            </li>
-        </ul>
-        <p class="govuk-body">
-            We make sure you cannot be directly identified by Google Analytics data. We do this by using <a href="https://support.google.com/analytics/answer/2763052" class="govuk-link">Google Analytics’ IP address anonymisation</a> feature and by removing any other personal data from the titles or URLs of the pages you visit.
-        </p>
+      <li>
+        how you got to the site
+      </li>
+      <li>
+        what you click on while you’re visiting the site
+      </li>
+    </ul>
+    <p class="govuk-body">
+      We make sure you cannot be directly identified by Google Analytics data. We do this by using <a href="https://support.google.com/analytics/answer/2763052" class="govuk-link">Google Analytics’ IP address anonymisation</a> feature and by removing any other personal data from the titles or URLs of the pages you visit.
+    </p>
+    <p class="govuk-body">
+      Microsoft Clarity processes information about:
+    </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
+      <li>
+        the pages you visit on the service
+      </li>
+      <li>
+        how long you spend on each page
+      </li>
+      <li>
+        how you interact with the page by scrolling, moving and clicking on each page
+      </li>
+    </ul>
+    <p class="govuk-body">
+      We make sure you cannot be directly identified by Microsoft Clarity data. We do this by assigning a generic user ID that will be assigned to features like Screen Recordings. For more information about how Microsoft collects and uses your data, visit the <a href="https://privacy.microsoft.com/en-GB/privacystatement" class="govuk-link">Microsoft Privacy Statement</a>.
+    </p>
 
-        <h2 class="govuk-heading-l">
-            Why our use of your personal data is lawful
-        </h2>
-        <p class="govuk-body">
-            In order for the use of personal data to be lawful, we need to meet one (or more) conditions in the data
-            protection legislation, as set out in Article 6(1) of the General Data Protection Regulation (GDPR).
-        </p>
-        <p class="govuk-body">
-            For the purpose of DfE ‘Find a tuition partner’, the relevant condition that we are meeting is ‘public task’
-            as specified under Article 6 (1)(e) of the GDPR.
-        </p>
+    <h2 class="govuk-heading-l">
+      Why our use of your personal data is lawful
+    </h2>
+    <p class="govuk-body">
+      In order for the use of personal data to be lawful, we need to meet one (or more) conditions in the data
+      protection legislation, as set out in Article 6(1) of the General Data Protection Regulation (GDPR).
+    </p>
+    <p class="govuk-body">
+      For the purpose of DfE ‘Find a tuition partner’, the relevant condition that we are meeting is ‘public task’
+      as specified under Article 6 (1)(e) of the GDPR.
+    </p>
 
-        <h2 class="govuk-heading-l">
-            Who we share your personal information with
-        </h2>
-        <p class="govuk-body">
-            We may share your information where the law allows, or where we have a legal obligation to do so.
-        </p>
+    <h2 class="govuk-heading-l">
+      Who we share your personal information with
+    </h2>
+    <p class="govuk-body">
+      We may share your information where the law allows, or where we have a legal obligation to do so.
+    </p>
 
-        <h2 class="govuk-heading-l">
-            How long we hold personal information
-        </h2>
-        <p class="govuk-body">
-            We will only retain your personal information for as long as necessary to fulfil the purposes we collected
-            it for, including for the purposes of satisfying any legal, accounting, or reporting requirements, after
-            which point it will be securely destroyed. Under the data protection legislation, and in compliance with the
-            relevant conditions, we can lawfully keep personal data processed purely for research purposes indefinitely.
-        </p>
-        <p class="govuk-body">
-            When you submit a query to the support desk your data will be deleted after 6 years from the date of
-            submission.
-        </p>
-        <p class="govuk-body">
-            Data collected when you submit a feedback form on the service is kept for as long as we need the data for
-            the purpose(s) of research, security and/or delivery of the service.
-        </p>
-        <p class="govuk-body">
-            If you participate in user research, you will be asked to sign a consent form. The consent form and any data
-            captured from a user research session will be kept for up to 2 years.
-        </p>
+    <h2 class="govuk-heading-l">
+      How long we hold personal information
+    </h2>
+    <p class="govuk-body">
+      We will only retain your personal information for as long as necessary to fulfil the purposes we collected
+      it for, including for the purposes of satisfying any legal, accounting, or reporting requirements, after
+      which point it will be securely destroyed. Under the data protection legislation, and in compliance with the
+      relevant conditions, we can lawfully keep personal data processed purely for research purposes indefinitely.
+    </p>
+    <p class="govuk-body">
+      When you submit a query to the support desk your data will be deleted after 6 years from the date of
+      submission.
+    </p>
+    <p class="govuk-body">
+      Data collected when you submit a feedback form on the service is kept for as long as we need the data for
+      the purpose(s) of research, security and/or delivery of the service.
+    </p>
+    <p class="govuk-body">
+      If you participate in user research, you will be asked to sign a consent form. The consent form and any data
+      captured from a user research session will be kept for up to 2 years.
+    </p>
 
-        <h2 class="govuk-heading-l">
-            Your data protection rights
-        </h2>
-        <p class="govuk-body">
-            Under data protection law, you have rights including:
-        </p>
+    <h2 class="govuk-heading-l">
+      Your data protection rights
+    </h2>
+    <p class="govuk-body">
+      Under data protection law, you have rights including:
+    </p>
 
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-            <li>
-                <b>Your right of access - </b>You have the right to ask us for copies of your personal information.
-            </li>
-            <li>
-                <b>Your right to rectification - </b>You have the right to ask us to rectify personal information you
-                think is inaccurate. You also have the right to ask us to complete information you think is incomplete.
-            </li>
-            <li>
-                <b>Your right to erasure - </b>You have the right to ask us to erase your personal information in
-                certain circumstances.
-            </li>
-            <li>
-                <b>Your right to restriction of processing - </b>You have the right to ask us to restrict the processing
-                of your personal information in certain circumstances.
-            </li>
-            <li>
-                <b>Your right to object to processing - </b>You have the right to object to the processing of your
-                personal information in certain circumstances.
-            </li>
-            <li>
-                <b>Your right to data portability - </b>You have the right to ask that we transfer the personal
-                information you gave us to another organisation, or to you, in certain circumstances.
-            </li>
-        </ul>
-        <p class="govuk-body">
-            You are not required to pay any charge for exercising your rights. If you make a request, we have one month
-            to respond to you.
-        </p>
-        <p class="govuk-body">
-            You can find more information about how the DfE handles personal information in <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter"
-               data-testid="personal-information-character-link" class="govuk-link">
-                DfE’s personal
-                information charter
-            </a>.
-        </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
+      <li>
+        <b>Your right of access - </b>You have the right to ask us for copies of your personal information.
+      </li>
+      <li>
+        <b>Your right to rectification - </b>You have the right to ask us to rectify personal information you
+        think is inaccurate. You also have the right to ask us to complete information you think is incomplete.
+      </li>
+      <li>
+        <b>Your right to erasure - </b>You have the right to ask us to erase your personal information in
+        certain circumstances.
+      </li>
+      <li>
+        <b>Your right to restriction of processing - </b>You have the right to ask us to restrict the processing
+        of your personal information in certain circumstances.
+      </li>
+      <li>
+        <b>Your right to object to processing - </b>You have the right to object to the processing of your
+        personal information in certain circumstances.
+      </li>
+      <li>
+        <b>Your right to data portability - </b>You have the right to ask that we transfer the personal
+        information you gave us to another organisation, or to you, in certain circumstances.
+      </li>
+    </ul>
+    <p class="govuk-body">
+      You are not required to pay any charge for exercising your rights. If you make a request, we have one month
+      to respond to you.
+    </p>
+    <p class="govuk-body">
+      You can find more information about how the DfE handles personal information in <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter"
+                                                                                         data-testid="personal-information-character-link" class="govuk-link">
+        DfE’s personal
+        information charter
+      </a>.
+    </p>
 
-        <h2 class="govuk-heading-l">
-            How to make a subject access request (SAR)
-        </h2>
-        <p class="govuk-body">
-            Under the Data Protection Act 2018, you are entitled to ask if we hold information relating to you and ask
-            for a copy, by making a ‘subject access request’. For further information and how to request your data,
-            please use the
-            <a href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen"
-               data-testid="contact-form-link" class="govuk-link">‘contact form’</a> in the Personal
-            Information Charter.
-        </p>
-        <p class="govuk-body">
-            If you have any questions regarding any of the above, you can <a href="https://www.gov.uk/contact-dfe"
-                data-testid="contact-dfe-link" class="govuk-link">contact DfE</a> stating your questions
-            are in regard to the National Tutoring Programme.
-        </p>
-        <p class="govuk-body">
-            Further information about your data protection rights appears on the <a href="https://ico.org.uk/your-data-matters/" data-testid="data-matters-link"
-                class="govuk-link">Information Commissioner’s website</a>
-        </p>
+    <h2 class="govuk-heading-l">
+      How to make a subject access request (SAR)
+    </h2>
+    <p class="govuk-body">
+      Under the Data Protection Act 2018, you are entitled to ask if we hold information relating to you and ask
+      for a copy, by making a ‘subject access request’. For further information and how to request your data,
+      please use the
+      <a href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen"
+         data-testid="contact-form-link" class="govuk-link">‘contact form’</a> in the Personal
+      Information Charter.
+    </p>
+    <p class="govuk-body">
+      If you have any questions regarding any of the above, you can <a href="https://www.gov.uk/contact-dfe"
+                                                                       data-testid="contact-dfe-link" class="govuk-link">contact DfE</a> stating your questions
+      are in regard to the National Tutoring Programme.
+    </p>
+    <p class="govuk-body">
+      Further information about your data protection rights appears on the <a href="https://ico.org.uk/your-data-matters/" data-testid="data-matters-link"
+                                                                              class="govuk-link">Information Commissioner’s website</a>
+    </p>
 
-        <h2 class="govuk-heading-l">
-            Withdrawal of consent
-        </h2>
-        <p class="govuk-body">
-            Where we are processing your personal data with your consent, you have the right to withdraw that consent.
-            If you change your mind, or you are unhappy with our use of your personal data, please let us know by
-            contacting <a href="https://www.gov.uk/contact-dfe" data-testid="contact-link"
-                          class="govuk-link">the Department for Education (DfE)</a> and state the name of this project.
-        </p>
+    <h2 class="govuk-heading-l">
+      Withdrawal of consent
+    </h2>
+    <p class="govuk-body">
+      Where we are processing your personal data with your consent, you have the right to withdraw that consent.
+      If you change your mind, or you are unhappy with our use of your personal data, please let us know by
+      contacting <a href="https://www.gov.uk/contact-dfe" data-testid="contact-link"
+                    class="govuk-link">the Department for Education (DfE)</a> and state the name of this project.
+    </p>
 
-        <h2 class="govuk-heading-l">
-            Get help or raise a concern
-        </h2>
-        <p class="govuk-body">
-            If you would like:
-        </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-            <li>
-                more information about how we process your personal data or your data protection rights
-            </li>
-            <li>
-                to make a request about your information – for example to request a copy of your information or to ask
-                for your information to be changed
-            </li>
-            <li>
-                to contact our Data Protection Officer
-            </li>
-        </ul>
-        <p class="govuk-body">
-            You can contact us in the following ways:
-        </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
-            <li>
-                Using our secure <a href="https://www.gov.uk/contact-dfe"
-                                    data-testid="contact-form-secure-link" class="govuk-link">online contact form</a>
-            </li>
-        </ul>
+    <h2 class="govuk-heading-l">
+      Get help or raise a concern
+    </h2>
+    <p class="govuk-body">
+      If you would like:
+    </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
+      <li>
+        more information about how we process your personal data or your data protection rights
+      </li>
+      <li>
+        to make a request about your information – for example to request a copy of your information or to ask
+        for your information to be changed
+      </li>
+      <li>
+        to contact our Data Protection Officer
+      </li>
+    </ul>
+    <p class="govuk-body">
+      You can contact us in the following ways:
+    </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-4">
+      <li>
+        Using our secure <a href="https://www.gov.uk/contact-dfe"
+                            data-testid="contact-form-secure-link" class="govuk-link">online contact form</a>
+      </li>
+    </ul>
 
-        <h2 class="govuk-heading-l">
-            The right to lodge a complaint
-        </h2>
-        <p class="govuk-body">
-            Contact us using our <a href="https://form.education.gov.uk/service/Contact-the-Department-for-Education"
-                                    data-testid="contact-form-secure-online-link" class="govuk-link">
-                secure online contact
-                form
-            </a> or by writing to:
-        </p>
-        <p class="govuk-body">
-            Emma Wharram<br>
-            Data Protection Officer<br>
-            Department for Education (B2.28)<br>
-            7 & 8 Wellington Place<br>
-            Wellington Street<br>
-            Leeds<br>
-            LS1 4AW
-        </p>
-        <p class="govuk-body">
-            If you wish to contact the DfE’s data protection officer, please use the secure online
-            form or write to the address above, stating your questions are in regards to the National Tutoring
-            Programme.
-        </p>
-        <p class="govuk-body">
-            You also have the right to lodge a complaint about data protection with the <a href="https://ico.org.uk/make-a-complaint/" data-testid="information-link"
-   class="govuk-link">Information Commissioner’s Office</a> (ICO).
-        </p>
+    <h2 class="govuk-heading-l">
+      The right to lodge a complaint
+    </h2>
+    <p class="govuk-body">
+      Contact us using our <a href="https://form.education.gov.uk/service/Contact-the-Department-for-Education"
+                              data-testid="contact-form-secure-online-link" class="govuk-link">
+        secure online contact
+        form
+      </a> or by writing to:
+    </p>
+    <p class="govuk-body">
+      Emma Wharram<br>
+      Data Protection Officer<br>
+      Department for Education (B2.28)<br>
+      7 & 8 Wellington Place<br>
+      Wellington Street<br>
+      Leeds<br>
+      LS1 4AW
+    </p>
+    <p class="govuk-body">
+      If you wish to contact the DfE’s data protection officer, please use the secure online
+      form or write to the address above, stating your questions are in regards to the National Tutoring
+      Programme.
+    </p>
+    <p class="govuk-body">
+      You also have the right to lodge a complaint about data protection with the <a href="https://ico.org.uk/make-a-complaint/" data-testid="information-link"
+                                                                                     class="govuk-link">Information Commissioner’s Office (ICO)</a>.
+    </p>
 
-        <h2 class="govuk-heading-l">
-            Changes to this privacy notice
-        </h2>
-        <p class="govuk-body">
-            We may change this privacy notice and we encourage you to check this privacy notice from time to time.
-        </p>
-        <p class="govuk-body">Date last updated: 29 March 2023</p>
-    </div>
+    <h2 class="govuk-heading-l">
+      Changes to this privacy notice
+    </h2>
+    <p class="govuk-body">
+      We may change this privacy notice and we encourage you to check this privacy notice from time to time.
+    </p>
+    <p class="govuk-body">Date last updated: 12 June 2023</p>
+  </div>
 </div>


### PR DESCRIPTION
## Context

Add use of Clarity to Privacy Statement

## Changes proposed in this pull request

The privacy statement lists tools like Google Analytics that we use to analyse peoples data. We probably need to add the use of MS Clarity to this as we intend to use this.

## Guidance to review

- Use of Microsoft Clarity
- Clean up of bullet points where there is only one bullet point listed
- Date published

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1222

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [x] **PR deployment has been signed off by wider team**