### PR TITLE
NTP-1246: Update the NTP data export script so includes some of the recent changes/data

### DIFF
--- a/scripts/export_enquiry_data.sh
+++ b/scripts/export_enquiry_data.sh
@@ -14,12 +14,12 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
     -c '\COPY ( 
 					SELECT 
 						"SupportReferenceNumber" AS "Reference",
-						"Schools"."EstablishmentName" AS "School Name",
+						'\''"'\'' || "Schools"."EstablishmentName" || '\''"'\'' AS "School Name",
 						"Schools"."Urn" AS "School URN",
 						"Postcode",
-						"LocalAuthorityDistrict" AS "Local Authority District",
+						'\''"'\'' || "LocalAuthorityDistrict" || '\''"'\'' AS "Local Authority District",
 						(
-							SELECT STRING_AGG("KeyStage"."Name" || '\'': '\'' || "Subjects"."Name", '\''; '\'' ORDER BY "KeyStage"."Id", "Subjects"."Name")
+							SELECT '\''"'\'' || STRING_AGG("KeyStage"."Name" || '\'': '\'' || "Subjects"."Name", '\''; '\'' ORDER BY "KeyStage"."Id", "Subjects"."Name") || '\''"'\''
 							FROM "KeyStageSubjectsEnquiry"
 								INNER JOIN "Subjects" ON "KeyStageSubjectsEnquiry"."SubjectId" = "Subjects"."Id"
 								INNER JOIN "KeyStage" ON "KeyStageSubjectsEnquiry"."KeyStageId" = "KeyStage"."Id"
@@ -119,13 +119,16 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 								AND "EnquiryResponses"."EnquiryResponseStatusId" = 5
 						) AS "Number Of Responses With Status - Not Interested",
 						"ClientReferenceNumber" AS "Notify Ref - To Enquirer - Enquiry Submitted",
+						"EmailLog"."CreatedDate" AS "Email Created Date - To Enquirer - Enquiry Submitted",
+						"EmailLog"."ProcessFromDate" AS "Email Process Date - To Enquirer - Enquiry Submitted",
 						"EmailStatus"."Status" AS "Email Status - To Enquirer - Enquiry Submitted",
-						"EmailStatus"."Description" AS "Email Status Desc - To Enquirer - Enquiry Submitted"
+						"EmailLog"."LastStatusChangedDate" AS "Email Status Date - To Enquirer - Enquiry Submitted",
+						'\''"'\'' || "EmailStatus"."Description" || '\''"'\'' AS "Email Status Desc - To Enquirer - Enquiry Submitted"
 					FROM "Enquiries" 
 						LEFT JOIN "Schools" ON "Schools"."Id" = "Enquiries"."SchoolId"
 						LEFT JOIN "EmailLog" ON "EmailLog"."Id" = "Enquiries"."EnquirerEnquirySubmittedEmailLogId"
 						LEFT JOIN "EmailStatus" ON "EmailStatus"."Id" = "EmailLog"."EmailStatusId"
