### PR TITLE
(OLD - to delete) NTP-1224: School rejecting a TP - Multiple Choice for reasons why

### DIFF
--- a/Application/Commands/Enquiry/Manage/SendNotInterestedNotificationCommand.cs
+++ b/Application/Commands/Enquiry/Manage/SendNotInterestedNotificationCommand.cs
@@ -61,7 +61,7 @@ public class SendNotInterestedNotificationCommandHandler : IRequestHandler<SendN
         {
             await _unitOfWork.Complete();
 
-            _logger.LogInformation("Not interested email setup to be sent.  Email id: {emailId}, SupportReferenceNumber: {supportReferenceNumber}, TuitionPartnerSeoUrl: {tuitionPartnerSeoUrl} delayed by {minsDelaySendingOutcomeEmailToTP} mins",
+            _logger.LogInformation("Not interested email has been scheduled to be sent.  Email id: {emailId}, SupportReferenceNumber: {supportReferenceNumber}, TuitionPartnerSeoUrl: {tuitionPartnerSeoUrl} delayed by {minsDelaySendingOutcomeEmailToTP} mins",
                 enquiryResponse.TuitionPartnerResponseNotInterestedEmailLogId, request.SupportReferenceNumber, request.TuitionPartnerSeoUrl, _minsDelaySendingOutcomeEmailToTP);
 
             if (_minsDelaySendingOutcomeEmailToTP <= 0)

--- a/Application/Common/Interfaces/IUnitOfWork.cs
+++ b/Application/Common/Interfaces/IUnitOfWork.cs
@@ -6,6 +6,7 @@ public interface IUnitOfWork : IDisposable
 {
     IEmailLogRepository EmailLogRepository { get; }
     IEmailStatusRepository EmailStatusRepository { get; }
+    IEnquirerNotInterestedReasonRepository EnquirerNotInterestedReasonRepository { get; }
     IEnquiryRepository EnquiryRepository { get; }
     IEnquiryResponseRepository EnquiryResponseRepository { get; }
     IEnquiryResponseStatusRepository EnquiryResponseStatusRepository { get; }

--- a/Application/Common/Interfaces/Repositories/IEnquirerNotInterestedReasonRepository.cs
+++ b/Application/Common/Interfaces/Repositories/IEnquirerNotInterestedReasonRepository.cs
@@ -1,0 +1,9 @@
+﻿using Application.Common.Models.Enquiry.Manage;
+using Domain;
+
+namespace Application.Common.Interfaces.Repositories;
+
+public interface IEnquirerNotInterestedReasonRepository : IGenericRepository<EnquirerNotInterestedReason>
+{
+    Task<List<EnquirerNotInterestedReasonModel>> GetEnquirerNotInterestedReasons();
+}

--- a/Application/Common/Models/Enquiry/Manage/EnquirerNotInterestedReasonModel.cs
+++ b/Application/Common/Models/Enquiry/Manage/EnquirerNotInterestedReasonModel.cs
@@ -1,0 +1,11 @@
+﻿namespace Application.Common.Models.Enquiry.Manage;
+
+public record EnquirerNotInterestedReasonModel
+{
+    public int Id { get; set; }
+
+    public string Description { get; set; } = null!;
+
+    public bool CollectAdditionalInfoIfSelected { get; set; }
+
+}

--- a/Application/Common/Models/Enquiry/Manage/NotInterestedFeedbackModel.cs
+++ b/Application/Common/Models/Enquiry/Manage/NotInterestedFeedbackModel.cs
@@ -10,6 +10,12 @@ public record NotInterestedFeedbackModel
 
     public string TuitionPartnerName { get; set; } = null!;
 
-    public string? NotInterestedFeedback { get; set; }
+    public int? EnquirerNotInterestedReasonId { get; set; }
+
+    public string? EnquirerNotInterestedReasonAdditionalInfo { get; set; }
+
+    public bool MustCollectAdditionalInfo { get; set; }
+
+    public List<EnquirerNotInterestedReasonModel> EnquirerNotInterestedReasonModels { get; set; } = null!;
 
 }

--- a/Application/Constants/StringConstants.cs
+++ b/Application/Constants/StringConstants.cs
@@ -35,6 +35,6 @@
 
         public const string NotifyBulletedListFormat = "* ";
 
-        public const string NotInterestedTextIfNoReasonSupplied = "No feedback provided";
+        public const string NotInterestedTextIfNoReasonSupplied = "The school has not provided any feedback on this occasion.";
     }
 }

--- a/Application/Queries/Enquiry/Manage/GetEnquirerNotInterestedReasonsQuery.cs
+++ b/Application/Queries/Enquiry/Manage/GetEnquirerNotInterestedReasonsQuery.cs
@@ -1,0 +1,22 @@
+﻿using Application.Common.Interfaces;
+using Application.Common.Models.Enquiry.Manage;
+
+namespace Application.Queries.Enquiry.Manage;
+
+public record GetEnquirerNotInterestedReasonsQuery() : IRequest<List<EnquirerNotInterestedReasonModel>>;
+
+public class GetEnquirerNotInterestedReasonsQueryHandler : IRequestHandler<GetEnquirerNotInterestedReasonsQuery, List<EnquirerNotInterestedReasonModel>>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    public GetEnquirerNotInterestedReasonsQueryHandler(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<List<EnquirerNotInterestedReasonModel>> Handle(GetEnquirerNotInterestedReasonsQuery request, CancellationToken cancellationToken)
+    {
+        return await _unitOfWork.EnquirerNotInterestedReasonRepository
+            .GetEnquirerNotInterestedReasons();
+    }
+}

