### PR TITLE
NTP-1288: Pass the required vars to the continuous deployment QA workflow

### DIFF
--- a/.github/actions/terraform-apply-and-deployment/action.yml
+++ b/.github/actions/terraform-apply-and-deployment/action.yml
@@ -177,6 +177,6 @@ runs:
       run: az webapp deployment slot delete --resource-group ${{ inputs.az_resource_group_name  }}  --name ${{ inputs.az_webapp_name }} --slot ${{ inputs.deployment_slot }}
       
     - name: Delete non prod Function App deployment slot
-      if: always() && ${{ inputs.deploy_to_azure_function_app == 'true' }}
+      if: ${{ inputs.deploy_to_azure_function_app == 'true' }}
       shell: bash
       run: az functionapp deployment slot delete --resource-group ${{ inputs.az_resource_group_name  }}  --name ${{ inputs.az_function_app_name }} --slot ${{ inputs.deployment_slot }}

--- a/.github/workflows/continuous-deployment-to-qa.yml
+++ b/.github/workflows/continuous-deployment-to-qa.yml
@@ -26,6 +26,7 @@ jobs:
     
     secrets:
       az_webapp_name: ${{ secrets.AZURE_WEBAPP_NAME }}
+      az_function_app_name: ${{ secrets.AZURE_FUNCTION_APP_NAME }}
       az_resource_group_name: ${{ secrets.AZURE_RESOURCE_GROUP }}
       az_tenant_id: ${{ secrets.ARM_TENANT_ID }}
       az_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
@@ -41,3 +42,4 @@ jobs:
       monitor_slack_webhook_receiver: ${{ secrets.SLACK_WEBHOOK }}
       monitor_email_receivers: ${{ secrets.MONITOR_EMAIL_RECEIVERS }}
       dfeAnalytics_credential: ${{ secrets.DFE_ANALYTICS_CREDENTIALS_JSON }}
+      blob_storage_enquiries_data_client_secret: ${{ secrets.BLOB_STORAGE_ENQUIRIES_DATA_CLIENT_SECRET }}

--- a/terraform/azure/modules/fatp_azure_web_app_services_hosting/key-vault.tf
+++ b/terraform/azure/modules/fatp_azure_web_app_services_hosting/key-vault.tf
@@ -164,7 +164,6 @@ resource "azurerm_monitor_diagnostic_setting" "default_key_vault" {
 
     retention_policy {
       enabled = true
-      days    = 7
     }
   }
 
@@ -173,7 +172,6 @@ resource "azurerm_monitor_diagnostic_setting" "default_key_vault" {
 
     retention_policy {
       enabled = true
-      days    = 7
     }
   }
 }

--- a/terraform/azure/modules/fatp_azure_web_app_services_hosting/logic-app.tf
+++ b/terraform/azure/modules/fatp_azure_web_app_services_hosting/logic-app.tf
@@ -62,7 +62,6 @@ resource "azurerm_monitor_diagnostic_setting" "webhook" {
 
     retention_policy {
       enabled = true
-      days    = 7
     }
   }
 
@@ -71,7 +70,6 @@ resource "azurerm_monitor_diagnostic_setting" "webhook" {
 
     retention_policy {
       enabled = true
-      days    = 7
     }
   }
 }

--- a/terraform/azure/modules/fatp_azure_web_app_services_hosting/logs-storage.tf
+++ b/terraform/azure/modules/fatp_azure_web_app_services_hosting/logs-storage.tf
@@ -70,7 +70,7 @@ resource "azurerm_monitor_diagnostic_setting" "web_app" {
     category = "Transaction"
 
     retention_policy {
-      enabled = false
+      enabled = true
     }
   }
 }
@@ -87,7 +87,7 @@ resource "azurerm_monitor_diagnostic_setting" "function_app" {
     category = "Transaction"
 
     retention_policy {
-      enabled = false
+      enabled = true
     }
   }
 }

--- a/terraform/azure/modules/fatp_azure_web_app_services_hosting/monitor.tf
+++ b/terraform/azure/modules/fatp_azure_web_app_services_hosting/monitor.tf
@@ -20,7 +20,6 @@ resource "azurerm_monitor_diagnostic_setting" "web_app_service" {
 
       retention_policy {
         enabled = true
-        days    = local.service_log_retention
       }
     }
   }
@@ -30,7 +29,6 @@ resource "azurerm_monitor_diagnostic_setting" "web_app_service" {
 
     retention_policy {
       enabled = true
-      days    = local.service_log_retention
     }
   }
 }
@@ -57,7 +55,6 @@ resource "azurerm_monitor_diagnostic_setting" "function_app_service" {
 
       retention_policy {
         enabled = true
-        days    = local.service_log_retention
       }
     }
   }
@@ -67,7 +64,6 @@ resource "azurerm_monitor_diagnostic_setting" "function_app_service" {
 
     retention_policy {
       enabled = true
-      days    = local.service_log_retention
     }
   }
 }

--- a/terraform/azure/modules/fatp_azure_web_app_services_hosting/postgresql.tf
+++ b/terraform/azure/modules/fatp_azure_web_app_services_hosting/postgresql.tf
@@ -81,7 +81,6 @@ resource "azurerm_monitor_diagnostic_setting" "default_postgresql_flexible_serve
 
       retention_policy {
         enabled = true
-        days    = local.service_log_retention
       }
     }
   }
@@ -91,7 +90,6 @@ resource "azurerm_monitor_diagnostic_setting" "default_postgresql_flexible_serve
 
     retention_policy {
       enabled = true
-      days    = local.service_log_retention
     }
   }
 }

--- a/terraform/azure/modules/fatp_azure_web_app_services_hosting/redis-cache.tf
+++ b/terraform/azure/modules/fatp_azure_web_app_services_hosting/redis-cache.tf
@@ -94,7 +94,6 @@ resource "azurerm_monitor_diagnostic_setting" "default_redis_cache" {
 
     retention_policy {
       enabled = true
-      days    = 7
     }
   }
 
@@ -103,7 +102,6 @@ resource "azurerm_monitor_diagnostic_setting" "default_redis_cache" {
 
     retention_policy {
       enabled = true
-      days    = 7
     }
   }
 }


### PR DESCRIPTION
## Context

This PR addresses a problem that was brought up in the prior PR: [https://github.com/DFE-Digital/find-a-tuition-partner/pull/397](https://github.com/DFE-Digital/find-a-tuition-partner/pull/397)

## Changes proposed in this pull request: 
Pass the required vars to the continuous deployment QA workflow.
It also remove the deprecated `days` from the [azurerm_monitor_diagnostic_setting](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting#retention_policy) `retention_policy block`. The following issue talk about it further: [https://github.com/hashicorp/terraform-provider-azurerm/issues/23051](https://github.com/hashicorp/terraform-provider-azurerm/issues/23051)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

[https://dfedigital.atlassian.net/browse/NTP-1288](https://dfedigital.atlassian.net/browse/NTP-1288)

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**