-					ORDER BY "CreatedAt" ASC
+					ORDER BY "CreatedAt" DESC
         )
         TO '\'$EXPORT_DIR'/enquiries.csv'\''
         WITH ( FORMAT CSV, HEADER );' \
@@ -135,7 +138,7 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 						"Enquiries"."SupportReferenceNumber" AS "Reference",
 						"TuitionPartners"."Name" AS "Tuition Partner Name",
 						(
-							SELECT STRING_AGG("KeyStage"."Name" || '\'': '\'' || "Subjects"."Name", '\''; '\'' ORDER BY "KeyStage"."Id", "Subjects"."Name")
+							SELECT '\''"'\'' || STRING_AGG("KeyStage"."Name" || '\'': '\'' || "Subjects"."Name", '\''; '\'' ORDER BY "KeyStage"."Id", "Subjects"."Name") || '\''"'\''
 							FROM "KeyStageSubjectsEnquiry"
 								INNER JOIN "Subjects" ON "KeyStageSubjectsEnquiry"."SubjectId" = "Subjects"."Id"
 								INNER JOIN "KeyStage" ON "KeyStageSubjectsEnquiry"."KeyStageId" = "KeyStage"."Id"
@@ -181,7 +184,7 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 							THEN trim('\''"'\'' FROM ("TutoringLogistics"::json->'\''TimeOfDay'\'')::text) 
 							ELSE NULL 
 						END AS "Enquiry - Time Of Day (Tuition Plan)",
-						"TutoringLogisticsText" AS "Response - Tuition Pla",
+						"TutoringLogisticsText" AS "Response - Tuition Plan",
 						"SENDRequirements" AS "Enquiry - SEND and additional requirements",
 						"SENDRequirementsText" AS "Response - SEND and additional requirements",
 						"AdditionalInformation" AS "Enquiry - Other tuition requirements",
@@ -190,21 +193,38 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 						"CompletedAt" AS "Response - Completed At",
 						"TuitionPartnerDeclinedEnquiryDate" AS "Tuition Partner Declined Enquiry At",
 						"EnquiryResponseStatus"."Status" AS "Response Status For Enquirer",
-						"EnquiryResponses"."EnquiryResponseStatusLastUpdated" AS "Response Status For Enquirer Last Updated At",
-						"EnquirerNotInterestedReasons"."Description" AS "Enquirer Not Interested Reason",
+						CASE 
+							WHEN isfinite("EnquiryResponses"."EnquiryResponseStatusLastUpdated")
+							THEN "EnquiryResponses"."EnquiryResponseStatusLastUpdated"
+							ELSE NULL
+						END
+						AS "Response Status For Enquirer Last Updated At",
+						'\''"'\'' || "EnquirerNotInterestedReasons"."Description" || '\''"'\'' AS "Enquirer Not Interested Reason",
 						"EnquiryResponses"."EnquirerNotInterestedReasonAdditionalInfo" AS "Enquirer Not Interested Reason Additional Information",
 						"TuitionPartnerEnquirySubmittedEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Enquiry Submitted",
+						"TuitionPartnerEnquirySubmittedEmailLog"."CreatedDate" AS "Email Created Date - To Tuition Partner - Enquiry Submitted",
+						"TuitionPartnerEnquirySubmittedEmailLog"."ProcessFromDate" AS "Email Process Date - To Tuition Partner - Enquiry Submitted",
 						"TuitionPartnerEnquirySubmittedEmailStatus"."Status" AS "Email Status - To Tuition Partner - Enquiry Submitted",
-						"TuitionPartnerEnquirySubmittedEmailStatus"."Description" AS "Email Status Desc - To Tuition Partner - Enquiry Submitted",
+						"TuitionPartnerEnquirySubmittedEmailLog"."LastStatusChangedDate" AS "Email Status Date - To Tuition Partner - Enquiry Submitted",
+						'\''"'\'' || "TuitionPartnerEnquirySubmittedEmailStatus"."Description" || '\''"'\'' AS "Email Status Desc - To Tuition Partner - Enquiry Submitted",
 						"TuitionPartnerResponseEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Response Submitted",
+						"TuitionPartnerResponseEmailLog"."CreatedDate" AS "Email Created Date - To Tuition Partner - Response Submitted",
+						"TuitionPartnerResponseEmailLog"."ProcessFromDate" AS "Email Process Date - To Tuition Partner - Response Submitted",
 						"TuitionPartnerResponseEmailStatus"."Status" AS "Email Status - To Tuition Partner - Response Submitted",
-						"TuitionPartnerResponseEmailStatus"."Description" AS "Email Status Desc - To Tuition Partner - Response Submitted",
+						"TuitionPartnerResponseEmailLog"."LastStatusChangedDate" AS "Email Status Date - To Tuition Partner - Response Submitted",
+						'\''"'\'' || "TuitionPartnerResponseEmailStatus"."Description" || '\''"'\'' AS "Email Status Desc - To Tuition Partner - Response Submitted",
 						"EnquirerResponseEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Enquirer - Response Submitted",
+						"EnquirerResponseEmailLog"."CreatedDate" AS "Email Created Date - To Enquirer - Response Submitted",
+						"EnquirerResponseEmailLog"."ProcessFromDate" AS "Email Process Date - To Enquirer - Response Submitted",
 						"EnquirerResponseEmailStatus"."Status" AS "Email Status - To Enquirer - Response Submitted",
-						"EnquirerResponseEmailStatus"."Description" AS "Email Status Desc - To Enquirer - Response Submitted",
+						"EnquirerResponseEmailLog"."LastStatusChangedDate" AS "Email Status Date - To Enquirer - Response Submitted",
+						'\''"'\'' || "EnquirerResponseEmailStatus"."Description" || '\''"'\'' AS "Email Status Desc - To Enquirer - Response Submitted",
 						"TuitionPartnerResponseNotInterestedEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Enquirer Not Int",
+						"TuitionPartnerResponseNotInterestedEmailLog"."CreatedDate" AS "Email Created Date - To Tuition Partner - Enquirer Not Int",
+						"TuitionPartnerResponseNotInterestedEmailLog"."ProcessFromDate" AS "Email Process Date - To Tuition Partner - Enquirer Not Int",
 						"TuitionPartnerResponseNotInterestedEmailStatus"."Status" AS "Email Status - To Tuition Partner - Enquirer Not Int",
-						"TuitionPartnerResponseNotInterestedEmailStatus"."Description" AS "Email Status Desc - To Tuition Partner - Enquirer Not Int"
+						"TuitionPartnerResponseNotInterestedEmailLog"."LastStatusChangedDate" AS "Email Status Date - To Tuition Partner - Enquirer Not Int",
+						'\''"'\'' || "TuitionPartnerResponseNotInterestedEmailStatus"."Description" || '\''"'\'' AS "Email Status Desc - To Tuition Partner - Enquirer Not Int"
 					FROM "Enquiries"
 						INNER JOIN "TuitionPartnersEnquiry" ON "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
 						INNER JOIN "TuitionPartners" ON "TuitionPartnersEnquiry"."TuitionPartnerId" = "TuitionPartners"."Id"
@@ -220,7 +240,7 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 						LEFT JOIN "EmailLog" AS "TuitionPartnerResponseNotInterestedEmailLog" ON "TuitionPartnerResponseNotInterestedEmailLog"."Id" = "EnquiryResponses"."TuitionPartnerResponseNotInterestedEmailLogId"
 						LEFT JOIN "EmailStatus" AS "TuitionPartnerResponseNotInterestedEmailStatus" ON "TuitionPartnerResponseNotInterestedEmailStatus"."Id" = "TuitionPartnerResponseNotInterestedEmailLog"."EmailStatusId"
 					ORDER BY 
-						"Enquiries"."CreatedAt" ASC, 
+						"Enquiries"."CreatedAt" DESC, 
 						COALESCE ("EnquiryResponses"."CompletedAt", "TuitionPartnersEnquiry"."TuitionPartnerDeclinedEnquiryDate") ASC,
 						"TuitionPartners"."Name" ASC
         )

--- a/scripts/export_enquiry_data.sh
+++ b/scripts/export_enquiry_data.sh
@@ -117,10 +117,10 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 								INNER JOIN "EnquiryResponses" ON "TuitionPartnersEnquiry"."EnquiryResponseId" = "EnquiryResponses"."Id"
 							WHERE "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
 								AND "EnquiryResponses"."EnquiryResponseStatusId" = 5
-						) AS "Number Of Responses With Status - Rejected",
+						) AS "Number Of Responses With Status - Not Interested",
 						"ClientReferenceNumber" AS "Notify Ref - To Enquirer - Enquiry Submitted",
 						"EmailStatus"."Status" AS "Email Status - To Enquirer - Enquiry Submitted",