--- a/Application/Validators/Enquiry/Manage/NotInterestedFeedbackModelValidator.cs
+++ b/Application/Validators/Enquiry/Manage/NotInterestedFeedbackModelValidator.cs
@@ -1,0 +1,19 @@
+﻿using Application.Common.Models.Enquiry.Manage;
+using Application.Constants;
+using FluentValidation;
+
+namespace Application.Validators.Enquiry.Manage;
+
+public class NotInterestedFeedbackModelValidator : AbstractValidator<NotInterestedFeedbackModel>
+{
+    public NotInterestedFeedbackModelValidator()
+    {
+        RuleFor(request => request.EnquirerNotInterestedReasonAdditionalInfo)
+            .NotEmpty()
+            .When(m => m.MustCollectAdditionalInfo)
+            .WithMessage("Enter your reasons for removing the tuition partner to submit your feedback ")
+            .Must(x => !string.IsNullOrEmpty(x) && x.Replace("\r\n", "\n").Length <= IntegerConstants.SmallTextAreaMaxCharacterSize)
+            .When(m => m.MustCollectAdditionalInfo)
+            .WithMessage($"Your reasons for removing the tuition partner must be {IntegerConstants.SmallTextAreaMaxCharacterSize:N0} characters or less");
+    }
+}

--- a/Domain/EnquirerNotInterestedReason.cs
+++ b/Domain/EnquirerNotInterestedReason.cs
@@ -1,0 +1,17 @@
+﻿namespace Domain
+{
+    public class EnquirerNotInterestedReason
+    {
+        public int Id { get; set; }
+
+        public string Description { get; set; } = null!;
+
+        public bool CollectAdditionalInfoIfSelected { get; set; }
+
+        public int OrderBy { get; set; }
+
+        public bool IsActive { get; set; }
+
+        public ICollection<EnquiryResponse>? EnquiryResponses { get; set; }
+    }
+}

--- a/Domain/EnquiryResponse.cs
+++ b/Domain/EnquiryResponse.cs
@@ -18,7 +18,9 @@ public class EnquiryResponse
 
     public DateTime? CompletedAt { get; set; }
 
-    public string? EnquirerNotInterestedReason { get; set; }
+    public int? EnquirerNotInterestedReasonId { get; set; }
+
+    public string? EnquirerNotInterestedReasonAdditionalInfo { get; set; }
 
     public int EnquirerResponseEmailLogId { get; set; }
 
@@ -29,6 +31,8 @@ public class EnquiryResponse
     public int EnquiryResponseStatusId { get; set; }
 
     public DateTime EnquiryResponseStatusLastUpdated { get; set; } = DateTime.UtcNow;
+
+    public EnquirerNotInterestedReason? EnquirerNotInterestedReason { get; set; } = null!;
 
     public EmailLog EnquirerResponseEmailLog { get; set; } = null!;
 

--- a/Infrastructure/EntityConfigurations/EnquirerNotInterestedReasonConfigurations.cs
+++ b/Infrastructure/EntityConfigurations/EnquirerNotInterestedReasonConfigurations.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.EntityConfigurations;
+
+public class EnquirerNotInterestedReasonConfigurations : IEntityTypeConfiguration<Domain.EnquirerNotInterestedReason>
+{
+    public void Configure(EntityTypeBuilder<Domain.EnquirerNotInterestedReason> builder)
+    {
+        builder.HasMany(e => e.EnquiryResponses).WithOne(e => e.EnquirerNotInterestedReason).OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(e => e.Description).IsUnique();
+
+        builder.HasData(
+            new Domain.EnquirerNotInterestedReason
+            {
+                Id = 1,
+                Description = "The response does not adequately cover my tuition plan needs",
+                CollectAdditionalInfoIfSelected = false,
+                OrderBy = 1,
+                IsActive = true
+            },
+            new Domain.EnquirerNotInterestedReason
+            {
+                Id = 2,
+                Description = "The response does not adequately cover support for our pupils with SEND",
+                CollectAdditionalInfoIfSelected = false,
+                OrderBy = 2,
+                IsActive = true
+            },
+            new Domain.EnquirerNotInterestedReason
+            {
+                Id = 3,
+                Description = "The response is too generic and doesn’t offer enough information",
+                CollectAdditionalInfoIfSelected = false,
+                OrderBy = 3,
+                IsActive = true
+            },
+            new Domain.EnquirerNotInterestedReason
+            {
+                Id = 4,
+                Description = "Other",
+                CollectAdditionalInfoIfSelected = true,
+                OrderBy = 4,
+                IsActive = true
+            }
+        );
+    }
+}

