### PR TITLE
NTP-1112: Users may struggle to find the comparison list link if they are at the bottom of the page.

### DIFF
--- a/UI/Pages/SearchResults.cshtml
+++ b/UI/Pages/SearchResults.cshtml
@@ -14,6 +14,9 @@
   ViewData["Title"] = "Your options for choosing a tuition partner";
   ViewData["BackLinkHref"] = $"/which-tuition-settings?{Model.Data.ToQueryString()}";
   ViewData["IncludePrintPage"] = true;
+  ViewData["IncludeBackToTopLink"] = true;
+  ViewData["IncludeComparePricesLink"] = Model.Data;
+  ViewData["TotalCompareListedTuitionPartners"] = Model.TotalCompareListedTuitionPartners;
 
   var validResults = (Model.Data != null && Model.Data.Results != null && Model.Data.Results.Results != null && Model.Data.Results.LocalAuthorityDistrictName != null);
   var results = !validResults ? new List<TuitionPartnerResult>() : Model!.Data!.Results!.Results;
@@ -181,7 +184,7 @@
                 Update price comparison list
               </govuk-button>
             </div>
-            <div class="govuk-grid-column-full">
+            <div class="govuk-grid-column-full" id="my-compare-list-link">
               <a asp-page="/CompareList" asp-all-route-data="@Model.Data.ToRouteData()" class="govuk-link govuk-!-font-size-24"
                  module="my-compare-listed-tuition-partners-link" data-testid="my-compare-listed-tuition-partners-link">
                 Compare tuition partner prices

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -9,6 +9,10 @@
   // Only allow search engines to index pages on the production environment that have explicitly set AllowIndexing to true
   var allowIndexing = HostEnvironment.IsProduction() && ViewData["AllowIndexing"] as bool? == true;
 
+  var includeBackToTopLink = ViewData["IncludeBackToTopLink"] == null ? false : (bool)ViewData["IncludeBackToTopLink"]!;
+  var comparePricesSearchResultsModel = ViewData["IncludeComparePricesLink"] == null ? null : ViewData["IncludeComparePricesLink"] as Application.Common.Models.SearchResultsModel;
+  var totalCompareListedTuitionPartners = ViewData["TotalCompareListedTuitionPartners"] == null ? 0 : (int)ViewData["TotalCompareListedTuitionPartners"]!;
+
   var includeHomeLink = ViewData["IncludeHomeLink"] as bool? == true;
   var backLinkHref = ViewData["BackLinkHref"] as string;
   var backLinkText = ViewData["BackLinkText"] as string;
@@ -166,7 +170,7 @@
 
   <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
-  <header class="govuk-header " role="banner" data-module="govuk-header">
+  <header class="govuk-header " role="banner" data-module="govuk-header" id="top">
     <div class="govuk-header__container govuk-width-container">
       <div class="govuk-header__logo">
         <a href="/" class="govuk-header__link govuk-header__link--homepage">
@@ -258,6 +262,25 @@
     <main class="govuk-main-wrapper " id="main-content" role="main">
       @RenderBody()
     </main>
+    @if (includeBackToTopLink)
+    {
+      <div class="govuk-body app-back-to-top-banner app-print-hide" data-module="back-to-top-banner">
+        <partial name="_TopLink" />
+        @if (comparePricesSearchResultsModel != null)
+        {
+          <a asp-page="/CompareList" asp-all-route-data="@comparePricesSearchResultsModel.ToRouteData()" class="govuk-link total-compare-listed-tuition-partners-top-link"
+             module="my-compare-listed-tuition-partners-link" data-testid="my-compare-listed-tuition-partners-link">
+            Compare tuition partner prices
+            <span id="total-compare-listed-tuition-partners-badge-top" class="moj-notification-badge my-compare-listed-partners-badge">
+              @totalCompareListedTuitionPartners
+            </span>
+          </a>
+        }
+      </div>
+      <div class="govuk-grid-row app-print-hide top-link-no-js">
+        <partial name="_TopLink" />
+      </div>
+    }
   </div>
 
   <footer class="govuk-footer " role="contentinfo">