-						"EmailStatus"."Description" AS "Email Status Description - To Enquirer - Enquiry Submitted"
+						"EmailStatus"."Description" AS "Email Status Desc - To Enquirer - Enquiry Submitted"
 					FROM "Enquiries" 
 						LEFT JOIN "Schools" ON "Schools"."Id" = "Enquiries"."SchoolId"
 						LEFT JOIN "EmailLog" ON "EmailLog"."Id" = "Enquiries"."EnquirerEnquirySubmittedEmailLogId"
@@ -195,16 +195,16 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 						"EnquiryResponses"."EnquirerNotInterestedReasonAdditionalInfo" AS "Enquirer Not Interested Reason Additional Information",
 						"TuitionPartnerEnquirySubmittedEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Enquiry Submitted",
 						"TuitionPartnerEnquirySubmittedEmailStatus"."Status" AS "Email Status - To Tuition Partner - Enquiry Submitted",
-						"TuitionPartnerEnquirySubmittedEmailStatus"."Description" AS "Email Status Description - To Tuition Partner - Enquiry Submitted",
+						"TuitionPartnerEnquirySubmittedEmailStatus"."Description" AS "Email Status Desc - To Tuition Partner - Enquiry Submitted",
 						"TuitionPartnerResponseEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Response Submitted",
 						"TuitionPartnerResponseEmailStatus"."Status" AS "Email Status - To Tuition Partner - Response Submitted",
-						"TuitionPartnerResponseEmailStatus"."Description" AS "Email Status Description - To Tuition Partner - Response Submitted",
+						"TuitionPartnerResponseEmailStatus"."Description" AS "Email Status Desc - To Tuition Partner - Response Submitted",
 						"EnquirerResponseEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Enquirer - Response Submitted",
 						"EnquirerResponseEmailStatus"."Status" AS "Email Status - To Enquirer - Response Submitted",
-						"EnquirerResponseEmailStatus"."Description" AS "Email Status Description - To Enquirer - Response Submitted",
-						"TuitionPartnerResponseNotInterestedEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Enquirer Not Interested",
-						"TuitionPartnerResponseNotInterestedEmailStatus"."Status" AS "Email Status - To Tuition Partner - Enquirer Not Interested",
-						"TuitionPartnerResponseNotInterestedEmailStatus"."Description" AS "Email Status Description - To Tuition Partner - Enquirer Not Interested"
+						"EnquirerResponseEmailStatus"."Description" AS "Email Status Desc - To Enquirer - Response Submitted",
+						"TuitionPartnerResponseNotInterestedEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Enquirer Not Int",
+						"TuitionPartnerResponseNotInterestedEmailStatus"."Status" AS "Email Status - To Tuition Partner - Enquirer Not Int",
+						"TuitionPartnerResponseNotInterestedEmailStatus"."Description" AS "Email Status Desc - To Tuition Partner - Enquirer Not Int"
 					FROM "Enquiries"
 						INNER JOIN "TuitionPartnersEnquiry" ON "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
 						INNER JOIN "TuitionPartners" ON "TuitionPartnersEnquiry"."TuitionPartnerId" = "TuitionPartners"."Id"
@@ -224,7 +224,7 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 					ORDER BY 
 						"Enquiries"."CreatedAt" ASC, 
 						COALESCE ("EnquiryResponses"."CompletedAt", "TuitionPartnersEnquiry"."TuitionPartnerDeclinedEnquiryDate") ASC,
-						"TuitionPartners"."Name"
+						"TuitionPartners"."Name" ASC
         )
         TO '\'$EXPORT_DIR'/responses.csv'\''
         WITH ( FORMAT CSV, HEADER );'

--- a/scripts/export_enquiry_data.sh
+++ b/scripts/export_enquiry_data.sh
@@ -219,8 +219,6 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 						LEFT JOIN "EmailStatus" AS "EnquirerResponseEmailStatus" ON "EnquirerResponseEmailStatus"."Id" = "EnquirerResponseEmailLog"."EmailStatusId"
 						LEFT JOIN "EmailLog" AS "TuitionPartnerResponseNotInterestedEmailLog" ON "TuitionPartnerResponseNotInterestedEmailLog"."Id" = "EnquiryResponses"."TuitionPartnerResponseNotInterestedEmailLogId"
 						LEFT JOIN "EmailStatus" AS "TuitionPartnerResponseNotInterestedEmailStatus" ON "TuitionPartnerResponseNotInterestedEmailStatus"."Id" = "TuitionPartnerResponseNotInterestedEmailLog"."EmailStatusId"
-					--Commented out, so includes the details of all the TPs the enquiry was sent to
-					--WHERE "EnquiryResponses"."Id" IS NOT NULL OR "TuitionPartnersEnquiry"."TuitionPartnerDeclinedEnquiry" = true
 					ORDER BY 
 						"Enquiries"."CreatedAt" ASC, 
 						COALESCE ("EnquiryResponses"."CompletedAt", "TuitionPartnersEnquiry"."TuitionPartnerDeclinedEnquiryDate") ASC,

--- a/scripts/export_enquiry_data.sh
+++ b/scripts/export_enquiry_data.sh
@@ -14,12 +14,12 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
     -c '\COPY ( 
 					SELECT 
 						"SupportReferenceNumber" AS "Reference",
-						'\''"'\'' || "Schools"."EstablishmentName" || '\''"'\'' AS "School Name",
+						"Schools"."EstablishmentName" AS "School Name",
 						"Schools"."Urn" AS "School URN",
 						"Postcode",
