### PR TITLE
Revert "NTP-1292: Fix Inconsistent Domain Resolution for https://www.find-tuition-partner.service.gov.uk"

### DIFF
--- a/terraform/azure/vars-production.tfvars
+++ b/terraform/azure/vars-production.tfvars
@@ -25,9 +25,3 @@ app_setting_googleTagManager_containerId                   = "GTM-KV8MCQW"
 appLogging_defaultLogEventLevel                            = "Information"
 appLogging_overrideLogEventLevel                           = "Information"
 app_setting_emailSettings_minsDelaySendingOutcomeEmailToTP = 1440
-cdn_frontdoor_host_redirects = [
-  {
-    "from" = "find-tuition-partner.service.gov.uk",
-    "to"   = "www.find-tuition-partner.service.gov.uk"
-  }
-]


### PR DESCRIPTION
Reverts DFE-Digital/find-a-tuition-partner#398