--- a/UI/Pages/Shared/_Layout.cshtml
+++ b/UI/Pages/Shared/_Layout.cshtml
@@ -269,7 +269,7 @@
         @if (comparePricesSearchResultsModel != null)
         {
           <a asp-page="/CompareList" asp-all-route-data="@comparePricesSearchResultsModel.ToRouteData()" class="govuk-link total-compare-listed-tuition-partners-top-link"
-             module="my-compare-listed-tuition-partners-link" data-testid="my-compare-listed-tuition-partners-link">
+             module="my-compare-listed-tuition-partners-link" data-testid="my-compare-listed-tuition-partners-link-top">
             Compare tuition partner prices
             <span id="total-compare-listed-tuition-partners-badge-top" class="moj-notification-badge my-compare-listed-partners-badge">
               @totalCompareListedTuitionPartners

--- a/UI/Pages/Shared/_TopLink.cshtml
+++ b/UI/Pages/Shared/_TopLink.cshtml
@@ -1,0 +1,6 @@
+﻿<a class="govuk-link" href="#top">
+  <svg class="app-back-to-top-link__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+    <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+  </svg>
+  Back to top
+</a>

--- a/UI/cypress/e2e/compare-list.feature
+++ b/UI/cypress/e2e/compare-list.feature
@@ -64,11 +64,11 @@ Feature: Tuition Partner price comparison list
     When they click on the option heading for 'Key stage 4'
     And they select subject 'key-stage-4-humanities'
     Then the price comparison list shows as having 2 entries on the results page
+
   Scenario: User changes their postcode to exclude a price comparison listed TP
     Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
     And they add tp name 1 to their price comparison list on the results page
     And they add tp name 3 to their price comparison list on the results page
-
     When they enter 'TN22 2BL' as the school's postcode
     And they click 'Search'
     Then the price comparison list shows as having 2 entries on the results page
@@ -341,3 +341,31 @@ Feature: Tuition Partner price comparison list
     When they choose to view their price comparison list from the results page
     Then there are 1 entries on the price comparison list page
     Then the correct Local Authority District is shown for 'Scarborough'
+
+  Scenario: User cannot see top fixed price comparison list page link when above the in page link
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+    When they scroll to the top of in page price comparison list page link
+    Then the top fixed price comparison list page link is not visible
+
+  Scenario: User can see top fixed price comparison list page link when below the in page link
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+    When they scroll to the first result
+    Then the top fixed price comparison list page link is visible
+
+  Scenario: User can add lots of TPs to their price comparison list in quick succession from the results page and the fixed price comparison list page link is updated
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+    When they programmatically add the first 20 results to their price comparison list on the results page
+    And they scroll to the first result
+    Then the top fixed price comparison list page link is visible
+    Then the top fixed price comparison list shows as having 20 entries on the results page
+
+  Scenario: User can add use the fixed price comparison list page link to go to the price comparison page
+    Given a user has arrived on the 'Search results' page for 'Key stage 2 English' for postcode 'SK1 1EB'
+    And they add tp name 1 to their price comparison list on the results page
+    And they add tp name 2 to their price comparison list on the results page
+    And they scroll to the first result
+    When they choose to view their price comparison list from the results page using the fixed price comparison list page link
+    Then there are 2 entries on the price comparison list page
+    And the heading caption is 'Tuition partners for Stockport'
+    And tp name 1 is entry 1 on the price comparison list page
+    And tp name 2 is entry 2 on the price comparison list page

--- a/UI/cypress/e2e/compare-list.js
+++ b/UI/cypress/e2e/compare-list.js
@@ -447,3 +447,48 @@ Then("the price comparison list key stage subjects header is not shown", () => {
     "not.exist"
   );
 });
+
+When(
+  "they scroll to the top of in page price comparison list page link",
+  () => {
+    cy.get(
+      '[data-testid="my-compare-listed-tuition-partners-link"]'
+    ).scrollIntoView();
+  }
+);
+
+Then("the top fixed price comparison list page link is not visible", () => {
+  cy.get('[data-testid="my-compare-listed-tuition-partners-link-top"]').should(
+    "not.be.visible"
+  );
+});
+
+When("they scroll to the first result", () => {
+  cy.get('[data-testid="results-list-item"]').first().scrollIntoView();
+});
+
+Then("the top fixed price comparison list page link is visible", () => {
+  cy.get('[data-testid="my-compare-listed-tuition-partners-link-top"]').should(
+    "be.visible"
+  );
+});
+
+Then(
+  "the top fixed price comparison list shows as having {int} entries on the results page",
+  (numEntries) => {
+    cy.get("#total-compare-listed-tuition-partners-badge-top").should((el) =>
+      expect(parseInt(el.text().trim())).to.equal(numEntries)
+    );
+  }
+);
+
+When(
+  "they choose to view their price comparison list from the results page using the fixed price comparison list page link",
+  () => {
+    cy.get('[data-testid="my-compare-listed-tuition-partners-link-top"]').click(
+      {
+        force: true,
+      }
+    );
+  }
+);

