### PR TITLE
NTP-1151: Fix so don't keep logging status update checks after 1st error is logged

### DIFF
--- a/Application/Common/Interfaces/INotificationsClientService.cs
+++ b/Application/Common/Interfaces/INotificationsClientService.cs
@@ -8,5 +8,5 @@ public interface INotificationsClientService
     Task<bool> SendEmailAsync(NotifyEmailDto notifyEmail, bool includeChangedFromEmailAddress = true);
     Task<bool> SendEmailAsync(IEnumerable<NotifyEmailDto> notifyEmails);
 
-    Task<EmailStatus> GetEmailStatus(string notificationId);
+    Task<EmailStatus> GetEmailStatus(string notificationId, int previousStatusId, string? previousExceptionMessage);
 }

--- a/Infrastructure/Services/NotificationsClientService.cs
+++ b/Infrastructure/Services/NotificationsClientService.cs
@@ -88,6 +88,7 @@ public class NotificationsClientService : INotificationsClientService
             }
             else
             {
+                _logger.LogInformation(ex, "A previously reported Notify error has occurred while attempting to SendEmailAsync, email ref: {clientReference}", clientReference);
                 return false;
             }
         }
@@ -116,7 +117,7 @@ public class NotificationsClientService : INotificationsClientService
         return allEmailsSent;
     }
 
-    public async Task<EmailStatus> GetEmailStatus(string notificationId)
+    public async Task<EmailStatus> GetEmailStatus(string notificationId, int previousStatusId, string? previousExceptionMessage)
     {
         try
         {
@@ -125,8 +126,14 @@ public class NotificationsClientService : INotificationsClientService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "An unexpected error has occurred while attempting to GetNotificationById, notificationId: {notificationId}", notificationId);
-            throw;
+            if (string.IsNullOrWhiteSpace(previousExceptionMessage) &&
+                !ex.Message.Equals(previousExceptionMessage))
+            {
+                _logger.LogError(ex, "An unexpected error has occurred while attempting to GetNotificationById, notificationId: {notificationId}", notificationId);
+                throw;
+            }
+            _logger.LogInformation(ex, "A previously reported unexpected error has occurred while attempting to GetNotificationById, notificationId: {notificationId}", notificationId);
+            return (EmailStatus)previousStatusId;
         }
     }
 

--- a/Infrastructure/Services/ProcessEmailsService.cs
+++ b/Infrastructure/Services/ProcessEmailsService.cs
@@ -260,7 +260,9 @@ public class ProcessEmailsService : IProcessEmailsService
                     processedEmailsModel.EmailsCheckStatus++;
 
                     var currentStatus = emailLog.EmailStatus.Status.GetEnumFromDisplayName<EmailStatus>();
-                    var newStatus = await _notificationsClientService.GetEmailStatus(emailLog!.EmailNotifyResponseLog!.NotifyId!);
+                    var newStatus = await _notificationsClientService.GetEmailStatus(emailLog!.EmailNotifyResponseLog!.NotifyId!,
+                                                                                emailLog!.EmailStatusId,
+                                                                                emailLog!.EmailNotifyResponseLog!.ExceptionMessage);
 
                     if (currentStatus != newStatus)
                     {
@@ -276,8 +278,14 @@ public class ProcessEmailsService : IProcessEmailsService
                 }
                 catch (Exception ex)
                 {
+                    if (emailLog != null && emailLog.EmailNotifyResponseLog != null)
+                    {
+                        emailLog.EmailNotifyResponseLog.ExceptionMessage = ex.Message;
+                        _unitOfWork.EmailLogRepository.Update(emailLog);
+                        await _unitOfWork.Complete();
+                    }
                     //We don't want to throw the error here, we log and continue processing other emails
-                    _logger.LogError(ex, "Unexpected error in emailsToPollForStatusUpdate for EmailLog.ClientReferenceNumber: {ClientReferenceNumber}, EmailLog.Id: {EmailLogId}", emailLog.ClientReferenceNumber, emailLog.Id);
+                    _logger.LogError(ex, "Unexpected error in emailsToPollForStatusUpdate for EmailLog.ClientReferenceNumber: {ClientReferenceNumber}, EmailLog.Id: {EmailLogId}", emailLog?.ClientReferenceNumber, emailLog?.Id);
                 }
             }
         }


### PR DESCRIPTION
## Context

Fix so don't keep logging status update checks after 1st error is logged

## Changes proposed in this pull request

Issue spotted in QA when deployed

## Guidance to review

Run against QA and ensure doesn't keep throwing errors after 1st error

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1151

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**