--- a/Infrastructure/EntityConfigurations/EnquiryResponseConfigurations.cs
+++ b/Infrastructure/EntityConfigurations/EnquiryResponseConfigurations.cs
@@ -10,5 +10,6 @@ public class EnquiryResponseConfigurations : IEntityTypeConfiguration<EnquiryRes
     {
         builder.HasOne(e => e.EnquirerResponseEmailLog).WithMany(e => e.EnquirerResponses).OnDelete(DeleteBehavior.Restrict);
         builder.HasOne(e => e.TuitionPartnerResponseEmailLog).WithMany(e => e.TuitionPartnerResponses).OnDelete(DeleteBehavior.Restrict);
+        builder.HasOne(e => e.TuitionPartnerResponseNotInterestedEmailLog).WithOne(e => e.TuitionPartnerResponseNotInterested).OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/Infrastructure/EntityConfigurations/EnquiryResponseStatusConfigurations.cs
+++ b/Infrastructure/EntityConfigurations/EnquiryResponseStatusConfigurations.cs
@@ -9,6 +9,8 @@ public class EnquiryResponseStatusConfigurations : IEntityTypeConfiguration<Doma
 {
     public void Configure(EntityTypeBuilder<Domain.EnquiryResponseStatus> builder)
     {
+        builder.HasMany(e => e.EnquiryResponses).WithOne(e => e.EnquiryResponseStatus).OnDelete(DeleteBehavior.Restrict);
+
         builder.HasIndex(e => e.Status).IsUnique();
 
         builder.HasData(

--- a/Infrastructure/Migrations/20230626100333_EnquiryResponseStatus.Designer.cs
+++ b/Infrastructure/Migrations/20230626100333_EnquiryResponseStatus.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(NtpDbContext))]
-    [Migration("20230613135539_EnquiryResponseStatus")]
+    [Migration("20230626100333_EnquiryResponseStatus")]
     partial class EnquiryResponseStatus
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -363,6 +363,69 @@ namespace Infrastructure.Migrations
                     b.ToTable("EmailTriggerActivation");
                 });
 