--- a/UI/cypress/support/step_definitions/results-page.js
+++ b/UI/cypress/support/step_definitions/results-page.js
@@ -6,9 +6,14 @@ import {
 } from "@badeball/cypress-cucumber-preprocessor";
 import { getJumpToLocationId, kebabCase, KeyStageSubjects } from "../utils";
 
+Given("the price comparison list is cleared", () => {
+  cy.clearCookie(".FindATuitionPartner.PriceComparisonList");
+});
+
 Given(
   "a user has arrived on the 'Search results' page for {string}",
   (keyStageSubject) => {
+    Step(this, "the price comparison list is cleared");
     cy.visit(
       `/search-results?postcode=sk11eb&${KeyStageSubjects(
         "subjects",
@@ -21,6 +26,7 @@ Given(
 Given(
   "a user has arrived on the 'Search results' page for {string} without a postcode",
   (keyStage) => {
+    Step(this, "the price comparison list is cleared");
     cy.visit(
       `/search-results?key-subjects=KeyStage1&subjects=KeyStage1-English`
     );
@@ -30,6 +36,7 @@ Given(
 Given(
   "a user has arrived on the 'Search results' page for {string} for postcode {string}",
   (keystages, postcode) => {
+    Step(this, "the price comparison list is cleared");
     const query = keystages
       .split(",")
       .map((s) => KeyStageSubjects("subjects", s.trim()))
@@ -41,6 +48,7 @@ Given(
 Given(
   "a user has arrived on the 'Search results' page for {string} for postcode {string} and tuition setting {string}",
   (keystages, postcode, tuitionSetting) => {
+    Step(this, "the price comparison list is cleared");
     const query = keystages
       .split(",")
       .map((s) => KeyStageSubjects("subjects", s.trim()))
@@ -64,6 +72,7 @@ Given(
 Given(
   "a user has arrived on the 'Search results' page without subjects for postcode {string}",
   (postcode) => {
+    Step(this, "the price comparison list is cleared");
     cy.visit(`/search-results?Postcode=${postcode}`);
   }
 );
@@ -71,11 +80,13 @@ Given(
 Given(
   "a user has arrived on the 'Search results' page without subjects or postcode",
   () => {
+    Step(this, "the price comparison list is cleared");
     cy.visit(`/search-results`);
   }
 );
 
 Given("a user has arrived on the 'Search results' page", () => {
+  Step(this, "the price comparison list is cleared");
   cy.visit(
     `/search-results?Postcode=sk11eb&Subjects=KeyStage1-English&Subjects=KeyStage1-Maths&Subjects=KeyStage1-Science&Subjects=KeyStage2-English&Subjects=KeyStage2-Maths&Subjects=KeyStage2-Science&Subjects=KeyStage3-English&Subjects=KeyStage3-Humanities&Subjects=KeyStage3-Maths&Subjects=KeyStage3-Modern%20foreign%20languages&Subjects=KeyStage3-Science&Subjects=KeyStage4-English&Subjects=KeyStage4-Humanities&Subjects=KeyStage4-Maths&Subjects=KeyStage4-Modern%20foreign%20languages&Subjects=KeyStage4-Science&KeyStages=KeyStage1&KeyStages=KeyStage2&KeyStages=KeyStage3&KeyStages=KeyStage4`
   );

--- a/UI/src/index.js
+++ b/UI/src/index.js
@@ -79,6 +79,12 @@ import PrintThisPage from "./javascript/print-this-page";
 var printThisPage = new PrintThisPage();
 printThisPage.init();
 
+import BackToTop from "./javascript/back-to-top";
+const backToTopBanner = document.querySelectorAll(
+  '[data-module="back-to-top-banner"]'
+);
+BackToTop.init(backToTopBanner);
+
 import CompareListCheckbox from "./javascript/compare-list-checkbox";
 const compareListCheckboxes = document.querySelectorAll(
   '[data-module="compare-list-checkbox"]'

--- a/UI/src/index.scss
+++ b/UI/src/index.scss
@@ -57,3 +57,4 @@ $govuk-page-width: 1180px;
 @import "src/sass/enquiry-build";
 @import "src/sass/enquiry-respond";
 @import "src/sass/enquiry-manage";
+@import "src/sass/back-to-top";

--- a/UI/src/javascript/back-to-top.js
+++ b/UI/src/javascript/back-to-top.js
@@ -1,0 +1,54 @@
+﻿"use strict";
+
+const BackToTop = (() => {
+  const init = (backToTopBanner) => {
+    if (backToTopBanner && backToTopBanner.length > 0) {
+      window.addEventListener("scroll", onScroll);
+      onScroll();
+    }
+  };
+
+  const onScroll = async () => {
+    var backToTopBanner = document.body.querySelector(
+      ".app-back-to-top-banner"
+    );
+
+    if (backToTopBanner) {
+      var windowScrolledFromTop =
+        window.pageYOffset || document.documentElement.scrollTop;
+
+      var showBanner = false;
+
+      var myCompareListLink = document.body.querySelector(
+        "#my-compare-list-link"
+      );
+      if (myCompareListLink) {
+        var compareLocationGoesOffWindow =
+          myCompareListLink.offsetTop + myCompareListLink.offsetHeight;
+        if (windowScrolledFromTop > compareLocationGoesOffWindow) {
+          showBanner = true;
+        }
+      } else {
+        var topElement = document.body.querySelector("#top");
+        if (topElement) {
+          var topElementGoesOffWindow = topElement.offsetTop;
+          if (windowScrolledFromTop > topElementGoesOffWindow) {
+            showBanner = true;
+          }
+        }
+      }
+
+      if (showBanner) {
+        backToTopBanner.classList.add("app-back-to-top-banner__fixed");
+      } else {
+        backToTopBanner.classList.remove("app-back-to-top-banner__fixed");
+      }
+    }
+  };
+
+  return {
+    init,
+  };
+})();
+
+export default BackToTop;

--- a/UI/src/javascript/compare-list-checkbox.js
+++ b/UI/src/javascript/compare-list-checkbox.js
@@ -68,18 +68,26 @@ const CompareListCheckbox = (() => {
       );
     }
   };
+  const setBadge = (badgeElementId, totalCompareListedTuitionPartners) => {
+    const badgeElement = document.getElementById(badgeElementId);
+    if (badgeElement) {
+      badgeElement.textContent = totalCompareListedTuitionPartners;
+      setCompareListedTuitionPartnersBadgeClass(
+        badgeElement,
+        totalCompareListedTuitionPartners
+      );
+    }
+  };
   const updateSearchResultPage = (result, checkBox, elseCheckboxState) => {
     if (isResultValid(result) && result.isCallSuccessful) {
-      const badgeElement = document.getElementById(
-        "totalCompareListedTuitionPartners"
+      setBadge(
+        "totalCompareListedTuitionPartners",
+        result.totalCompareListedTuitionPartners
       );
-      if (badgeElement) {
-        badgeElement.textContent = result.totalCompareListedTuitionPartners;
-        setCompareListedTuitionPartnersBadgeClass(
-          badgeElement,
-          result.totalCompareListedTuitionPartners
-        );
-      }
+      setBadge(
+        "total-compare-listed-tuition-partners-badge-top",
+        result.totalCompareListedTuitionPartners
+      );
     } else {
       checkBox.checked = elseCheckboxState;
     }

--- a/UI/src/sass/back-to-top.scss
+++ b/UI/src/sass/back-to-top.scss
@@ -1,0 +1,49 @@
+﻿.app-back-to-top-banner {
+  background: #fff;
+  display: none;
+}
+
+.app-back-to-top-banner__fixed {
+  position: fixed;
+  display: block;
+  top: 0;
+  border: 1px solid #b1b4b6;
+  border-top: 0;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
+  box-sizing: border-box;
+  padding: 10px 15px;
+  left: 0;
+  width: 100%;
+  max-width: 1240px;
+}
+
+@include govuk-media-query($from: mobile) {
+  .app-back-to-top-banner__fixed {
+    padding: 12px 30px;
+  }
+}
+
+@include govuk-media-query($from: tablet) {
+  .app-back-to-top-banner__fixed {
+    left: auto;
+    margin-left: -30px;
+  }
+}
+
+.app-back-to-top-banner .total-compare-listed-tuition-partners-top-link {
+  margin-top: 0;
+  float: right;
+}
+
+.js-enabled .top-link-no-js {
+  display: none;
+}
+
+.top-link-no-js {
+  a {
+    display: inline-block;
+    margin-bottom: 30px;
+    margin-left: 30px;
+    margin-right: 30px;
+  }
+}


### PR DESCRIPTION
## Context

Users may struggle to find the comparison list link if they are at the bottom of the page.

## Changes proposed in this pull request

Add link that shows at top of page to return to top or view price compare list, like https://findapprenticeshiptraining.apprenticeships.education.gov.uk/courses

## Guidance to review

Test with js enabled and disabled, in desktop, tablet and mobile and check accessible

## Link to Jira ticket

https://dfedigital.atlassian.net/browse/NTP-1112

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [x] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [x] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [x] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**