-						'\''"'\'' || "LocalAuthorityDistrict" || '\''"'\'' AS "Local Authority District",
+						"LocalAuthorityDistrict" AS "Local Authority District",
 						(
-							SELECT '\''"'\'' || STRING_AGG("KeyStage"."Name" || '\'': '\'' || "Subjects"."Name", '\''; '\'' ORDER BY "KeyStage"."Id", "Subjects"."Name") || '\''"'\''
+							SELECT STRING_AGG("KeyStage"."Name" || '\'': '\'' || "Subjects"."Name", '\''; '\'' ORDER BY "KeyStage"."Id", "Subjects"."Name")
 							FROM "KeyStageSubjectsEnquiry"
 								INNER JOIN "Subjects" ON "KeyStageSubjectsEnquiry"."SubjectId" = "Subjects"."Id"
 								INNER JOIN "KeyStage" ON "KeyStageSubjectsEnquiry"."KeyStageId" = "KeyStage"."Id"
@@ -123,7 +123,7 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 						"EmailLog"."ProcessFromDate" AS "Email Process Date - To Enquirer - Enquiry Submitted",
 						"EmailStatus"."Status" AS "Email Status - To Enquirer - Enquiry Submitted",
 						"EmailLog"."LastStatusChangedDate" AS "Email Status Date - To Enquirer - Enquiry Submitted",
-						'\''"'\'' || "EmailStatus"."Description" || '\''"'\'' AS "Email Status Desc - To Enquirer - Enquiry Submitted"
+						"EmailStatus"."Description" AS "Email Status Desc - To Enquirer - Enquiry Submitted"
 					FROM "Enquiries" 
 						LEFT JOIN "Schools" ON "Schools"."Id" = "Enquiries"."SchoolId"
 						LEFT JOIN "EmailLog" ON "EmailLog"."Id" = "Enquiries"."EnquirerEnquirySubmittedEmailLogId"
@@ -138,7 +138,7 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 						"Enquiries"."SupportReferenceNumber" AS "Reference",
 						"TuitionPartners"."Name" AS "Tuition Partner Name",
 						(
-							SELECT '\''"'\'' || STRING_AGG("KeyStage"."Name" || '\'': '\'' || "Subjects"."Name", '\''; '\'' ORDER BY "KeyStage"."Id", "Subjects"."Name") || '\''"'\''
+							SELECT STRING_AGG("KeyStage"."Name" || '\'': '\'' || "Subjects"."Name", '\''; '\'' ORDER BY "KeyStage"."Id", "Subjects"."Name")
 							FROM "KeyStageSubjectsEnquiry"
 								INNER JOIN "Subjects" ON "KeyStageSubjectsEnquiry"."SubjectId" = "Subjects"."Id"
 								INNER JOIN "KeyStage" ON "KeyStageSubjectsEnquiry"."KeyStageId" = "KeyStage"."Id"
@@ -199,32 +199,32 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 							ELSE NULL
 						END
 						AS "Response Status For Enquirer Last Updated At",
-						'\''"'\'' || "EnquirerNotInterestedReasons"."Description" || '\''"'\'' AS "Enquirer Not Interested Reason",
+						"EnquirerNotInterestedReasons"."Description" AS "Enquirer Not Interested Reason",
 						"EnquiryResponses"."EnquirerNotInterestedReasonAdditionalInfo" AS "Enquirer Not Interested Reason Additional Information",
 						"TuitionPartnerEnquirySubmittedEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Enquiry Submitted",
 						"TuitionPartnerEnquirySubmittedEmailLog"."CreatedDate" AS "Email Created Date - To Tuition Partner - Enquiry Submitted",
 						"TuitionPartnerEnquirySubmittedEmailLog"."ProcessFromDate" AS "Email Process Date - To Tuition Partner - Enquiry Submitted",
 						"TuitionPartnerEnquirySubmittedEmailStatus"."Status" AS "Email Status - To Tuition Partner - Enquiry Submitted",
 						"TuitionPartnerEnquirySubmittedEmailLog"."LastStatusChangedDate" AS "Email Status Date - To Tuition Partner - Enquiry Submitted",
-						'\''"'\'' || "TuitionPartnerEnquirySubmittedEmailStatus"."Description" || '\''"'\'' AS "Email Status Desc - To Tuition Partner - Enquiry Submitted",
+						"TuitionPartnerEnquirySubmittedEmailStatus"."Description" AS "Email Status Desc - To Tuition Partner - Enquiry Submitted",
 						"TuitionPartnerResponseEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Response Submitted",
 						"TuitionPartnerResponseEmailLog"."CreatedDate" AS "Email Created Date - To Tuition Partner - Response Submitted",
 						"TuitionPartnerResponseEmailLog"."ProcessFromDate" AS "Email Process Date - To Tuition Partner - Response Submitted",
 						"TuitionPartnerResponseEmailStatus"."Status" AS "Email Status - To Tuition Partner - Response Submitted",
 						"TuitionPartnerResponseEmailLog"."LastStatusChangedDate" AS "Email Status Date - To Tuition Partner - Response Submitted",
-						'\''"'\'' || "TuitionPartnerResponseEmailStatus"."Description" || '\''"'\'' AS "Email Status Desc - To Tuition Partner - Response Submitted",
+						"TuitionPartnerResponseEmailStatus"."Description" AS "Email Status Desc - To Tuition Partner - Response Submitted",
 						"EnquirerResponseEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Enquirer - Response Submitted",
 						"EnquirerResponseEmailLog"."CreatedDate" AS "Email Created Date - To Enquirer - Response Submitted",
 						"EnquirerResponseEmailLog"."ProcessFromDate" AS "Email Process Date - To Enquirer - Response Submitted",
 						"EnquirerResponseEmailStatus"."Status" AS "Email Status - To Enquirer - Response Submitted",
 						"EnquirerResponseEmailLog"."LastStatusChangedDate" AS "Email Status Date - To Enquirer - Response Submitted",
-						'\''"'\'' || "EnquirerResponseEmailStatus"."Description" || '\''"'\'' AS "Email Status Desc - To Enquirer - Response Submitted",
+						"EnquirerResponseEmailStatus"."Description" AS "Email Status Desc - To Enquirer - Response Submitted",
 						"TuitionPartnerResponseNotInterestedEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Enquirer Not Int",
 						"TuitionPartnerResponseNotInterestedEmailLog"."CreatedDate" AS "Email Created Date - To Tuition Partner - Enquirer Not Int",
 						"TuitionPartnerResponseNotInterestedEmailLog"."ProcessFromDate" AS "Email Process Date - To Tuition Partner - Enquirer Not Int",
 						"TuitionPartnerResponseNotInterestedEmailStatus"."Status" AS "Email Status - To Tuition Partner - Enquirer Not Int",
 						"TuitionPartnerResponseNotInterestedEmailLog"."LastStatusChangedDate" AS "Email Status Date - To Tuition Partner - Enquirer Not Int",
-						'\''"'\'' || "TuitionPartnerResponseNotInterestedEmailStatus"."Description" || '\''"'\'' AS "Email Status Desc - To Tuition Partner - Enquirer Not Int"
+						"TuitionPartnerResponseNotInterestedEmailStatus"."Description" AS "Email Status Desc - To Tuition Partner - Enquirer Not Int"
 					FROM "Enquiries"
 						INNER JOIN "TuitionPartnersEnquiry" ON "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
 						INNER JOIN "TuitionPartners" ON "TuitionPartnersEnquiry"."TuitionPartnerId" = "TuitionPartners"."Id"

--- a/scripts/export_enquiry_data.sh
+++ b/scripts/export_enquiry_data.sh
@@ -12,34 +12,219 @@ cf target -s $CF_SPACE
 
 cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
     -c '\COPY ( 
-            SELECT "Enquiries"."SupportReferenceNumber" AS "Reference",
-            "TutoringLogistics",
-            "SENDRequirements",
-            "AdditionalInformation",
-            "TuitionSettings"."Name" AS "TuitionSetting",
-            "CreatedAt"
-            FROM "Enquiries" 
-            LEFT JOIN "EnquiryTuitionSetting" ON "Enquiries"."Id" = "EnquiryTuitionSetting"."EnquiriesId"
-            LEFT JOIN "TuitionSettings" ON "TuitionSettings"."Id" = "EnquiryTuitionSetting"."TuitionSettingsId"
-            ORDER BY "CreatedAt" ASC 
+					SELECT 
+						"SupportReferenceNumber" AS "Reference",
+						"Schools"."EstablishmentName" AS "School Name",
+						"Schools"."Urn" AS "School URN",
+						"Postcode",
+						"LocalAuthorityDistrict" AS "Local Authority District",
+						(
+							SELECT STRING_AGG("KeyStage"."Name" || '\'': '\'' || "Subjects"."Name", '\''; '\'' ORDER BY "KeyStage"."Id", "Subjects"."Name")
+							FROM "KeyStageSubjectsEnquiry"
+								INNER JOIN "Subjects" ON "KeyStageSubjectsEnquiry"."SubjectId" = "Subjects"."Id"
+								INNER JOIN "KeyStage" ON "KeyStageSubjectsEnquiry"."KeyStageId" = "KeyStage"."Id"
+							WHERE "Enquiries"."Id" = "KeyStageSubjectsEnquiry"."EnquiryId"
+							GROUP BY "Enquiries"."Id"
+						) AS "Key Stage And Subjects",
+						CASE (
+								SELECT count(*)
+								FROM "EnquiryTuitionSetting"
+								WHERE "Enquiries"."Id" = "EnquiryTuitionSetting"."EnquiriesId"
+							)
+							WHEN 0
+							THEN '\''No preference'\''
+							WHEN 1
+							THEN (
+								SELECT "TuitionSettings"."Name"
+								FROM "EnquiryTuitionSetting" 
+									INNER JOIN "TuitionSettings" ON "TuitionSettings"."Id" = "EnquiryTuitionSetting"."TuitionSettingsId"
+								WHERE "Enquiries"."Id" = "EnquiryTuitionSetting"."EnquiriesId"
+							)
+							ELSE '\''Both face-to-face and online'\''
+						END AS "Tuition Setting",
+						"TutoringLogistics" AS "Tuition Plan - Full",
+						CASE 
+							WHEN "TutoringLogistics" like '\''{"NumberOfPupils"%'\'' 
+							THEN trim('\''"'\'' FROM ("TutoringLogistics"::json->'\''NumberOfPupils'\'')::text) 
+							ELSE NULL 
+						END AS "Number Of Pupils (Tuition Plan)",
+						CASE 
+							WHEN "TutoringLogistics" like '\''{"NumberOfPupils"%'\'' 
+							THEN trim('\''"'\'' FROM ("TutoringLogistics"::json->'\''StartDate'\'')::text) 
+							ELSE NULL 
+						END AS "Start Date (Tuition Plan)",
+						CASE 
+							WHEN "TutoringLogistics" like '\''{"NumberOfPupils"%'\'' 
+							THEN trim('\''"'\'' FROM ("TutoringLogistics"::json->'\''TuitionDuration'\'')::text) 
+							ELSE NULL 
+						END AS "Tuition Duration (Tuition Plan)",
+						CASE 
+							WHEN "TutoringLogistics" like '\''{"NumberOfPupils"%'\'' 
+							THEN trim('\''"'\'' FROM ("TutoringLogistics"::json->'\''TimeOfDay'\'')::text) 
+							ELSE NULL 
+						END AS "Time Of Day (Tuition Plan)",
+						"SENDRequirements" AS "SEND and additional requirements",
+						"AdditionalInformation" AS "Other tuition requirements",
+						"CreatedAt" AS "Enquiry Created At",
+						(
+							SELECT count(*)
+							FROM "TuitionPartnersEnquiry"
+							WHERE "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
+						) AS "Number Of TPs Enquiry Sent To",
+						(
+							SELECT count(*)
+							FROM "TuitionPartnersEnquiry"
+							WHERE "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
+								AND "TuitionPartnerDeclinedEnquiry" = true
+						) AS "Number Of TPs Declined To Respond",
+						(
+							SELECT count(*)
+							FROM "TuitionPartnersEnquiry"
+							WHERE "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
+								AND "EnquiryResponseId" IS NOT NULL
+						) AS "Number Of TP Responses",
+						(
+							SELECT count(*)
+							FROM "TuitionPartnersEnquiry"
+								INNER JOIN "EnquiryResponses" ON "TuitionPartnersEnquiry"."EnquiryResponseId" = "EnquiryResponses"."Id"
+							WHERE "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
+								AND "EnquiryResponses"."EnquiryResponseStatusId" = 4
+						) AS "Number Of Responses With Status - Not Set",
+						(
+							SELECT count(*)
+							FROM "TuitionPartnersEnquiry"
+								INNER JOIN "EnquiryResponses" ON "TuitionPartnersEnquiry"."EnquiryResponseId" = "EnquiryResponses"."Id"
+							WHERE "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
+								AND "EnquiryResponses"."EnquiryResponseStatusId" = 3
+						) AS "Number Of Responses With Status - Unread",
+						(
+							SELECT count(*)
+							FROM "TuitionPartnersEnquiry"
+								INNER JOIN "EnquiryResponses" ON "TuitionPartnersEnquiry"."EnquiryResponseId" = "EnquiryResponses"."Id"
+							WHERE "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
+								AND "EnquiryResponses"."EnquiryResponseStatusId" = 2
+						) AS "Number Of Responses With Status - Undecided",
+						(
+							SELECT count(*)
+							FROM "TuitionPartnersEnquiry"
+								INNER JOIN "EnquiryResponses" ON "TuitionPartnersEnquiry"."EnquiryResponseId" = "EnquiryResponses"."Id"
+							WHERE "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
+								AND "EnquiryResponses"."EnquiryResponseStatusId" = 1
+						) AS "Number Of Responses With Status - Interested",
+						(
+							SELECT count(*)
+							FROM "TuitionPartnersEnquiry"
+								INNER JOIN "EnquiryResponses" ON "TuitionPartnersEnquiry"."EnquiryResponseId" = "EnquiryResponses"."Id"
+							WHERE "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
+								AND "EnquiryResponses"."EnquiryResponseStatusId" = 5
+						) AS "Number Of Responses With Status - Rejected",
+						"ClientReferenceNumber" AS "Notify Ref - To Enquirer - Enquiry Submitted",
+						"EmailStatus"."Status" AS "Email Status - To Enquirer - Enquiry Submitted",
+						"EmailStatus"."Description" AS "Email Status Description - To Enquirer - Enquiry Submitted"
+					FROM "Enquiries" 
+						LEFT JOIN "Schools" ON "Schools"."Id" = "Enquiries"."SchoolId"
+						LEFT JOIN "EmailLog" ON "EmailLog"."Id" = "Enquiries"."EnquirerEnquirySubmittedEmailLogId"
+						LEFT JOIN "EmailStatus" ON "EmailStatus"."Id" = "EmailLog"."EmailStatusId"
+					ORDER BY "CreatedAt" ASC
         )
         TO '\'$EXPORT_DIR'/enquiries.csv'\''
         WITH ( FORMAT CSV, HEADER );' \
     \
     -c '\COPY ( 
-        SELECT "Enquiries"."SupportReferenceNumber" AS "Reference",
-            "TuitionPartners"."Name" AS "TuitionPartner",
-            "EnquiryResponses"."KeyStageAndSubjectsText" AS "KeyStageAndSubjects",
-            "EnquiryResponses"."TuitionSettingText" AS "TuitionSetting",
-            "EnquiryResponses"."TutoringLogisticsText" AS "TutoringLogistics",
-            "EnquiryResponses"."SENDRequirementsText" AS "SENDRequirements",
-            "EnquiryResponses"."AdditionalInformationText" AS "AdditionalInformation",
-            "EnquiryResponses"."CompletedAt"
-            FROM "Enquiries"
-            INNER JOIN "TuitionPartnersEnquiry" ON "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
-            INNER JOIN "TuitionPartners" ON "TuitionPartnersEnquiry"."TuitionPartnerId" = "TuitionPartners"."Id"
-            INNER JOIN "EnquiryResponses" ON "TuitionPartnersEnquiry"."EnquiryResponseId" = "EnquiryResponses"."Id"
-            ORDER BY "Enquiries"."CreatedAt" ASC, "EnquiryResponses"."CompletedAt" ASC
+					SELECT 
+						"Enquiries"."SupportReferenceNumber" AS "Reference",
+						"TuitionPartners"."Name" AS "Tuition Partner Name",
+						(
+							SELECT STRING_AGG("KeyStage"."Name" || '\'': '\'' || "Subjects"."Name", '\''; '\'' ORDER BY "KeyStage"."Id", "Subjects"."Name")
+							FROM "KeyStageSubjectsEnquiry"
+								INNER JOIN "Subjects" ON "KeyStageSubjectsEnquiry"."SubjectId" = "Subjects"."Id"
+								INNER JOIN "KeyStage" ON "KeyStageSubjectsEnquiry"."KeyStageId" = "KeyStage"."Id"
+							WHERE "Enquiries"."Id" = "KeyStageSubjectsEnquiry"."EnquiryId"
+							GROUP BY "Enquiries"."Id"
+						) AS "Enquiry - Key Stage And Subjects",
+						"EnquiryResponses"."KeyStageAndSubjectsText" AS "Response - Key Stage And Subjects",
+						CASE (
+								SELECT count(*)
+								FROM "EnquiryTuitionSetting"
+								WHERE "Enquiries"."Id" = "EnquiryTuitionSetting"."EnquiriesId"
+							)
+							WHEN 0
+							THEN '\''No preference'\''
+							WHEN 1
+							THEN (
+								SELECT "TuitionSettings"."Name"
+								FROM "EnquiryTuitionSetting" 
+									INNER JOIN "TuitionSettings" ON "TuitionSettings"."Id" = "EnquiryTuitionSetting"."TuitionSettingsId"
+								WHERE "Enquiries"."Id" = "EnquiryTuitionSetting"."EnquiriesId"
+							)
+							ELSE '\''Both face-to-face and online'\''
+						END AS "Enquiry - Tuition Setting",
+						"EnquiryResponses"."TuitionSettingText" AS "Response - Tuition Setting",
+						"TutoringLogistics" AS "Enquiry - Tuition Plan - Full",
+						CASE 
+							WHEN "TutoringLogistics" like '\''{"NumberOfPupils"%'\'' 
+							THEN trim('\''"'\'' FROM ("TutoringLogistics"::json->'\''NumberOfPupils'\'')::text) 
+							ELSE NULL 
+						END AS "Enquiry - Number Of Pupils (Tuition Plan)",
+						CASE 
+							WHEN "TutoringLogistics" like '\''{"NumberOfPupils"%'\'' 
+							THEN trim('\''"'\'' FROM ("TutoringLogistics"::json->'\''StartDate'\'')::text) 
+							ELSE NULL 
+						END AS "Enquiry - Start Date (Tuition Plan)",
+						CASE 
+							WHEN "TutoringLogistics" like '\''{"NumberOfPupils"%'\'' 
+							THEN trim('\''"'\'' FROM ("TutoringLogistics"::json->'\''TuitionDuration'\'')::text) 
+							ELSE NULL 
+						END AS "Enquiry - Tuition Duration (Tuition Plan)",
+						CASE 
+							WHEN "TutoringLogistics" like '\''{"NumberOfPupils"%'\'' 
+							THEN trim('\''"'\'' FROM ("TutoringLogistics"::json->'\''TimeOfDay'\'')::text) 
+							ELSE NULL 
+						END AS "Enquiry - Time Of Day (Tuition Plan)",
+						"TutoringLogisticsText" AS "Response - Tuition Pla",
+						"SENDRequirements" AS "Enquiry - SEND and additional requirements",
+						"SENDRequirementsText" AS "Response - SEND and additional requirements",
+						"AdditionalInformation" AS "Enquiry - Other tuition requirements",
+						"AdditionalInformationText" AS "Response - Other tuition requirements",
+						"Enquiries"."CreatedAt" AS "Enquiry - Created At",
+						"CompletedAt" AS "Response - Completed At",
+						"TuitionPartnerDeclinedEnquiryDate" AS "Tuition Partner Declined Enquiry At",
+						"EnquiryResponseStatus"."Status" AS "Response Status For Enquirer",
+						"EnquiryResponses"."EnquiryResponseStatusLastUpdated" AS "Response Status For Enquirer Last Updated At",
+						"EnquirerNotInterestedReasons"."Description" AS "Enquirer Not Interested Reason",
+						"EnquiryResponses"."EnquirerNotInterestedReasonAdditionalInfo" AS "Enquirer Not Interested Reason Additional Information",
+						"TuitionPartnerEnquirySubmittedEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Enquiry Submitted",
+						"TuitionPartnerEnquirySubmittedEmailStatus"."Status" AS "Email Status - To Tuition Partner - Enquiry Submitted",
+						"TuitionPartnerEnquirySubmittedEmailStatus"."Description" AS "Email Status Description - To Tuition Partner - Enquiry Submitted",
+						"TuitionPartnerResponseEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Response Submitted",
+						"TuitionPartnerResponseEmailStatus"."Status" AS "Email Status - To Tuition Partner - Response Submitted",
+						"TuitionPartnerResponseEmailStatus"."Description" AS "Email Status Description - To Tuition Partner - Response Submitted",
+						"EnquirerResponseEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Enquirer - Response Submitted",
+						"EnquirerResponseEmailStatus"."Status" AS "Email Status - To Enquirer - Response Submitted",
+						"EnquirerResponseEmailStatus"."Description" AS "Email Status Description - To Enquirer - Response Submitted",
+						"TuitionPartnerResponseNotInterestedEmailLog"."ClientReferenceNumber" AS "Notify Ref - To Tuition Partner - Enquirer Not Interested",
+						"TuitionPartnerResponseNotInterestedEmailStatus"."Status" AS "Email Status - To Tuition Partner - Enquirer Not Interested",
+						"TuitionPartnerResponseNotInterestedEmailStatus"."Description" AS "Email Status Description - To Tuition Partner - Enquirer Not Interested"
+					FROM "Enquiries"
+						INNER JOIN "TuitionPartnersEnquiry" ON "Enquiries"."Id" = "TuitionPartnersEnquiry"."EnquiryId"
+						INNER JOIN "TuitionPartners" ON "TuitionPartnersEnquiry"."TuitionPartnerId" = "TuitionPartners"."Id"
+						LEFT JOIN "EnquiryResponses" ON "TuitionPartnersEnquiry"."EnquiryResponseId" = "EnquiryResponses"."Id"
+						LEFT JOIN "EnquiryResponseStatus" ON "EnquiryResponseStatus"."Id" = "EnquiryResponses"."EnquiryResponseStatusId"
+						LEFT JOIN "EnquirerNotInterestedReasons" ON "EnquirerNotInterestedReasons"."Id" = "EnquiryResponses"."EnquirerNotInterestedReasonId"
+						LEFT JOIN "EmailLog" AS "TuitionPartnerEnquirySubmittedEmailLog" ON "TuitionPartnerEnquirySubmittedEmailLog"."Id" = "TuitionPartnersEnquiry"."TuitionPartnerEnquirySubmittedEmailLogId"
+						LEFT JOIN "EmailStatus" AS "TuitionPartnerEnquirySubmittedEmailStatus" ON "TuitionPartnerEnquirySubmittedEmailStatus"."Id" = "TuitionPartnerEnquirySubmittedEmailLog"."EmailStatusId"
+						LEFT JOIN "EmailLog" AS "TuitionPartnerResponseEmailLog" ON "TuitionPartnerResponseEmailLog"."Id" = "EnquiryResponses"."TuitionPartnerResponseEmailLogId"
+						LEFT JOIN "EmailStatus" AS "TuitionPartnerResponseEmailStatus" ON "TuitionPartnerResponseEmailStatus"."Id" = "TuitionPartnerResponseEmailLog"."EmailStatusId"
+						LEFT JOIN "EmailLog" AS "EnquirerResponseEmailLog" ON "EnquirerResponseEmailLog"."Id" = "EnquiryResponses"."EnquirerResponseEmailLogId"
+						LEFT JOIN "EmailStatus" AS "EnquirerResponseEmailStatus" ON "EnquirerResponseEmailStatus"."Id" = "EnquirerResponseEmailLog"."EmailStatusId"
+						LEFT JOIN "EmailLog" AS "TuitionPartnerResponseNotInterestedEmailLog" ON "TuitionPartnerResponseNotInterestedEmailLog"."Id" = "EnquiryResponses"."TuitionPartnerResponseNotInterestedEmailLogId"
+						LEFT JOIN "EmailStatus" AS "TuitionPartnerResponseNotInterestedEmailStatus" ON "TuitionPartnerResponseNotInterestedEmailStatus"."Id" = "TuitionPartnerResponseNotInterestedEmailLog"."EmailStatusId"
+					--Commented out, so includes the details of all the TPs the enquiry was sent to
+					--WHERE "EnquiryResponses"."Id" IS NOT NULL OR "TuitionPartnersEnquiry"."TuitionPartnerDeclinedEnquiry" = true
+					ORDER BY 
+						"Enquiries"."CreatedAt" ASC, 
+						COALESCE ("EnquiryResponses"."CompletedAt", "TuitionPartnersEnquiry"."TuitionPartnerDeclinedEnquiryDate") ASC,
+						"TuitionPartners"."Name"
         )
         TO '\'$EXPORT_DIR'/responses.csv'\''
         WITH ( FORMAT CSV, HEADER );'

--- a/scripts/export_enquiry_data.sh
+++ b/scripts/export_enquiry_data.sh
@@ -14,6 +14,7 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
     -c '\COPY ( 
 					SELECT 
 						"SupportReferenceNumber" AS "Reference",
+						"CreatedAt" AS "Enquiry Created At",
 						"Schools"."EstablishmentName" AS "School Name",
 						"Schools"."Urn" AS "School URN",
 						"Postcode",
@@ -65,7 +66,6 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 						END AS "Time Of Day (Tuition Plan)",
 						"SENDRequirements" AS "SEND and additional requirements",
 						"AdditionalInformation" AS "Other tuition requirements",
-						"CreatedAt" AS "Enquiry Created At",
 						(
 							SELECT count(*)
 							FROM "TuitionPartnersEnquiry"
@@ -136,6 +136,8 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
     -c '\COPY ( 
 					SELECT 
 						"Enquiries"."SupportReferenceNumber" AS "Reference",
+						"Enquiries"."CreatedAt" AS "Enquiry - Created At",
+						"CompletedAt" AS "Response - Completed At",
 						"TuitionPartners"."Name" AS "Tuition Partner Name",
 						(
 							SELECT STRING_AGG("KeyStage"."Name" || '\'': '\'' || "Subjects"."Name", '\''; '\'' ORDER BY "KeyStage"."Id", "Subjects"."Name")
@@ -189,8 +191,6 @@ cf conduit $DB_SERVICE -c '{"read_only": true}' -- psql \
 						"SENDRequirementsText" AS "Response - SEND and additional requirements",
 						"AdditionalInformation" AS "Enquiry - Other tuition requirements",
 						"AdditionalInformationText" AS "Response - Other tuition requirements",
-						"Enquiries"."CreatedAt" AS "Enquiry - Created At",
-						"CompletedAt" AS "Response - Completed At",
 						"TuitionPartnerDeclinedEnquiryDate" AS "Tuition Partner Declined Enquiry At",
 						"EnquiryResponseStatus"."Status" AS "Response Status For Enquirer",
 						CASE 


### PR DESCRIPTION
## Context

Update the NTP data export script so includes some of the recent changes/data

## Changes proposed in this pull request

There is an existing data export script that allows us to get the live enquiry data and do some analysis and/or help with any user enquiries that come via the helpdesk.  See [find-a-tuition-partner/scripts/export_enquiry_data.sh at main · DFE-Digital/find-a-tuition-partner](https://github.com/DFE-Digital/find-a-tuition-partner/blob/main/scripts/export_enquiry_data.sh) 

This export should include some of the data from the more recent changes, but after review could also be improved.

 

Update the script to:

Include the recent changes/data:

School name, postcode and LAD

If the TP has declined to respond

If the enquirer has rejected the response and if selected other the free text reason

The enquirers status set for a response

The email details (the Notify reference and the email delivery status we have collected within the NTP database) - for any email sent (other than the email verification one)

Update the script so that the enquiry questions are included alongside each response to make this easy to review.

The script is missing the Key Stage and Subject details, these should be added in.

If “both” was selected for tuition setting then there are 2 rows in the enquiry export, this should be 1 row with the setting set correctly.  If no preference is set for the setting it is blank in the report, this could state “no preference“

Ensure that details of all the TPs that the enquiry has been sent to are included, to help with the visibility of the email logging (that will be included, as mentioned above)

## Guidance to review

Review the SQL, run it locally and then run against live to get data and compare to previous script to ensure bring matching data

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1246

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [x] **PR deployment has been signed off by wider team**