### PR TITLE
NTP-1288: Separate the key vault access policy from the primary `azurerm_key_vault` resource

### DIFF
--- a/UI/cypress.config.js
+++ b/UI/cypress.config.js
@@ -63,6 +63,6 @@ module.exports = defineConfig({
     baseUrl: "https://localhost:7036/",
     specPattern: "**/*.feature",
     setupNodeEvents,
-    defaultCommandTimeout: 10000, // Command timeout overridden for E2E tests
+    defaultCommandTimeout: 20000, // Command timeout overridden for E2E tests set to 20 seconds
   },
 });

--- a/terraform/azure/modules/fatp_azure_web_app_services_hosting/key-vault.tf
+++ b/terraform/azure/modules/fatp_azure_web_app_services_hosting/key-vault.tf
@@ -8,56 +8,6 @@ resource "azurerm_key_vault" "default" {
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true
 
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "Create",
-      "Get",
-    ]
-
-    secret_permissions = [
-      "Set",
-      "Get",
-      "Delete",
-      "Purge",
-      "Recover",
-      "List",
-    ]
-  }
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = azurerm_linux_web_app.default[0].identity[0].principal_id
-
-    key_permissions = [
-      "Get",
-      "List",
-    ]
-
-    secret_permissions = [
-      "Get",
-      "List",
-    ]
-  }
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = azurerm_linux_function_app.default.identity[0].principal_id
-
-    key_permissions = [
-      "Get",
-      "List",
-    ]
-
-    secret_permissions = [
-      "Get",
-      "List",
-    ]
-  }
-
-
   network_acls {
     bypass                     = "AzureServices"
     default_action             = "Deny"
@@ -74,6 +24,58 @@ resource "azurerm_key_vault" "default" {
     ]
   }
 
+}
+
+resource "azurerm_key_vault_access_policy" "pipeline_service_account" {
+  key_vault_id = azurerm_key_vault.default.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = [
+    "Create",
+    "Get",
+  ]
+
+  secret_permissions = [
+    "Set",
+    "Get",
+    "Delete",
+    "Purge",
+    "Recover",
+    "List",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "fatp_web_app" {
+  key_vault_id = azurerm_key_vault.default.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_linux_web_app.default[0].identity[0].principal_id
+
+  key_permissions = [
+    "Get",
+    "List",
+  ]
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "fatp_function_app" {
+  key_vault_id = azurerm_key_vault.default.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_linux_function_app.default.identity[0].principal_id
+
+  key_permissions = [
+    "Get",
+    "List",
+  ]
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
 }
 
 resource "azurerm_key_vault_secret" "fatpdbconnectionstring" {

--- a/terraform/azure/modules/fatp_azure_web_app_services_hosting/key-vault.tf
+++ b/terraform/azure/modules/fatp_azure_web_app_services_hosting/key-vault.tf
@@ -110,6 +110,7 @@ resource "azurerm_key_vault_secret" "fatpredisconnectionstring" {
 }
 
 resource "azurerm_key_vault_secret" "govuknotifyapikey" {
+  depends_on      = [azurerm_postgresql_flexible_server_database.default]
   name            = "GovUkNotify--ApiKey"
   value           = var.govuk_notify_apikey
   key_vault_id    = azurerm_key_vault.default.id
@@ -124,6 +125,7 @@ resource "azurerm_key_vault_secret" "govuknotifyapikey" {
 }
 
 resource "azurerm_key_vault_secret" "blobstorageclientsecret" {
+  depends_on      = [azurerm_postgresql_flexible_server_database.default]
   name            = "BlobStorage--ClientSecret"
   value           = var.blob_storage_client_secret
   key_vault_id    = azurerm_key_vault.default.id
@@ -138,6 +140,7 @@ resource "azurerm_key_vault_secret" "blobstorageclientsecret" {
 }
 
 resource "azurerm_key_vault_secret" "blobstorageenquiriesdataclientsecret" {
+  depends_on      = [azurerm_postgresql_flexible_server_database.default]
   name            = "BlobStorageEnquiriesData--ClientSecret"
   value           = var.blob_storage_enquiries_data_client_secret
   key_vault_id    = azurerm_key_vault.default.id


### PR DESCRIPTION

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Separate the key vault access policy from the primary `azurerm_key_vault` resource because it is unable to identify changes, such as the addition of a new access policy.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

[https://dfedigital.atlassian.net/browse/NTP-1288](https://dfedigital.atlassian.net/browse/NTP-1288)

## Things to check

- [x] Title is in the format "NTP-XXX: Short description" where NTP-XXX is the Jira ticket reference
- [x] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [x] `dotnet format` has been run in the repository root
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/UI/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions with JavaScript on and off
- [ ] Database migrations can be applied to the current codebase in main without causing exceptions
- [ ] Debug logging has been added after all logic decision points
- [ ] All [automated testing](/README.md#testing) including accessibility and security has been run against your code
- [ ] **PR deployment has been signed off by wider team**