### PR TITLE
NTP-1244: Fix URL creation if a TP has forward slash in their name and tweak alerts

### DIFF
--- a/Application.Tests/Extensions/StringExtensionsTests.cs
+++ b/Application.Tests/Extensions/StringExtensionsTests.cs
@@ -121,16 +121,8 @@ public class StringExtensionsTests
     }
 
     [Theory]
-    [InlineData("Find/Location", "find/location")]
-    [InlineData("find/location", "find/location")]
-    [InlineData("FindPage/LocationSearch", "find-page/location-search")]
-    [InlineData("find-page/location-search", "find-page/location-search")]
-    [InlineData("Find/FindAnNTPApprovedTuitionPartner", "find/find-an-ntp-approved-tuition-partner")]
-    [InlineData("Find/FindATuitionPartner", "find/find-a-tuition-partner")]
-    [InlineData("Find/FindATuitionPartner ", "find/find-a-tuition-partner")]
-    [InlineData("Find/findATuitionPartner", "find/find-a-tuition-partner")]
-    [InlineData("tuition-partner/A Tuition Co", "tuition-partner/a-tuition-co")]
-    public void ToSeoUrl_ReturnsKebabCase_WhenDirectory(string camel, string kebab)
+    [InlineData("FindATuiti/onPartner", "find-a-tuition-partner")]
+    public void ToSeoUrl_ReturnsKebabCase_With_Forward_Slash(string camel, string kebab)
     {
         camel.ToSeoUrl().Should().Be(kebab);
     }

--- a/Application/Constants/StringConstants.cs
+++ b/Application/Constants/StringConstants.cs
@@ -11,7 +11,7 @@
 
         public const string CamelCaseBoundaries = @"((?<=[a-z])[A-Z]|(?<=[^\-\W])[A-Z](?=[a-z])|(?<=[a-z])\d+|(?<=\d+)[a-z])";
         public const string SpacesAndUnderscore = @"[\s_]+";
-        public const string UrlUnsafeCharacters = "[^a-zA-Z0-9_{}()\\-~/]";
+        public const string UrlUnsafeCharacters = "[^a-zA-Z0-9_{}()\\-~]";
         public const string MultipleUnderscores = @"[-]{2,}";
 
         public const string DateFormatGDS = @"dddd d MMMM yyyy h:mmtt";

--- a/Infrastructure/DataImporterService.cs
+++ b/Infrastructure/DataImporterService.cs
@@ -432,7 +432,7 @@ public class DataImporterService : IHostedService
         var partnersWithoutLogos = partners.Except(matching.Select(x => x.Partner)).ToList();
         if (partnersWithoutLogos.Any())
         {
-            _logger.LogInformation("{Count} active tuition partners do not have logos:\n{WithoutLogo}",
+            _logger.LogWarning("{Count} active tuition partners do not have logos:\n{WithoutLogo}",
                 partnersWithoutLogos.Count, string.Join("\n", partnersWithoutLogos.Select(x => x.SeoUrl)));
         }
 

--- a/Infrastructure/Factories/TribalSpreadsheetTuitionPartnerFactory.cs
+++ b/Infrastructure/Factories/TribalSpreadsheetTuitionPartnerFactory.cs
@@ -383,7 +383,7 @@ public class TribalSpreadsheetTuitionPartnerFactory : ITribalSpreadsheetTuitionP
             var previousLastUpdated = _tpImportedDates[tuitionPartner.Name.ToLower()];
             if (previousLastUpdated > tuitionPartner.TPLastUpdatedData)
             {
-                _errors.Add($"The existing TP has a last updated date of {previousLastUpdated} and the spreadsheet last updated date is {tuitionPartner.TPLastUpdatedData}, which is before");
+                _warnings.Add($"The existing TP has a last updated date of {previousLastUpdated} and the spreadsheet last updated date is {tuitionPartner.TPLastUpdatedData}, which is before.");
             }
         }
     }

--- a/UI/cypress/support/utils.js
+++ b/UI/cypress/support/utils.js
@@ -6,7 +6,7 @@ export const kebabCase = (string) =>
     )
     .trim()
     .replace(/[\s_]+/g, "-")
-    .replace(/[^a-zA-Z0-9_{}()\-~/]/g, "")
+    .replace(/[^a-zA-Z0-9_{}()\-~]/g, "")
     .replace(/[-]{2,}/g, "-")
     .toLowerCase();
 


### PR DESCRIPTION
## Context

Fix URL creation if a TP has forward slash in their name and tweak alerts

## Changes proposed in this pull request

A new TP has the name “Ravenspoint Ltd T/A Tutor Doctor Reading, Maidenhead, Wokingham“ the forward slash is causing an issue since we use this name to create the URL for the TP details.  So the / should be stripped out when used in the URL, otherwise the path is invalid.

We also spotted that if there is a missing logo we are not alerted (this is logged as info).  Since all TPs seem to have a logo we will log this as a warning (so will not stop upload, but we’ll be alerted), so we have visibility of the missing logo now that Tribal control the data maintenance for TPs.

Since the new spreadsheet successfully uploaded, we had an issue rolling back to the previous version.  This is because the old data could not be uploaded and was throwing an error, in case this is being done by accident.  To resolve this, we will set this as a warning, allowing old data to be uploaded, with a longer term solution being added to the backlog: https://dfedigital.atlassian.net/browse/NTP-1245

## Guidance to review

Run against new TP data with / and also make sure can rollback

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1244

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**