+            modelBuilder.Entity("Domain.EnquirerNotInterestedReason", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<bool>("CollectAdditionalInfoIfSelected")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("boolean");
+
+                    b.Property<int>("OrderBy")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Description")
+                        .IsUnique();
+
+                    b.ToTable("EnquirerNotInterestedReasons");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = 1,
+                            CollectAdditionalInfoIfSelected = false,
+                            Description = "The response does not adequately cover my tuition plan needs",
+                            IsActive = true,
+                            OrderBy = 1
+                        },
+                        new
+                        {
+                            Id = 2,
+                            CollectAdditionalInfoIfSelected = false,
+                            Description = "The response does not adequately cover support for our pupils with SEND",
+                            IsActive = true,
+                            OrderBy = 2
+                        },
+                        new
+                        {
+                            Id = 3,
+                            CollectAdditionalInfoIfSelected = false,
+                            Description = "The response is too generic and doesn’t offer enough information",
+                            IsActive = true,
+                            OrderBy = 3
+                        },
+                        new
+                        {
+                            Id = 4,
+                            CollectAdditionalInfoIfSelected = true,
+                            Description = "Other",
+                            IsActive = true,
+                            OrderBy = 4
+                        });
+                });
+
             modelBuilder.Entity("Domain.Enquiry", b =>
                 {
                     b.Property<int>("Id")
@@ -442,8 +505,11 @@ namespace Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("EnquirerNotInterestedReason")
+                    b.Property<string>("EnquirerNotInterestedReasonAdditionalInfo")
                         .HasColumnType("text");
+
+                    b.Property<int?>("EnquirerNotInterestedReasonId")
+                        .HasColumnType("integer");
 
                     b.Property<int>("EnquirerResponseEmailLogId")
                         .HasColumnType("integer");
@@ -476,6 +542,8 @@ namespace Infrastructure.Migrations
                         .HasColumnType("text");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("EnquirerNotInterestedReasonId");
 
                     b.HasIndex("EnquirerResponseEmailLogId");
 
@@ -5214,6 +5282,11 @@ namespace Infrastructure.Migrations
 
             modelBuilder.Entity("Domain.EnquiryResponse", b =>
                 {
+                    b.HasOne("Domain.EnquirerNotInterestedReason", "EnquirerNotInterestedReason")
+                        .WithMany("EnquiryResponses")
+                        .HasForeignKey("EnquirerNotInterestedReasonId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
                     b.HasOne("Domain.EmailLog", "EnquirerResponseEmailLog")
                         .WithMany("EnquirerResponses")
                         .HasForeignKey("EnquirerResponseEmailLogId")
@@ -5223,7 +5296,7 @@ namespace Infrastructure.Migrations
                     b.HasOne("Domain.EnquiryResponseStatus", "EnquiryResponseStatus")
                         .WithMany("EnquiryResponses")
                         .HasForeignKey("EnquiryResponseStatusId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("Domain.EmailLog", "TuitionPartnerResponseEmailLog")
@@ -5234,7 +5307,10 @@ namespace Infrastructure.Migrations
 
                     b.HasOne("Domain.EmailLog", "TuitionPartnerResponseNotInterestedEmailLog")
                         .WithOne("TuitionPartnerResponseNotInterested")
-                        .HasForeignKey("Domain.EnquiryResponse", "TuitionPartnerResponseNotInterestedEmailLogId");
+                        .HasForeignKey("Domain.EnquiryResponse", "TuitionPartnerResponseNotInterestedEmailLogId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.Navigation("EnquirerNotInterestedReason");
 
                     b.Navigation("EnquirerResponseEmailLog");
 
@@ -5539,6 +5615,11 @@ namespace Infrastructure.Migrations
             modelBuilder.Entity("Domain.EmailStatus", b =>
                 {
                     b.Navigation("EmailLogs");
+                });
+
+            modelBuilder.Entity("Domain.EnquirerNotInterestedReason", b =>
+                {
+                    b.Navigation("EnquiryResponses");
                 });
 
             modelBuilder.Entity("Domain.Enquiry", b =>

--- a/Infrastructure/Migrations/20230626100333_EnquiryResponseStatus.cs
+++ b/Infrastructure/Migrations/20230626100333_EnquiryResponseStatus.cs
@@ -11,9 +11,15 @@ namespace Infrastructure.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<string>(
-                name: "EnquirerNotInterestedReason",
+                name: "EnquirerNotInterestedReasonAdditionalInfo",
                 table: "EnquiryResponses",
                 type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EnquirerNotInterestedReasonId",
+                table: "EnquiryResponses",
+                type: "integer",
                 nullable: true);
 
             migrationBuilder.AddColumn<int>(
@@ -37,6 +43,22 @@ namespace Infrastructure.Migrations
                 nullable: true);
 
             migrationBuilder.CreateTable(
+                name: "EnquirerNotInterestedReasons",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Description = table.Column<string>(type: "text", nullable: false),
+                    CollectAdditionalInfoIfSelected = table.Column<bool>(type: "boolean", nullable: false),
+                    OrderBy = table.Column<int>(type: "integer", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EnquirerNotInterestedReasons", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "EnquiryResponseStatus",
                 columns: table => new
                 {
@@ -49,6 +71,17 @@ namespace Infrastructure.Migrations
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_EnquiryResponseStatus", x => x.Id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "EnquirerNotInterestedReasons",
+                columns: new[] { "Id", "CollectAdditionalInfoIfSelected", "Description", "IsActive", "OrderBy" },
+                values: new object[,]
+                {
+                    { 1, false, "The response does not adequately cover my tuition plan needs", true, 1 },
+                    { 2, false, "The response does not adequately cover support for our pupils with SEND", true, 2 },
+                    { 3, false, "The response is too generic and doesn’t offer enough information", true, 3 },
+                    { 4, true, "Other", true, 4 }
                 });
 
             migrationBuilder.InsertData(
@@ -68,6 +101,11 @@ namespace Infrastructure.Migrations
             //MANUAL CHANGES - END
 
             migrationBuilder.CreateIndex(
+                name: "IX_EnquiryResponses_EnquirerNotInterestedReasonId",
+                table: "EnquiryResponses",
+                column: "EnquirerNotInterestedReasonId");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_EnquiryResponses_EnquiryResponseStatusId",
                 table: "EnquiryResponses",
                 column: "EnquiryResponseStatusId");
@@ -76,6 +114,12 @@ namespace Infrastructure.Migrations
                 name: "IX_EnquiryResponses_TuitionPartnerResponseNotInterestedEmailLo~",
                 table: "EnquiryResponses",
                 column: "TuitionPartnerResponseNotInterestedEmailLogId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EnquirerNotInterestedReasons_Description",
+                table: "EnquirerNotInterestedReasons",
+                column: "Description",
                 unique: true);
 
             migrationBuilder.CreateIndex(
@@ -89,7 +133,16 @@ namespace Infrastructure.Migrations
                 table: "EnquiryResponses",
                 column: "TuitionPartnerResponseNotInterestedEmailLogId",
                 principalTable: "EmailLog",
-                principalColumn: "Id");
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_EnquiryResponses_EnquirerNotInterestedReasons_EnquirerNotIn~",
+                table: "EnquiryResponses",
+                column: "EnquirerNotInterestedReasonId",
+                principalTable: "EnquirerNotInterestedReasons",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
 
             migrationBuilder.AddForeignKey(
                 name: "FK_EnquiryResponses_EnquiryResponseStatus_EnquiryResponseStatu~",
@@ -97,7 +150,7 @@ namespace Infrastructure.Migrations
                 column: "EnquiryResponseStatusId",
                 principalTable: "EnquiryResponseStatus",
                 principalColumn: "Id",
-                onDelete: ReferentialAction.Cascade);
+                onDelete: ReferentialAction.Restrict);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -107,11 +160,22 @@ namespace Infrastructure.Migrations
                 table: "EnquiryResponses");
 
             migrationBuilder.DropForeignKey(
+                name: "FK_EnquiryResponses_EnquirerNotInterestedReasons_EnquirerNotIn~",
+                table: "EnquiryResponses");
+
+            migrationBuilder.DropForeignKey(
                 name: "FK_EnquiryResponses_EnquiryResponseStatus_EnquiryResponseStatu~",
                 table: "EnquiryResponses");
 
             migrationBuilder.DropTable(
+                name: "EnquirerNotInterestedReasons");
+
+            migrationBuilder.DropTable(
                 name: "EnquiryResponseStatus");
+
+            migrationBuilder.DropIndex(
+                name: "IX_EnquiryResponses_EnquirerNotInterestedReasonId",
+                table: "EnquiryResponses");
 
             migrationBuilder.DropIndex(
                 name: "IX_EnquiryResponses_EnquiryResponseStatusId",
@@ -122,7 +186,11 @@ namespace Infrastructure.Migrations
                 table: "EnquiryResponses");
 
             migrationBuilder.DropColumn(
-                name: "EnquirerNotInterestedReason",
+                name: "EnquirerNotInterestedReasonAdditionalInfo",
+                table: "EnquiryResponses");
+
+            migrationBuilder.DropColumn(
+                name: "EnquirerNotInterestedReasonId",
                 table: "EnquiryResponses");
 
             migrationBuilder.DropColumn(

--- a/Infrastructure/Migrations/NtpDbContextModelSnapshot.cs
+++ b/Infrastructure/Migrations/NtpDbContextModelSnapshot.cs
@@ -361,6 +361,69 @@ namespace Infrastructure.Migrations
                     b.ToTable("EmailTriggerActivation");
                 });
 
+            modelBuilder.Entity("Domain.EnquirerNotInterestedReason", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<bool>("CollectAdditionalInfoIfSelected")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("boolean");
+
+                    b.Property<int>("OrderBy")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Description")
+                        .IsUnique();
+
+                    b.ToTable("EnquirerNotInterestedReasons");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = 1,
+                            CollectAdditionalInfoIfSelected = false,
+                            Description = "The response does not adequately cover my tuition plan needs",
+                            IsActive = true,
+                            OrderBy = 1
+                        },
+                        new
+                        {
+                            Id = 2,
+                            CollectAdditionalInfoIfSelected = false,
+                            Description = "The response does not adequately cover support for our pupils with SEND",
+                            IsActive = true,
+                            OrderBy = 2
+                        },
+                        new
+                        {
+                            Id = 3,
+                            CollectAdditionalInfoIfSelected = false,
+                            Description = "The response is too generic and doesn’t offer enough information",
+                            IsActive = true,
+                            OrderBy = 3
+                        },
+                        new
+                        {
+                            Id = 4,
+                            CollectAdditionalInfoIfSelected = true,
+                            Description = "Other",
+                            IsActive = true,
+                            OrderBy = 4
+                        });
+                });
+
             modelBuilder.Entity("Domain.Enquiry", b =>
                 {
                     b.Property<int>("Id")
@@ -440,8 +503,11 @@ namespace Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("EnquirerNotInterestedReason")
+                    b.Property<string>("EnquirerNotInterestedReasonAdditionalInfo")
                         .HasColumnType("text");
+
+                    b.Property<int?>("EnquirerNotInterestedReasonId")
+                        .HasColumnType("integer");
 
                     b.Property<int>("EnquirerResponseEmailLogId")
                         .HasColumnType("integer");
@@ -474,6 +540,8 @@ namespace Infrastructure.Migrations
                         .HasColumnType("text");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("EnquirerNotInterestedReasonId");
 
                     b.HasIndex("EnquirerResponseEmailLogId");
 
@@ -5211,37 +5279,45 @@ namespace Infrastructure.Migrations
                 });
 
             modelBuilder.Entity("Domain.EnquiryResponse", b =>
-            {
-                b.HasOne("Domain.EmailLog", "EnquirerResponseEmailLog")
-                    .WithMany("EnquirerResponses")
-                    .HasForeignKey("EnquirerResponseEmailLogId")
-                    .OnDelete(DeleteBehavior.Restrict)
-                    .IsRequired();
+                {
+                    b.HasOne("Domain.EnquirerNotInterestedReason", "EnquirerNotInterestedReason")
+                        .WithMany("EnquiryResponses")
+                        .HasForeignKey("EnquirerNotInterestedReasonId")
+                        .OnDelete(DeleteBehavior.Restrict);
 
-                b.HasOne("Domain.EnquiryResponseStatus", "EnquiryResponseStatus")
-                    .WithMany("EnquiryResponses")
-                    .HasForeignKey("EnquiryResponseStatusId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
+                    b.HasOne("Domain.EmailLog", "EnquirerResponseEmailLog")
+                        .WithMany("EnquirerResponses")
+                        .HasForeignKey("EnquirerResponseEmailLogId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
 
-                b.HasOne("Domain.EmailLog", "TuitionPartnerResponseEmailLog")
-                    .WithMany("TuitionPartnerResponses")
-                    .HasForeignKey("TuitionPartnerResponseEmailLogId")
-                    .OnDelete(DeleteBehavior.Restrict)
-                    .IsRequired();
+                    b.HasOne("Domain.EnquiryResponseStatus", "EnquiryResponseStatus")
+                        .WithMany("EnquiryResponses")
+                        .HasForeignKey("EnquiryResponseStatusId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
 
-                b.HasOne("Domain.EmailLog", "TuitionPartnerResponseNotInterestedEmailLog")
-                    .WithOne("TuitionPartnerResponseNotInterested")
-                    .HasForeignKey("Domain.EnquiryResponse", "TuitionPartnerResponseNotInterestedEmailLogId");
+                    b.HasOne("Domain.EmailLog", "TuitionPartnerResponseEmailLog")
+                        .WithMany("TuitionPartnerResponses")
+                        .HasForeignKey("TuitionPartnerResponseEmailLogId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
 
-                b.Navigation("EnquirerResponseEmailLog");
+                    b.HasOne("Domain.EmailLog", "TuitionPartnerResponseNotInterestedEmailLog")
+                        .WithOne("TuitionPartnerResponseNotInterested")
+                        .HasForeignKey("Domain.EnquiryResponse", "TuitionPartnerResponseNotInterestedEmailLogId")
+                        .OnDelete(DeleteBehavior.Restrict);
 
-                b.Navigation("EnquiryResponseStatus");
+                    b.Navigation("EnquirerNotInterestedReason");
 
-                b.Navigation("TuitionPartnerResponseEmailLog");
+                    b.Navigation("EnquirerResponseEmailLog");
 
-                b.Navigation("TuitionPartnerResponseNotInterestedEmailLog");
-            });
+                    b.Navigation("EnquiryResponseStatus");
+
+                    b.Navigation("TuitionPartnerResponseEmailLog");
+
+                    b.Navigation("TuitionPartnerResponseNotInterestedEmailLog");
+                });
 
             modelBuilder.Entity("Domain.KeyStageSubjectEnquiry", b =>
                 {
@@ -5512,32 +5588,37 @@ namespace Infrastructure.Migrations
                 });
 
             modelBuilder.Entity("Domain.EmailLog", b =>
-            {
-                b.Navigation("EmailLogHistories");
+                {
+                    b.Navigation("EmailLogHistories");
 
-                b.Navigation("EmailNotifyResponseLog");
+                    b.Navigation("EmailNotifyResponseLog");
 
-                b.Navigation("EmailPersonalisationLogs");
+                    b.Navigation("EmailPersonalisationLogs");
 
-                b.Navigation("EmailsActivatedByThisEmail");
+                    b.Navigation("EmailsActivatedByThisEmail");
 
-                b.Navigation("EnquirerEnquiriesSubmitted");
+                    b.Navigation("EnquirerEnquiriesSubmitted");
 
-                b.Navigation("EnquirerResponses");
+                    b.Navigation("EnquirerResponses");
 
-                b.Navigation("ThisEmailActivationTriggeredBy");
+                    b.Navigation("ThisEmailActivationTriggeredBy");
 
-                b.Navigation("TuitionPartnerEnquiriesSubmitted");
+                    b.Navigation("TuitionPartnerEnquiriesSubmitted");
 
-                b.Navigation("TuitionPartnerResponseNotInterested");
+                    b.Navigation("TuitionPartnerResponseNotInterested");
 
-                b.Navigation("TuitionPartnerResponses");
-            });
+                    b.Navigation("TuitionPartnerResponses");
+                });
 
             modelBuilder.Entity("Domain.EmailStatus", b =>
-            {
-                b.Navigation("EmailLogs");
-            });
+                {
+                    b.Navigation("EmailLogs");
+                });
+
+            modelBuilder.Entity("Domain.EnquirerNotInterestedReason", b =>
+                {
+                    b.Navigation("EnquiryResponses");
+                });
 
             modelBuilder.Entity("Domain.Enquiry", b =>
                 {

--- a/Infrastructure/NtpDbContext.cs
+++ b/Infrastructure/NtpDbContext.cs
@@ -12,26 +12,36 @@ public class NtpDbContext : DbContext, INtpDbContext, IDataProtectionKeyContext
     }
 
     public DbSet<DataProtectionKey> DataProtectionKeys { get; set; } = null!;
-    public DbSet<LocalAuthorityDistrict> LocalAuthorityDistricts { get; set; } = null!;
-    public DbSet<LocalAuthorityDistrictCoverage> LocalAuthorityDistrictCoverage { get; set; } = null!;
-    public DbSet<LocalAuthority> LocalAuthority { get; set; } = null!;
-    public DbSet<Price> Prices { get; set; } = null!;
-    public DbSet<Region> Regions { get; set; } = null!;
-    public DbSet<Subject> Subjects { get; set; } = null!;
-    public DbSet<TuitionPartner> TuitionPartners { get; set; } = null!;
-    public DbSet<TuitionSetting> TuitionSettings { get; set; } = null!;
-    public DbSet<SubjectCoverage> SubjectCoverage { get; set; } = null!;
-    public DbSet<School> Schools { get; set; } = null!;
-    public DbSet<PhaseOfEducation> PhaseOfEducation { get; set; } = null!;
-    public DbSet<EstablishmentTypeGroup> EstablishmentTypeGroup { get; set; } = null!;
-    public DbSet<EstablishmentStatus> EstablishmentStatus { get; set; } = null!;
+    public DbSet<EmailLog> EmailLog { get; set; } = null!;
+    public DbSet<EmailLogHistory> EmailLogHistory { get; set; } = null!;
+    public DbSet<EmailNotifyResponseLog> EmailNotifyResponseLog { get; set; } = null!;
+    public DbSet<EmailPersonalisationLog> EmailPersonalisationLog { get; set; } = null!;
+    public DbSet<EmailStatus> EmailStatus { get; set; } = null!;
+    public DbSet<EmailTriggerActivation> EmailTriggerActivation { get; set; } = null!;
+    public DbSet<EnquirerNotInterestedReason> EnquirerNotInterestedReasons { get; set; } = null!;
     public DbSet<Enquiry> Enquiries { get; set; } = null!;
     public DbSet<EnquiryResponse> EnquiryResponses { get; set; } = null!;
+    public DbSet<EnquiryResponseStatus> EnquiryResponseStatus { get; set; } = null!;
+    public DbSet<EstablishmentStatus> EstablishmentStatus { get; set; } = null!;
+    public DbSet<EstablishmentTypeGroup> EstablishmentTypeGroup { get; set; } = null!;
+    public DbSet<KeyStage> KeyStage { get; set; } = null!;
+    public DbSet<KeyStageSubjectEnquiry> KeyStageSubjectsEnquiry { get; set; } = null!;
+    public DbSet<LocalAuthority> LocalAuthority { get; set; } = null!;
+    public DbSet<LocalAuthorityDistrictCoverage> LocalAuthorityDistrictCoverage { get; set; } = null!;
+    public DbSet<LocalAuthorityDistrict> LocalAuthorityDistricts { get; set; } = null!;
     public DbSet<MagicLink> MagicLinks { get; set; } = null!;
     public DbSet<OrganisationType> OrganisationType { get; set; } = null!;
-
+    public DbSet<PhaseOfEducation> PhaseOfEducation { get; set; } = null!;
+    public DbSet<Price> Prices { get; set; } = null!;
+    public DbSet<Region> Regions { get; set; } = null!;
+    public DbSet<ScheduledProcessingInfo> ScheduledProcessingInfo { get; set; } = null!;
+    public DbSet<School> Schools { get; set; } = null!;
+    public DbSet<SubjectCoverage> SubjectCoverage { get; set; } = null!;
+    public DbSet<Subject> Subjects { get; set; } = null!;
+    public DbSet<TuitionPartner> TuitionPartners { get; set; } = null!;
     public DbSet<TuitionPartnerEnquiry> TuitionPartnersEnquiry { get; set; } = null!;
-    public DbSet<KeyStageSubjectEnquiry> KeyStageSubjectsEnquiry { get; set; } = null!;
+    public DbSet<TuitionSetting> TuitionSettings { get; set; } = null!;
+
 
     public Task<int> SaveChangesAsync()
     {

--- a/Infrastructure/Repositories/EnquirerNotInterestedReasonRepository.cs
+++ b/Infrastructure/Repositories/EnquirerNotInterestedReasonRepository.cs
@@ -1,0 +1,26 @@
+﻿using Application.Common.Interfaces.Repositories;
+using Application.Common.Models.Enquiry.Manage;
+using Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Repositories;
+
+public class EnquirerNotInterestedReasonRepository : GenericRepository<EnquirerNotInterestedReason>, IEnquirerNotInterestedReasonRepository
+{
+    public EnquirerNotInterestedReasonRepository(NtpDbContext context) : base(context)
+    {
+    }
+
+    public async Task<List<EnquirerNotInterestedReasonModel>> GetEnquirerNotInterestedReasons()
+    {
+        return await _context.EnquirerNotInterestedReasons
+            .Where(e => e.IsActive)
+            .OrderBy(e => e.OrderBy)
+            .Select(e => new EnquirerNotInterestedReasonModel()
+            {
+                Id = e.Id,
+                Description = e.Description,
+                CollectAdditionalInfoIfSelected = e.CollectAdditionalInfoIfSelected
+            }).ToListAsync();
+    }
+}

--- a/Infrastructure/UnitOfWorks/UnitOfWork.cs
+++ b/Infrastructure/UnitOfWorks/UnitOfWork.cs
@@ -13,6 +13,7 @@ public class UnitOfWork : IUnitOfWork
         _context = context;
         EmailLogRepository = new EmailLogRepository(_context);
         EmailStatusRepository = new EmailStatusRepository(_context);
+        EnquirerNotInterestedReasonRepository = new EnquirerNotInterestedReasonRepository(_context);
         EnquiryRepository = new EnquiryRepository(_context);
         EnquiryResponseRepository = new EnquiryResponseRepository(_context);
         EnquiryResponseStatusRepository = new EnquiryResponseStatusRepository(_context);
@@ -28,6 +29,7 @@ public class UnitOfWork : IUnitOfWork
     }
     public IEmailLogRepository EmailLogRepository { get; private set; }
     public IEmailStatusRepository EmailStatusRepository { get; private set; }
+    public IEnquirerNotInterestedReasonRepository EnquirerNotInterestedReasonRepository { get; private set; }
     public IEnquiryRepository EnquiryRepository { get; private set; }
     public IEnquiryResponseRepository EnquiryResponseRepository { get; private set; }
     public IEnquiryResponseStatusRepository EnquiryResponseStatusRepository { get; private set; }

--- a/UI/Extensions/HttpContextExtensions.cs
+++ b/UI/Extensions/HttpContextExtensions.cs
@@ -43,6 +43,11 @@ namespace UI.Extensions
             httpContext.AddToAnalytics<T>("SchoolUrn", urn.ToString());
         }
 
+        public static void AddEnquirerNotInterestedReasonToAnalytics<T>(this HttpContext httpContext, string enquirerNotInterestedReason)
+        {
+            httpContext.AddToAnalytics<T>("EnquirerNotInterestedReason", enquirerNotInterestedReason);
+        }
+
         private static void AddToAnalytics<T>(this HttpContext httpContext, string? key, string? value)
         {
             if (httpContext != null && !string.IsNullOrWhiteSpace(key) && !string.IsNullOrWhiteSpace(value))

--- a/UI/Pages/Enquiry/Manage/AllEnquirerResponses.cshtml
+++ b/UI/Pages/Enquiry/Manage/AllEnquirerResponses.cshtml
@@ -138,7 +138,7 @@
             </a>
           </td>
           <td class="govuk-table__cell">
-            <span class="enquiry-status-box enquiry-status-@item.EnquiryResponseStatus.DisplayName().ToSeoUrl()">@item.EnquiryResponseStatus.DisplayName()</span>
+            <strong class="govuk-tag enquiry-status-@item.EnquiryResponseStatus.DisplayName().ToSeoUrl()">@item.EnquiryResponseStatus.DisplayName()</strong>
           </td>
         </tr>
       }

--- a/UI/Pages/Enquiry/Manage/NotInterestedFeedback.cshtml
+++ b/UI/Pages/Enquiry/Manage/NotInterestedFeedback.cshtml
@@ -3,23 +3,42 @@
 @{
   var baseServiceUrl = Request.GetBaseServiceUrl();
   var skipLink = $"{baseServiceUrl}/enquiry/{Model.SupportReferenceNumber}?Token={@Model.Data.Token}&{Model.EnquirerResponseResultsModel.ToQueryString()}#all-responses-table";
-  ViewData["Title"] = Model.Data.TuitionPartnerName + " has been removed from your list of responses";
+  ViewData["Title"] = "You have removed the tuition partner " + Model.Data.TuitionPartnerName;
 }
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <form method="post">
-      <h1 class="govuk-heading-l">@Model.Data.TuitionPartnerName has been removed from your list of responses</h1>
+      <h1 class="govuk-heading-l">You have removed the tuition partner:</h1>
 
-      <govuk-character-count asp-for="Data.NotInterestedFeedback" threshold="@IntegerConstants.MediumTextAreaMaxCharacterThreshold" rows="12" max-length="@IntegerConstants.MediumTextAreaMaxCharacterSize">
-        <govuk-character-count-label class="govuk-label--m">
-          Provide anonymous feedback to the response from @Model.Data.TuitionPartnerName (optional)
-        </govuk-character-count-label>
-        <govuk-character-count-hint>
-          Your feedback helps to improve this service
-        </govuk-character-count-hint>
-      </govuk-character-count>
+      <h2 class="govuk-heading-m">@Model.Data.TuitionPartnerName</h2>
 
+      <govuk-radios asp-for="Data.EnquirerNotInterestedReasonId">
+        <govuk-radios-fieldset>
+          <govuk-radios-fieldset-legend class="govuk-fieldset__legend--s">
+            Provide anonymous feedback to their response (optional)
+          </govuk-radios-fieldset-legend>
+          <govuk-radios-hint>
+            Your feedback helps to improve this service
+          </govuk-radios-hint>
+          @foreach (var item in Model.Data.EnquirerNotInterestedReasonModels)
+          {
+            <govuk-radios-item id="@item.Description.ToSeoUrl()" value="@item.Id" checked="@item.Id == @Model.Data.EnquirerNotInterestedReasonId">
+              @item.Description
+              @if (item.CollectAdditionalInfoIfSelected)
+            {
+              <govuk-radios-item-conditional>
+                  <govuk-character-count asp-for="Data.EnquirerNotInterestedReasonAdditionalInfo" threshold="@IntegerConstants.SmallTextAreaMaxCharacterThreshold" rows="3" max-length="@IntegerConstants.SmallTextAreaMaxCharacterSize">
+                    <govuk-character-count-label>
+                      Specify your reasons
+                    </govuk-character-count-label>
+                  </govuk-character-count>
+              </govuk-radios-item-conditional>
+            }
+            </govuk-radios-item>
+          }
+        </govuk-radios-fieldset>
+      </govuk-radios>
       <div class="govuk-button-group">
         <govuk-button prevent-double-click="true" type="submit">Submit feedback</govuk-button>
         <a class="govuk-link" href="@skipLink">Skip and return to your enquiry</a>

--- a/UI/Pages/Enquiry/Manage/NotInterestedFeedback.cshtml.cs
+++ b/UI/Pages/Enquiry/Manage/NotInterestedFeedback.cshtml.cs
@@ -2,6 +2,7 @@ using Application.Commands.Enquiry.Build;
 using Application.Common.Models.Enquiry.Manage;
 using Application.Queries.Enquiry;
 using Application.Queries.Enquiry.Manage;
+using UI.Extensions;
 
 namespace UI.Pages.Enquiry.Manage
 {
@@ -92,6 +93,8 @@ namespace UI.Pages.Enquiry.Manage
                                     Data.EnquirerNotInterestedReasonId!.Value,
                                     selectedReason.Description,
                                     selectedReason.CollectAdditionalInfoIfSelected ? Data.EnquirerNotInterestedReasonAdditionalInfo : null));
+
+                HttpContext.AddEnquirerNotInterestedReasonToAnalytics<NotInterestedFeedback>(selectedReason.Description);
             }
 
             var redirectPageUrl = $"/enquiry/{Data.SupportReferenceNumber}?Token={Data.Token}&{EnquirerResponseResultsModel.ToQueryString()}#all-responses-table";

--- a/UI/src/sass/enquiry-manage.scss
+++ b/UI/src/sass/enquiry-manage.scss
@@ -1,24 +1,15 @@
-﻿span.enquiry-status-box {
-  padding: 0.2em;
-  font-weight: 600;
+﻿.enquiry-status-interested {
+  @extend .govuk-tag--green;
 }
 
-span.enquiry-status-interested {
-  background-color: #d0e1d9;
-  color: #689178;
+.enquiry-status-undecided {
+  @extend .govuk-tag--yellow;
 }
 
-span.enquiry-status-undecided {
-  background-color: #fef8c5;
-  color: #665d22;
+.enquiry-status-unread {
+  @extend .govuk-tag--grey;
 }
 
-span.enquiry-status-unread {
-  background-color: #eeefef;
-  color: #5b6063;
-}
-
-span.enquiry-status-not-set {
-  background-color: #dad6e7;
-  color: #5a4989;
+.enquiry-status-not-set {
+  @extend .govuk-tag--purple;
 }


### PR DESCRIPTION
## Context

School rejecting a TP - Multiple Choice for reasons why

## Changes proposed in this pull request

Where the school rejects a TP right now they have a free text box to provide feedback.

This ticket will change that free text box to a single select multiple choice, with an ‘other’ option, which has a small free text box.

This will have to populate the e-mail to the TP about the rejection

Where the TP does not provide feeback, the e-mail will

not display the feedback indent and instead,

will display an alternative ‘normal’ line

We will want to have the radio button selections available for service metrics

## Guidance to review

Ensure works as per ticket and cypress tests work

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1224

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**